### PR TITLE
fixed crash in SourcePlugin

### DIFF
--- a/src/lib/converter/plugins/SourcePlugin.ts
+++ b/src/lib/converter/plugins/SourcePlugin.ts
@@ -160,11 +160,11 @@ export class SourcePlugin extends ConverterComponent {
             let directory = home;
             const path = Path.dirname(file.fileName);
             if (path !== '.') {
-                path.split('/').forEach((path) => {
-                    if (!Object.prototype.hasOwnProperty.call(directory, path)) {
-                        directory.directories[path] = new SourceDirectory(path, directory);
+                path.split('/').forEach((pathPiece) => {
+                    if (!Object.prototype.hasOwnProperty.call(directory.directories, pathPiece)) {
+                        directory.directories[pathPiece] = new SourceDirectory(pathPiece, directory);
                     }
-                    directory = directory.directories[path];
+                    directory = directory.directories[pathPiece];
                 });
             }
 


### PR DESCRIPTION
updated if clause to properly check the correct property. This was indirectly causing crashes when a folder had the same name as a directory property.
Also updated the path variable to pathPiece to prevent path from being shadowed.

Should fix #440 