### PR TITLE
add exported flag to declaration when default export - Fixes #393

### DIFF
--- a/src/lib/converter/factories/declaration.ts
+++ b/src/lib/converter/factories/declaration.ts
@@ -62,6 +62,11 @@ export function createDeclaration(context:Context, node:ts.Node, kind:Reflection
         isExported = isExported || !!(modifiers & ts.ModifierFlags.Export);
     }
 
+    // if the node itself has its exported flag set, override isExported to true
+    if (node.flags & ReflectionFlag.Exported) {
+        isExported = true;
+    }
+
     if (!isExported && context.converter.excludeNotExported) {
         return null;
     }

--- a/src/lib/converter/nodes/export.ts
+++ b/src/lib/converter/nodes/export.ts
@@ -30,9 +30,16 @@ export class ExportConverter extends ConverterNodeComponent<ts.ExportAssignment>
             symbol.declarations.forEach((declaration) => {
                 if (!declaration.symbol) return;
                 var id = project.symbolMapping[context.getSymbolID(declaration.symbol)];
-                if (!id) return;
+                let reflection;
 
-                var reflection = project.reflections[id];
+                if (!id) {
+                    // Add Exported to the declaration's flags value
+                    declaration.flags |= ReflectionFlag.Exported;
+                    reflection = this.owner.convertNode(context, declaration);
+                } else {
+                    reflection = project.reflections[id];
+                }
+
                 if (node.isExportEquals && reflection instanceof DeclarationReflection) {
                     (<DeclarationReflection>reflection).setFlag(ReflectionFlag.ExportAssignment, true);
                 }


### PR DESCRIPTION
Add `ReflectionFlag.Export` flag to a node's flag variable when the export
converter is run and then check for that flag in `createDeclaration`.

This fixes a scenario described in #393 where `export default` is used in a separate
statement from the variable creation, such as:

```ts
const foo = 'bar';
export default foo;
```

In the above example, the export converter cannot find the symbolmapping
for the `foo` declaration because the createDeclaration code returns
null when --excludeNotExported flag is set.

Looking at the tests, it doesn't look like any of them run with `excludeNoExport` set, and setting it makes several fail. Setting `excludeNoExport` and running the export-default test does pass with this fix, though. I could try looking into that here, or perhaps as part of the proposed work in #378?