### PR TITLE
Add `--listInvalidSymbolLinks` option to list broken symbol links after generation

### DIFF
--- a/src/lib/output/plugins/MarkedLinksPlugin.ts
+++ b/src/lib/output/plugins/MarkedLinksPlugin.ts
@@ -139,7 +139,7 @@ export class MarkedLinksPlugin extends ContextAwareRendererComponent
      * Triggered when [[Renderer]] is finished
      */
     onEndRenderer(event:RendererEvent) {
-        if (this.listInvalidSymbolLinks) {
+        if (this.listInvalidSymbolLinks && this.warnings.length > 0) {
             this.application.logger.write('');
             this.application.logger.warn('[MarkedLinksPlugin]: Found invalid symbol reference(s) in JSDocs, ' +
                 'they will not render as links in the generated documentation.');

--- a/src/lib/output/plugins/MarkedLinksPlugin.ts
+++ b/src/lib/output/plugins/MarkedLinksPlugin.ts
@@ -141,8 +141,8 @@ export class MarkedLinksPlugin extends ContextAwareRendererComponent
     onEndRenderer(event:RendererEvent) {
         if (this.listInvalidSymbolLinks) {
             this.application.logger.write('');
-            this.application.logger.warn('[MarkedLinksPlugin]: Found invalid symbol reference(s) in JSDocs, \
-                they will not render as links in the generated documentation.');            
+            this.application.logger.warn('[MarkedLinksPlugin]: Found invalid symbol reference(s) in JSDocs, ' +
+                'they will not render as links in the generated documentation.');
 
             for (var warning of this.warnings) {
                 this.application.logger.write('  ' + warning);

--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -103,7 +103,7 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
         help: 'Specifies the fully qualified name of the root symbol. Defaults to global namespace.',
         type: ParameterType.String
     })
-    entryPoint:string;
+    entryPoint:string;    
 
     /**
      * Create a new Renderer instance.


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/563819/21579880/2a988c8c-cf8f-11e6-9d5d-69b1b5e1e2c0.png)

Just added a `--listInvalidSymbolLinks` switch to aid in fixing broken links due to refactoring/changes in large codebases. It does not break the generation, although that could be done too.

Let me know if you want any of the messaging changed. Note that the MarkedLinks plugin has no context for the exact symbol/signature it is parsing, it is only passed the text to parse so that's the most I could expose. I am not familiar enough to figure out how to pass in exact line/file reference info :)