### PR TITLE
Keep TypeScript up to date

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "typescript": "1.6.2",
+    "typescript": "^1.6.2",
     "typedoc-default-themes": "0.3.4",
     "fs-extra": "^0.22.1",
     "minimatch": "^2.0.10",


### PR DESCRIPTION
Some my updated definitions from Typings were no longer compiling with this older version of TypeScript. I bumped the package version here so they would work again.