### PR TITLE
fixed homepage url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ There is a plugin available to run TypeDoc with Grunt created by Bart van der Sc
 ## Advanced guides and docs
 
 Visit our homepage for advanced guides and an extensive API documentation:<br>
-[http://typedoc.io](http://typedoc.io)
+[http://typedoc.org](http://typedoc.org)
 
 
 ## Contributing


### PR DESCRIPTION
The homepage URL was not alive anymore so this update makes it the same as it is in the repo description, which is alive.