### PR TITLE
Fix parsing of comments for unix line endings.

### DIFF
--- a/src/typedoc/factories/handlers/CommentHandler.ts
+++ b/src/typedoc/factories/handlers/CommentHandler.ts
@@ -148,7 +148,7 @@ module TypeDoc.Factories
 
             var currentTag:Models.CommentTag;
             var shortText:number = 0;
-            var lines = text.split(/\r\n/);
+            var lines = text.split(/\n/);
             lines.forEach((line) => {
                 line = line.replace(/^\s*\*? ?/, '');
                 line = line.replace(/\s*$/, '');


### PR DESCRIPTION
This fixes #2. Note: I did not update the compiled version.
