### PR TITLE
Ignore --types and --typeRoots TypeScript compiler configuration options

### DIFF
--- a/src/lib/utils/options/sources/typescript.ts
+++ b/src/lib/utils/options/sources/typescript.ts
@@ -15,7 +15,7 @@ export class TypeScriptSource extends OptionsComponent
      */
     static IGNORED:string[] = [
         'out', 'version', 'help',
-        'watch', 'declaration', 'mapRoot',
+        'watch', 'declaration', 'mapRoot', 'types', 'typeRoots',
         'sourceMap', 'inlineSources', 'removeComments'
     ];
 


### PR DESCRIPTION
Added `types` and `typeRoots` to the list of strings ignored by `TypeScriptSource`. This means TypeDoc will ignore these compiler settings. This is a quick patch for #305 and #311.