### PR TITLE
Include type arguments when converting aliases

### DIFF
--- a/src/lib/converter/types/alias.ts
+++ b/src/lib/converter/types/alias.ts
@@ -72,8 +72,8 @@ export class AliasConverter extends ConverterTypeComponent implements TypeNodeCo
      */
     convertNode(context: Context, node: ts.TypeReferenceNode): ReferenceType {
         const name = _ts.getTextOfNode(node.typeName);
-
         const result = new ReferenceType(name, ReferenceType.SYMBOL_ID_RESOLVE_BY_NAME);
+
         if (node.typeArguments) {
             result.typeArguments = node.typeArguments.map(n => this.owner.convertType(context, n));
         }

--- a/src/lib/converter/types/alias.ts
+++ b/src/lib/converter/types/alias.ts
@@ -72,6 +72,12 @@ export class AliasConverter extends ConverterTypeComponent implements TypeNodeCo
      */
     convertNode(context: Context, node: ts.TypeReferenceNode): ReferenceType {
         const name = _ts.getTextOfNode(node.typeName);
-        return new ReferenceType(name, ReferenceType.SYMBOL_ID_RESOLVE_BY_NAME);
+
+        const result = new ReferenceType(name, ReferenceType.SYMBOL_ID_RESOLVE_BY_NAME);
+        if (node.typeArguments) {
+            result.typeArguments = node.typeArguments.map(n => this.owner.convertType(context, n));
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
Fixes problem where aliases with type arguments such as `Partial<T>` are rendered without type arguments, as in the example below.

![image](https://cloud.githubusercontent.com/assets/4385210/24138893/4d68cef6-0e1a-11e7-8f09-1d6a0cbcff2e.png)

Might fix #288