### PR TITLE
Allows comments in tsconfig.json just like tsc

### DIFF
--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -56,8 +56,7 @@ export class TSConfigReader extends OptionsComponent
             return;
         }
 
-        var result = ts.readConfigFile(fileName, (fileName) => FS.readFileSync(fileName, 'utf8'));
-        var data = result.config;
+        var data = ts.readConfigFile(fileName, (fileName) => ts.sys.readFile(fileName)).config;
         if (typeof data !== "object") {
             event.addError('The tsconfig file %s does not return an object.', fileName);
             return;

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -61,7 +61,7 @@ export class TSConfigReader extends OptionsComponent
             event.addError('The tsconfig file %s does not contain valid JSON.', fileName);
             return;
         }
-        if (typeof data !== "object") {
+        if (!_.isPlainObject(data)) {
             event.addError('The tsconfig file %s does not contain a JSON object.', fileName);
             return;
         }

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -1,6 +1,7 @@
 import * as Path from "path";
 import * as FS from "fs";
 import * as _ from "lodash";
+import * as ts from "typescript";
 
 import {Component, Option} from "../../component";
 import {OptionsComponent, DiscoverEvent} from "../options";
@@ -55,7 +56,8 @@ export class TSConfigReader extends OptionsComponent
             return;
         }
 
-        var data = require(fileName);
+        var result = ts.readConfigFile(fileName, (fileName) => FS.readFileSync(fileName, 'utf8'));
+        var data = result.config;
         if (typeof data !== "object") {
             event.addError('The tsconfig file %s does not return an object.', fileName);
             return;

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -57,8 +57,12 @@ export class TSConfigReader extends OptionsComponent
         }
 
         var data = ts.readConfigFile(fileName, (fileName) => ts.sys.readFile(fileName)).config;
+        if (data === undefined) {
+            event.addError('The tsconfig file %s does not contain valid JSON.', fileName);
+            return;
+        }
         if (typeof data !== "object") {
-            event.addError('The tsconfig file %s does not return an object.', fileName);
+            event.addError('The tsconfig file %s does not contain a JSON object.', fileName);
             return;
         }
 


### PR DESCRIPTION
This uses the same function in Typescript's compiler to parse tsconfig.json, meaning it matches tsc's behavior allowing comments in tsconfig.json.

Do you want to preserve the ability for config files to be written in .js instead of .json?  If so, this PR will need to be updated to use the old method for loading .js.