### PR TITLE
TypeDoc now also honors the --exclude option on a list of files

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -272,7 +272,7 @@ export class Application extends ChildableComponent<Application, AbstractCompone
             file = Path.resolve(file);
             if (FS.statSync(file).isDirectory()) {
                 add(file);
-            } else {
+            } else if (exclude && !exclude.match(file)) {
                 files.push(file);
             }
         });

--- a/test/typedoc.js
+++ b/test/typedoc.js
@@ -16,5 +16,13 @@ describe('TypeDoc', function() {
             Assert.notEqual(expanded.indexOf(Path.join(inputFiles, 'class.ts')), -1);
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
+        it('honors the exclude argument even on a fixed file list', function() {
+            var inputFiles = Path.join(__dirname, 'converter', 'class');
+            application.options.setValue('exclude', '**/class.ts');
+            var expanded = application.expandInputFiles([inputFiles]);
+
+            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class.ts')), -1);
+            Assert.equal(expanded.indexOf(inputFiles), -1);
+        });
     });
 });

--- a/test/typedoc.js
+++ b/test/typedoc.js
@@ -24,5 +24,14 @@ describe('TypeDoc', function() {
             Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class.ts')), -1);
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
+        it('supports multiple excludes', function() {
+            var inputFiles = Path.join(__dirname, 'converter');
+            application.options.setValue('exclude', '**/+(class|access).ts');
+            var expanded = application.expandInputFiles([inputFiles]);
+
+            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class', 'class.ts')), -1);
+            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'access', 'access.ts')), -1);
+            Assert.equal(expanded.indexOf(inputFiles), -1);
+        });
     });
 });


### PR DESCRIPTION
This pull request lets typedoc honor the --exclude argument also for typedoc calls, that include a list of files. Previously --exclude only worked if you specify a directory.

As one could possibly argue, running typedoc with a list of files already excludes the files we don't want to use, but typedoc seems to also check tsconfig.json for input files and overwrites the list of the provided files.