### PR TITLE
Support `baseUrl` and `paths` compiler options

### DIFF
--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -97,14 +97,16 @@ export class OptionDeclaration
                 value = value || "";
                 break;
             case ParameterType.Map:
-                var key = value ? (value + "").toLowerCase() : '';
-                if (key in this.map) {
-                    value = this.map[key];
-                } else if (errorCallback) {
-                    if (this.mapError) {
-                        errorCallback(this.mapError);
-                    } else {
-                        errorCallback('Invalid value for option "%s".', this.name);
+                if (this.map !== 'object') {
+                    var key = value ? (value + "").toLowerCase() : '';
+                    if (key in this.map) {
+                        value = this.map[key];
+                    } else if (errorCallback) {
+                        if (this.mapError) {
+                            errorCallback(this.mapError);
+                        } else {
+                            errorCallback('Invalid value for option "%s".', this.name);
+                        }
                     }
                 }
                 break;

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -168,7 +168,9 @@ export class Options extends ChildableComponent<Application, OptionsComponent>
     setValues(obj:Object, prefix:string = '', errorCallback?:Function) {
         for (var key in obj) {
             var value = obj[key];
-            if (typeof value === 'object') {
+            var declaration = this.getDeclaration(key);
+            var shouldValueBeAnObject = declaration && declaration.map === 'object';
+            if (typeof value === 'object' && !shouldValueBeAnObject) {
                 this.setValues(value, prefix + key + '.', errorCallback);
             } else {
                 this.setValue(prefix + key, value, errorCallback);

--- a/src/lib/utils/options/sources/typescript.ts
+++ b/src/lib/utils/options/sources/typescript.ts
@@ -20,7 +20,7 @@ export class TypeScriptSource extends OptionsComponent
         'watch', 'declaration', 'mapRoot',
         'sourceMap', 'inlineSources', 'removeComments',
         // Ignore new TypeScript 2.0 options until typedoc can't manage it.
-        'baseUrl', 'paths', 'lib', 'strictNullChecks', 'noImplicitThis',
+        'lib', 'strictNullChecks', 'noImplicitThis',
         'traceResolution', 'noUnusedParameters', 'noUnusedLocals',
         'skipLibCheck', 'declarationDir', 'types', 'typeRoots'
     ];


### PR DESCRIPTION
Fixes issue https://github.com/TypeStrong/typedoc/issues/340.

The `paths` option, which is expected to be a JSON object mapping strings to arrays of strings, comes with an internal TS option declaration with property `map: 'object'`, so we special-case the option-setting logic when we find that property on the declaration. This sticks the whole `paths` object unchanged into `options.compilerOptions`, which is forwarded on to `ts.createProgram` in the converter.