### PR TITLE
Use raw typedocOptions

### DIFF
--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -85,7 +85,7 @@ export class TSConfigReader extends OptionsComponent
         _.merge(event.data, compilerOptions);
 
         if ("typedocOptions" in data) {
-            _.merge(event.data, data.typedocOptions);
+            _.merge(event.data, data.raw.typedocOptions);
         }
     }
 }


### PR DESCRIPTION
The tsconfig reader has a [section of code](https://github.com/TypeStrong/typedoc/blob/v0.5.3/src/lib/utils/options/readers/tsconfig.ts#L87-L89) that looks for a `typedocOptions` property. The property will never exist because the tsconfig options are processed with [ts.parseJsonConfigFileContent](https://github.com/Microsoft/TypeScript/blob/v2.1.4/src/compiler/commandLineParser.ts#L851)