### PR TITLE
Only call getRelativeUrl when url is defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - 6
+  - 4
   - "0.10"

--- a/src/lib/output/plugins/MarkedPlugin.ts
+++ b/src/lib/output/plugins/MarkedPlugin.ts
@@ -88,7 +88,7 @@ export class MarkedPlugin extends ContextAwareRendererComponent
 
         var that = this;
         Handlebars.registerHelper('markdown', function(arg:any) { return that.parseMarkdown(arg.fn(this), this); });
-        Handlebars.registerHelper('relativeURL', (url:string) => this.getRelativeUrl(url));
+        Handlebars.registerHelper('relativeURL', (url:string) => url ? this.getRelativeUrl(url) : url);
 
         Marked.setOptions({
             highlight: (text:any, lang:any) => this.getHighlighted(text, lang)


### PR DESCRIPTION
This fixes an issue with Node.js 6 where you are only allowed anymore to pass undefined with the path module.
https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#path

Fixes  #236

