### PR TITLE
Add typeArguments to ReferenceType.toString()

### DIFF
--- a/src/lib/models/types/reference.ts
+++ b/src/lib/models/types/reference.ts
@@ -113,12 +113,18 @@ export class ReferenceType extends Type
 
     /**
      * Return a string representation of this type.
+     * @example EventEmitter<any>
      */
     toString() {
-        if (this.reflection) {
-            return this.reflection.name + (this.isArray ? '[]' : '');
-        } else {
-            return this.name + (this.isArray ? '[]' : '');
+        var name = this.reflection ? this.reflection.name : this.name;
+        var arraySuffix = this.isArray ? '[]' : '';
+        var typeArgs = '';
+        if (this.typeArguments) {
+            typeArgs += '<';
+            typeArgs += this.typeArguments.map(arg => arg.toString()).join(', ');
+            typeArgs += '>'
         }
+        
+        return name + typeArgs + arraySuffix;
     }
 }


### PR DESCRIPTION
First of all good job for the hard work on this project! ❤️ 
I'm using the `Converter` API to generate custom documentation for Angular components and I noticed that `typeArguments` are missing when calling `.toString()` on a `ReferenceType`.