### PR TITLE
Added toc option to allow restriction of top-level menu items

### DIFF
--- a/src/lib/output/plugins/TocPlugin.ts
+++ b/src/lib/output/plugins/TocPlugin.ts
@@ -40,8 +40,9 @@ export class TocPlugin extends RendererComponent
             model = model.parent;
         }
 
+        var tocRestriction = this.owner.toc;
         page.toc = new NavigationItem();
-        TocPlugin.buildToc(model, trail, page.toc);
+        TocPlugin.buildToc(model, trail, page.toc, tocRestriction);
     }
 
 
@@ -51,8 +52,9 @@ export class TocPlugin extends RendererComponent
      * @param model   The models whose children should be written to the toc.
      * @param trail   Defines the active trail of expanded toc entries.
      * @param parent  The parent [[NavigationItem]] the toc should be appended to.
+     * @param restriction  The restricted table of contents.
      */
-    static buildToc(model:Reflection, trail:Reflection[], parent:NavigationItem) {
+    static buildToc(model:Reflection, trail:Reflection[], parent:NavigationItem, restriction?: string[]) {
         var index = trail.indexOf(model);
         var children = model['children'] || [];
 
@@ -64,6 +66,9 @@ export class TocPlugin extends RendererComponent
             TocPlugin.buildToc(child, trail, item);
         } else {
             children.forEach((child:DeclarationReflection) => {
+
+                if (restriction && restriction.length > 0 && restriction.indexOf(child.name) === -1) return;
+
                 if (child.kindOf(ReflectionKind.SomeModule)) {
                     return;
                 }

--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -105,6 +105,13 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
     })
     entryPoint:string;    
 
+    @Option({
+        name: 'toc',
+        help: 'Specifies the top level table of contents.',
+        type: ParameterType.Array
+    })
+    toc:string[];
+
     /**
      * Create a new Renderer instance.
      *

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -12,7 +12,8 @@ export enum ParameterType {
     Number,
     Boolean,
     Map,
-    Mixed
+    Mixed,
+    Array
 }
 
 
@@ -95,6 +96,13 @@ export class OptionDeclaration
                 break;
             case ParameterType.String:
                 value = value || "";
+                break;
+            case ParameterType.Array:
+                if (!value) {
+                    value = [];
+                } else if (typeof value === "string") {
+                    value = value.split(",");
+                }
                 break;
             case ParameterType.Map:
                 if (this.map !== 'object') {


### PR DESCRIPTION
This PR adds the ability to restrict the table of contents using a comma-delimited string of items in the `toc` option.

Related to issue #406.