### PR TITLE
Change GitHub source links to prevent link rot

### DIFF
--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -74,7 +74,7 @@ class Repository
             });
         }
 
-        out = <ShellJS.ExecOutputReturnValue>ShellJS.exec('git rev-parse --abbrev-ref HEAD', {silent:true});
+        out = <ShellJS.ExecOutputReturnValue>ShellJS.exec('git rev-parse --short HEAD', {silent:true});
         if (out.code == 0) {
             this.branch = out.output.replace('\n', '');
         }


### PR DESCRIPTION
Previously the commit reference was generated with `rev-parse --abbrev-ref`. This would return a name that wasn't actually fixed to the proper commit. For instance, when run at the most recent commit, it returns the branch name (i.e., master). Links using that will always point to the most recent commit in that branch, even though the source files change and lines move.

This makes links not point to where they're supposed to go, and can cause them to fail entirely if the file is renamed. Example: in [TypeDoc's own API](http://typedoc.io/api/classes/td.converter.basepath.html#add), all of these links 404 because the files they referenced no longer exist in the current repository branch. 

Using the `--short` option returns the first 7 characters of the commit SHA1 hash, which GitHub will resolve to be the exact point that the documentation was generated at, even after more commits are made later.