### PR TITLE
remove exclusion of TS 2 options, add lib support

### DIFF
--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -95,12 +95,13 @@ export class OptionDeclaration {
                 const map = this.map;
                 if (map !== 'object') {
                     const key = value ? (value + '').toLowerCase() : '';
+                    const values = Object.keys(map).map(key => map[key]);
 
                     if (map instanceof Map && map.has(key)) {
                         value = map.get(key);
                     } else if (key in map) {
                         value = map[key];
-                    } else if (errorCallback) {
+                    } else if (!~values.indexOf(value) && errorCallback) {
                         if (this.mapError) {
                             errorCallback(this.mapError);
                         } else {

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -101,7 +101,7 @@ export class OptionDeclaration {
                         value = map.get(key);
                     } else if (key in map) {
                         value = map[key];
-                    } else if (!~values.indexOf(value) && errorCallback) {
+                    } else if (values.indexOf(value) === -1 && errorCallback) {
                         if (this.mapError) {
                             errorCallback(this.mapError);
                         } else {

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -97,8 +97,8 @@ export class OptionDeclaration {
                     const key = value ? (value + '').toLowerCase() : '';
                     const values = Object.keys(map).map(key => map[key]);
 
-                    if (map instanceof Map && map.has(key)) {
-                        value = map.get(key);
+                    if (map instanceof Map) {
+                        value = map.has(key) ? map.get(key) : key;
                     } else if (key in map) {
                         value = map[key];
                     } else if (values.indexOf(value) === -1 && errorCallback) {

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -152,10 +152,10 @@ export class Options extends ChildableComponent<Application, OptionsComponent> {
             const value = obj[key];
             const declaration = this.getDeclaration(key);
             const shouldValueBeAnObject = declaration && declaration['map'] === 'object';
-            if (typeof value === 'object' && !shouldValueBeAnObject) {
+            if (!Array.isArray(value) && typeof value === 'object' && !shouldValueBeAnObject) {
                 this.setValues(value, prefix + key + '.', errorCallback);
             } else {
-                this.setValue(prefix + key, value, errorCallback);
+                this.setValue(prefix + key, value);
             }
         }
     }

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -133,9 +133,6 @@ export class Options extends ChildableComponent<Application, OptionsComponent> {
     setValue(name: string|OptionDeclaration, value: any, errorCallback?: Function) {
         const declaration = name instanceof OptionDeclaration ? name : this.getDeclaration(<string> name);
         if (!declaration) {
-            if (errorCallback) {
-                errorCallback('Unknown option `%s`.', name.toString());
-            }
             return;
         }
 
@@ -155,7 +152,7 @@ export class Options extends ChildableComponent<Application, OptionsComponent> {
             if (!Array.isArray(value) && typeof value === 'object' && !shouldValueBeAnObject) {
                 this.setValues(value, prefix + key + '.', errorCallback);
             } else {
-                this.setValue(prefix + key, value);
+                this.setValue(prefix + key, value, errorCallback);
             }
         }
     }

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -51,7 +51,7 @@ export class TSConfigReader extends OptionsComponent {
             return;
         }
 
-        let { config } = ts.readConfigFile(fileName, ts.sys.readFile);
+        const { config } = ts.readConfigFile(fileName, ts.sys.readFile);
         if (config === undefined) {
             event.addError('The tsconfig file %s does not contain valid JSON.', fileName);
             return;

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -51,31 +51,30 @@ export class TSConfigReader extends OptionsComponent {
             return;
         }
 
-        let data = ts.readConfigFile(fileName, ts.sys.readFile).config;
-        if (data === undefined) {
+        let { config } = ts.readConfigFile(fileName, ts.sys.readFile);
+        if (config === undefined) {
             event.addError('The tsconfig file %s does not contain valid JSON.', fileName);
             return;
         }
-        if (!_.isPlainObject(data)) {
+        if (!_.isPlainObject(config)) {
             event.addError('The tsconfig file %s does not contain a JSON object.', fileName);
             return;
         }
 
-        data = ts.parseJsonConfigFileContent(
-            data,
+        const { fileNames, options, raw: { typedocOptions }} = ts.parseJsonConfigFileContent(
+            config,
             ts.sys,
             Path.resolve(Path.dirname(fileName)),
             {},
             Path.resolve(fileName));
 
-        event.inputFiles = data.fileNames;
+        event.inputFiles = fileNames;
 
         const ignored = TypeScriptSource.IGNORED;
-        let compilerOptions = _.clone(data.raw.compilerOptions);
         for (const key of ignored) {
-            delete compilerOptions[key];
+            delete options[key];
         }
 
-        _.defaults(event.data, data.raw.typedocOptions, compilerOptions);
+        _.defaults(event.data, typedocOptions, options);
     }
 }

--- a/src/lib/utils/options/sources/typescript.ts
+++ b/src/lib/utils/options/sources/typescript.ts
@@ -15,11 +15,7 @@ export class TypeScriptSource extends OptionsComponent {
     static IGNORED: string[] = [
         'out', 'version', 'help',
         'watch', 'declaration', 'mapRoot',
-        'sourceMap', 'inlineSources', 'removeComments',
-        // Ignore new TypeScript 2.0 options until typedoc can't manage it.
-        'lib', 'noImplicitThis',
-        'traceResolution', 'noUnusedParameters', 'noUnusedLocals',
-        'skipLibCheck', 'declarationDir', 'types', 'typeRoots'
+        'sourceMap', 'inlineSources', 'removeComments'
     ];
 
     initialize() {
@@ -58,6 +54,9 @@ export class TypeScriptSource extends OptionsComponent {
                 break;
             case 'string':
                 param.type = ParameterType.String;
+                break;
+            case 'list':
+                param.type = ParameterType.Array;
                 break;
             default:
                 param.type = ParameterType.Map;

--- a/src/test/renderer/specs/classes/_access_.privateclass.html
+++ b/src/test/renderer/specs/classes/_access_.privateclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_classes_.baseclass.html
+++ b/src/test/renderer/specs/classes/_classes_.baseclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_classes_.genericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.genericclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_classes_.internalclass.html
+++ b/src/test/renderer/specs/classes/_classes_.internalclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_classes_.nongenericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.nongenericclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_classes_.subclassa.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassa.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_classes_.subclassb.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassb.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
+++ b/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_default_export_.notexportedclassname.html
+++ b/src/test/renderer/specs/classes/_default_export_.notexportedclassname.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
+++ b/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_single_export_.notexportedclass.html
+++ b/src/test/renderer/specs/classes/_single_export_.notexportedclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_single_export_.singleexportedclass.html
+++ b/src/test/renderer/specs/classes/_single_export_.singleexportedclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/classes/_typescript_1_4_.simpleclass.html
+++ b/src/test/renderer/specs/classes/_typescript_1_4_.simpleclass.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/enums/_enumerations_.directions.html
+++ b/src/test/renderer/specs/enums/_enumerations_.directions.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/enums/_enumerations_.size.html
+++ b/src/test/renderer/specs/enums/_enumerations_.size.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/globals.html
+++ b/src/test/renderer/specs/globals.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/interfaces/_generics_.a.html
+++ b/src/test/renderer/specs/interfaces/_generics_.a.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/interfaces/_generics_.ab.html
+++ b/src/test/renderer/specs/interfaces/_generics_.ab.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/interfaces/_generics_.abnumber.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abnumber.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/interfaces/_generics_.abstring.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abstring.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/interfaces/_generics_.b.html
+++ b/src/test/renderer/specs/interfaces/_generics_.b.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/interfaces/_typescript_1_4_.runoptions.html
+++ b/src/test/renderer/specs/interfaces/_typescript_1_4_.runoptions.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_access_.html
+++ b/src/test/renderer/specs/modules/_access_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_access_.privatemodule.html
+++ b/src/test/renderer/specs/modules/_access_.privatemodule.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_classes_.html
+++ b/src/test/renderer/specs/modules/_classes_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_default_export_.html
+++ b/src/test/renderer/specs/modules/_default_export_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_enumerations_.html
+++ b/src/test/renderer/specs/modules/_enumerations_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_flattened_.html
+++ b/src/test/renderer/specs/modules/_flattened_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_functions_.html
+++ b/src/test/renderer/specs/modules/_functions_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_functions_.modulefunction.html
+++ b/src/test/renderer/specs/modules/_functions_.modulefunction.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_generics_.html
+++ b/src/test/renderer/specs/modules/_generics_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_modules_.html
+++ b/src/test/renderer/specs/modules/_modules_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_modules_.mymodule.html
+++ b/src/test/renderer/specs/modules/_modules_.mymodule.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_modules_.mymodule.mysubmodule.html
+++ b/src/test/renderer/specs/modules/_modules_.mymodule.mysubmodule.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_single_export_.html
+++ b/src/test/renderer/specs/modules/_single_export_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_typescript_1_3_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_3_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_typescript_1_4_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_4_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/test/renderer/specs/modules/_typescript_1_5_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_5_.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="default no-js">
+<html class="default">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": [
       "DOM",
       "ES5",
-      "ES2015.Collection"
+      "ES2015.Collection",
+	  "ES2015.Iterable"
     ],
     "target": "ES5",
     "noImplicitAny": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
       "DOM",
       "ES5",
       "ES2015.Collection",
-	  "ES2015.Iterable"
+      "ES2015.Iterable"
     ],
     "target": "ES5",
     "noImplicitAny": false,


### PR DESCRIPTION
* Remove restriction on what compilerOptions can be set
* remove filtering of TS 2.2 compilerOptions
* add support for 'list' option types
* Switch to processed compilerOptions
* add support for `compilerOptions.lib`

This PR removes the restrictions on setting options that aren't explicitly setup as options to allow new compilerOptions to pass through TypeDoc to TypeScript. It also sets up support for 'list' parameter types, and switches to use the processed compilerOptions, rather than `raw` so that the `lib` properties are properly parsed.

This should fix #315 and I believe #311.