### PR TITLE
Add directoryExists implementation to CompilerHost

### DIFF
--- a/src/lib/converter/utils/compiler-host.ts
+++ b/src/lib/converter/utils/compiler-host.ts
@@ -105,6 +105,19 @@ export class CompilerHost extends ConverterComponent implements ts.CompilerHost
 
 
     /**
+     * Check whether the given directory exists.
+     *
+     * Implementation of ts.CompilerHost.directoryExists(directoryName)
+     *
+     * @param directoryName
+     * @returns {boolean}
+     */
+    directoryExists(directoryName:string):boolean {
+        return ts.sys.directoryExists(directoryName);
+    }
+
+
+    /**
      * Return the contents of the given file.
      *
      * Implementation of ts.CompilerHost.readFile(fileName)


### PR DESCRIPTION
This PR adds an implementation of the optional `directoryExists` property to the CompilerHost class. This property must be present for TypeScript's automatic type discovery to work (like finding things in @types).