### PR TITLE
Support directories named like prototype methods

### DIFF
--- a/src/lib/converter/plugins/SourcePlugin.ts
+++ b/src/lib/converter/plugins/SourcePlugin.ts
@@ -163,7 +163,7 @@ export class SourcePlugin extends ConverterComponent
             var path = Path.dirname(file.fileName);
             if (path != '.') {
                 path.split('/').forEach((path) => {
-                    if (!directory.directories[path]) {
+                    if (!Object.prototype.hasOwnProperty.call(directory, path)) {
                         directory.directories[path] = new SourceDirectory(path, directory);
                     }
                     directory = directory.directories[path];


### PR DESCRIPTION
If a directory would be named "toString" (or "constructor", ...) 
the code would crash when trying to invoke `push` on that object.

This happens when for example in the "lodash" repo.