### PR TITLE
chore: Add link to default theme repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ themes shipped with the package:
 [http://typedoc.io/themes/default](http://typedoc.io/themes/default)<br>
 [http://typedoc.io/themes/minimal](http://typedoc.io/themes/minimal)
 
+The default themes can be found here: [https://github.com/sebastian-lenz/typedoc-default-themes](https://github.com/sebastian-lenz/typedoc-default-themes)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ themes shipped with the package:
 [http://typedoc.io/themes/default](http://typedoc.io/themes/default)<br>
 [http://typedoc.io/themes/minimal](http://typedoc.io/themes/minimal)
 
-The default themes can be found here: [https://github.com/sebastian-lenz/typedoc-default-themes](https://github.com/sebastian-lenz/typedoc-default-themes)
+The default themes can be found here: [https://github.com/TypeStrong/typedoc-default-themes](https://github.com/TypeStrong/typedoc-default-themes)
 
 ## Usage
 


### PR DESCRIPTION
For me it wasn't clear where to find the default templates.