### PR TITLE
Removed 404ing Preview links from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,6 @@ $ typedoc
 ```
 
 
-## Preview
-
-If you want to know what a documentation created with TypeDoc looks like, head over
-to the homepage of the project. We've setup examples demonstrating the two default
-themes shipped with the package:
-
-[http://typedoc.io/themes/default](http://typedoc.io/themes/default)<br>
-[http://typedoc.io/themes/minimal](http://typedoc.io/themes/minimal)
-
-The default themes can be found here: [https://github.com/TypeStrong/typedoc-default-themes](https://github.com/TypeStrong/typedoc-default-themes)
-
 ## Usage
 
 ### Shell


### PR DESCRIPTION
`typedoc.io` is down and there are no equivalents on `typedoc.org`. Is there a new location for the samples?