### PR TITLE
Fix for Issue #228

### DIFF
--- a/src/lib/converter/context.ts
+++ b/src/lib/converter/context.ts
@@ -138,17 +138,21 @@ export class Context
      * @returns The type declaration of the given node.
      */
     getTypeAtLocation(node:ts.Node):ts.Type {
+        var nodeType:ts.Type;
         try {
-            return this.checker.getTypeAtLocation(node);
-        } catch (error) {
-            try {
-                if (node.symbol) {
-                    return this.checker.getDeclaredTypeOfSymbol(node.symbol);
-                }
-            } catch (error) {}
+            nodeType = this.checker.getTypeAtLocation(node);
+        } catch (error) {            
         }
-
-        return null;
+        if (!nodeType) {
+            if (node.symbol) {
+                nodeType = this.checker.getDeclaredTypeOfSymbol(node.symbol);
+            } else if (node.parent && node.parent.symbol) {
+                nodeType = this.checker.getDeclaredTypeOfSymbol(node.parent.symbol);
+            } else if (node.parent && node.parent.parent && node.parent.parent.symbol) {
+                nodeType = this.checker.getDeclaredTypeOfSymbol(node.parent.parent.symbol);
+            }
+        }
+        return nodeType;
     }
 
 


### PR DESCRIPTION
SupportsNode method at at references.ts is causing error because getTypeAtLocation is returning undefined since the given node does not contain node.
Solution is to retrieve the symbol of the given node from its parent node or parent's parent.