### PR TITLE
Fix theme options

### DIFF
--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -69,7 +69,7 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
         type: ParameterType.String,
         defaultValue: 'default'
     })
-    themeName:string
+    themeName:string;
 
     @Option({
         name: 'disableOutputCheck',
@@ -78,7 +78,32 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
     })
     disableOutputCheck:boolean;
 
+    @Option({
+        name: 'gaID',
+        help: 'Set the Google Analytics tracking ID and activate tracking code.'
+    })
+    gaID:string;
 
+    @Option({
+        name: 'gaSite',
+        help: 'Set the site name for Google Analytics. Defaults to `auto`.',
+        defaultValue: 'auto'
+    })
+    gaSite:string;
+
+    @Option({
+        name: 'hideGenerator',
+        help: 'Do not print the TypeDoc link at the end of the page.',
+        type: ParameterType.Boolean
+    })
+    hideGenerator:boolean;
+
+    @Option({
+        name: 'entryPoint',
+        help: 'Specifies the fully qualified name of the root symbol. Defaults to global namespace.',
+        type: ParameterType.String
+    })
+    entryPoint:string;
 
     /**
      * Create a new Renderer instance.

--- a/src/lib/output/theme.ts
+++ b/src/lib/output/theme.ts
@@ -3,9 +3,9 @@ import {ProjectReflection} from "../models/reflections/project";
 import {UrlMapping} from "./models/UrlMapping";
 import {NavigationItem} from "./models/NavigationItem";
 import {RendererComponent} from "./components";
-import {Component} from "../utils/component";
+import {Component, Option} from "../utils/component";
 import {Resources} from "./utils/resources";
-
+import {ParameterType} from "../utils/options/declaration";
 
 /**
  * Base class of all themes.
@@ -50,7 +50,7 @@ import {Resources} from "./utils/resources";
  *   of TypeDoc. If this file is not present, an instance of [[DefaultTheme]] will be used to render
  *   this theme.
  */
-@Component({name:"rendrer:theme", internal:true})
+@Component({name:"theme", internal:true})
 export class Theme extends RendererComponent
 {
     /**
@@ -58,7 +58,7 @@ export class Theme extends RendererComponent
      */
     basePath:string;
 
-    resources:Resources;
+    resources:Resources;    
 
 
     /**

--- a/src/lib/output/themes/DefaultTheme.ts
+++ b/src/lib/output/themes/DefaultTheme.ts
@@ -8,9 +8,7 @@ import {ReflectionGroup} from "../../models/ReflectionGroup";
 import {UrlMapping} from "../models/UrlMapping";
 import {NavigationItem} from "../models/NavigationItem";
 import {RendererEvent} from "../events";
-import {Option} from "../../utils/component";
-import {ParameterType} from "../../utils/options/declaration";
-
+import {Component} from "../../utils/component";
 
 /**
  * Defines a mapping of a [[Models.Kind]] to a template file.
@@ -47,34 +45,7 @@ export interface ITemplateMapping
  * [[BaseTheme]] implementation, this theme class will be used.
  */
 export class DefaultTheme extends Theme
-{
-    @Option({
-        name: 'gaID',
-        help: 'Set the Google Analytics tracking ID and activate tracking code.'
-    })
-    gaID:string;
-
-    @Option({
-        name: 'gaSite',
-        help: 'Set the site name for Google Analytics. Defaults to `auto`.',
-        defaultValue: 'auto'
-    })
-    gaSite:string;
-
-    @Option({
-        name: 'hideGenerator',
-        help: 'Do not print the TypeDoc link at the end of the page.',
-        type: ParameterType.Boolean
-    })
-    hideGenerator:boolean;
-
-    @Option({
-        name: 'entryPoint',
-        help: 'Specifies the fully qualified name of the root symbol. Defaults to global namespace.',
-        type: ParameterType.String
-    })
-    entryPoint:string;
-
+{    
     /**
      * Mappings of reflections kinds to templates used by this theme.
      */
@@ -170,7 +141,7 @@ export class DefaultTheme extends Theme
      * @returns The reflection that should be used as the entry point.
      */
     getEntryPoint(project:ProjectReflection):ContainerReflection {
-        var entryPoint = this.entryPoint;
+        var entryPoint = this.owner.entryPoint;
         if (entryPoint) {
             var reflection = project.getChildByName(entryPoint);
             if (reflection) {

--- a/test/renderer.js
+++ b/test/renderer.js
@@ -62,9 +62,10 @@ describe('Renderer', function() {
     it('constructs', function() {
         app = new TypeDoc.Application({
             mode:   'Modules',
-            logger: 'none',
+            logger: 'console',
             target: 'ES5',
             module: 'CommonJS',
+            gaSite: 'foo.com', // verify theme option without modifying output
             noLib:  true
         });
     });


### PR DESCRIPTION
Fixes #222 

## The Problem

Options only get added by Components when `addComponent` is called. For `DefaultTheme`, it was only being added in the `Renderer` inside `prepareTheme`. However, when you tried to set a theme option (e.g. `gaID`), the option declaration **has not** been added yet to the `Options` bag. When `Application.bootstrap` is called, which in turn calls `Options.setValue`, the declarations don't exist yet so Typedoc fails.

## The Fix

Move `DefaultTheme` options to `Renderer` because `Renderer` is added immediately in the `Application` constructor.

There may be a cleaner way to fix this without moving the options if we can initialize the theme before app bootstrap is called **or** if the decorator just registered options itself (the main issue there is that the order of the Component and Options decorator execution is in a way such that `_componentName` is not set before the Options decorator factory runs, so it's `undefined`). You might be able to use the reflection helpers to find the parent Component (class context) of the Options property decorator.