### PR TITLE
FS.fileExistsSync does not exists.

### DIFF
--- a/src/typedoc/factories/handlers/PackageHandler.ts
+++ b/src/typedoc/factories/handlers/PackageHandler.ts
@@ -59,7 +59,7 @@ module TypeDoc.Factories
             this.noReadmeFile = (readme == 'none');
             if (!this.noReadmeFile && readme) {
                 readme = Path.resolve(readme);
-                if (FS.fileExistsSync(readme)) {
+                if (FS.existsSync(readme)) {
                     this.readmeFile = readme;
                 }
             }


### PR DESCRIPTION
FS.fileExistsSync does not exists. This method throws a error. Changed to FS.existsSync
