### PR TITLE
Removes package.json "main" field since it points to a file that doesn't exist.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "bin": {
     "typedoc": "bin/typedoc"
   },
-  "main": "bin/typedoc.js",
   "author": {
     "name": "Sebastian Lenz",
     "url": "http://www.sebastian-lenz.de/"


### PR DESCRIPTION
A really tiny thing; I noticed the package.json's "main" field points to a file that doesn't exist; figured it was a simple oversight.