### PR TITLE
Fix Map parameter handling in declaration.ts

### DIFF
--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -98,7 +98,7 @@ export class OptionDeclaration {
                     const values = Object.keys(map).map(key => map[key]);
 
                     if (map instanceof Map) {
-                        value = map.has(key) ? map.get(key) : key;
+                        value = map.has(key) ? map.get(key) : value;
                     } else if (key in map) {
                         value = map[key];
                     } else if (values.indexOf(value) === -1 && errorCallback) {


### PR DESCRIPTION
The code for handling map parameters in declaration.ts was overwriting the value in a case where it shouldn't have been. The logic should be to use `map[key]` if the key is present, or just stick with `value` if it's not.

Fixes #454