### PR TITLE
Only apply exclusion rules when available

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -272,7 +272,7 @@ export class Application extends ChildableComponent<Application, AbstractCompone
             file = Path.resolve(file);
             if (FS.statSync(file).isDirectory()) {
                 add(file);
-            } else if (exclude && !exclude.match(file)) {
+            } else if (!exclude || !exclude.match(file)) {
                 files.push(file);
             }
         });

--- a/test/typedoc.js
+++ b/test/typedoc.js
@@ -9,19 +9,32 @@ describe('TypeDoc', function() {
         it('constructs', function() {
             application = new TypeDoc.Application();
         });
-        it('expands input files', function() {
+        it('expands input directory', function() {
             var inputFiles = Path.join(__dirname, 'converter', 'class');
             var expanded = application.expandInputFiles([inputFiles]);
 
             Assert.notEqual(expanded.indexOf(Path.join(inputFiles, 'class.ts')), -1);
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
-        it('honors the exclude argument even on a fixed file list', function() {
+        it('expands input files', function() {
+            var inputFiles = Path.join(__dirname, 'converter', 'class', 'class.ts');
+            var expanded = application.expandInputFiles([inputFiles]);
+
+            Assert.notEqual(expanded.indexOf(inputFiles), -1);
+        });
+        it('honors the exclude argument even on a fixed directory list', function() {
             var inputFiles = Path.join(__dirname, 'converter', 'class');
             application.options.setValue('exclude', '**/class.ts');
             var expanded = application.expandInputFiles([inputFiles]);
 
             Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class.ts')), -1);
+            Assert.equal(expanded.indexOf(inputFiles), -1);
+        });
+        it('honors the exclude argument even on a fixed file list', function() {
+            var inputFiles = Path.join(__dirname, 'converter', 'class', 'class.ts');
+            application.options.setValue('exclude', '**/class.ts');
+            var expanded = application.expandInputFiles([inputFiles]);
+
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
         it('supports multiple excludes', function() {


### PR DESCRIPTION
A recent change to the exclusion logic causes all files to be excluded by default (files  are only added to the input list if an exclude rule is provided _and_ it doesn't match). This PR causes files to be added to the input list if there is no exclude rule _or_ if the provided exclude rule doesn't match a file.