### PR TITLE
Fix for lodash 4.x

### DIFF
--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -138,7 +138,7 @@ export class Options extends ChildableComponent<Application, OptionsComponent>
             }
         }
 
-        return _.unique(result);
+        return _.uniq(result);
     }
 
 


### PR DESCRIPTION
lodash 4.x does not alias `_.unique -> uniq`. May fix #239.