### PR TITLE
Have the typescript package perform as much processing of the configuration file as possible.

### DIFF
--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import * as _ts from "../ts-internal";
 import * as Path from "path";
+import * as _ from "lodash";
 
 import {Application} from "../application";
 import {ParameterType} from "../utils/options/declaration";
@@ -424,19 +425,19 @@ export class Converter extends ChildableComponent<Application, ConverterComponen
         program.getSourceFiles().forEach((sourceFile) => {
             this.convertNode(context, sourceFile);
         });
-        
+
         let diagnostics = program.getOptionsDiagnostics();
         if (diagnostics.length) return diagnostics;
-        
+
         diagnostics = program.getSyntacticDiagnostics();
         if (diagnostics.length) return diagnostics;
-        
+
         diagnostics = program.getGlobalDiagnostics();
         if (diagnostics.length) return diagnostics;
 
         diagnostics = program.getSemanticDiagnostics();
         if (diagnostics.length) return diagnostics;
-        
+
         return [];
     }
 


### PR DESCRIPTION
This is proposed to fix #326. It *may* also have an impact on some of the other issues in #301.

This is not a complete PR yet but I'd like some help before moving forward. I quickly discovered while working on this that there is currently no test in the test suite that covers the code I changed. (I know because I had some pretty big errors when I copy-pasted into typedoc's codebase the code from the prototype file I created to figure how I'd load a `tsconfig.json` outside `tsc`. The big errors I had did not cause any test failure!) I'm not sure though what kinds of tests are desired. Should I create an  `Application`, and check whether it is seeing the right configuration options? Is there a better way to do this?

(The first commit in this PR is fixing the same problem as in #353. I need it there, otherwise the code does not compile. I'll remove it once #353 is merged.)