### PR TITLE
Expose src for direct api usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "tslint": "^4.4.2"
   },
   "files": [
+    "src",
     "bin",
     "dist",
     "tasks",


### PR DESCRIPTION
Allow consumers to directly use TypeDoc's internal TypeScript objects (beyond the ones exposed in `index.d.ts`)