### PR TITLE
fix #393 - excludeNotExported with default exports in two statements

### DIFF
--- a/src/lib/converter/factories/declaration.ts
+++ b/src/lib/converter/factories/declaration.ts
@@ -60,10 +60,6 @@ export function createDeclaration(context: Context, node: ts.Node, kind: Reflect
         isExported = isExported || !!(modifiers & ts.ModifierFlags.Export);
     }
 
-    if (!isExported && context.converter.excludeNotExported) {
-        return null;
-    }
-
     // Test whether the node is private, when inheriting ignore private members
     const isPrivate = !!(modifiers & ts.ModifierFlags.Private);
     if (context.isInherit && isPrivate) {


### PR DESCRIPTION
Fix issue where default exports are separated across two statements such
as

```ts
const foo = {};
export default foo;
```

In this above example, the could would originally not be able to find `foo` in its reflections list because the declaration factory would return `null` for `foo` because when that statement is hit, it's not set to be exported when `excludeNotExported` is true. This PR fixes that by not returning `null` in the declaration factory, and then by pruning the list of reflections and children from the project structure later on in the converter's resolve.

* remove the short-circuit in the declaration factory so all reflections
exist after converter#convert is run
* in converter#resolve, add check for excludeNotExported and then prune
the references list and children in the project structure whose
isExported flag is false

The tests do not currently run with the `excludeNotExported` flag enabled.

This fix is associated with some project fixes and refactoring detailed in #378 and fixes #393.