### PR TITLE
Make CLI compiler options take precedence over tsconfig

### DIFF
--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -82,10 +82,6 @@ export class TSConfigReader extends OptionsComponent
             delete compilerOptions[key];
         }
 
-        _.merge(event.data, compilerOptions);
-
-        if ("typedocOptions" in data) {
-            _.merge(event.data, data.raw.typedocOptions);
-        }
+        _.defaults(event.data, data.raw.typedocOptions, compilerOptions);
     }
 }


### PR DESCRIPTION
From the `tsc` docs:

>Compiler options specified on the command line override those specified in the tsconfig.json file.
-- https://www.typescriptlang.org/docs/handbook/tsconfig-json.html

I think typedoc should have the same behavior as the typescript compiler in terms of options precedence. For example, `--target ES6` should override the target specified in the tsconfig.json.

fixes #371