### PR TITLE
Fix separator in getDefaultLibFileName

### DIFF
--- a/src/lib/converter/utils/compiler-host.ts
+++ b/src/lib/converter/utils/compiler-host.ts
@@ -1,9 +1,7 @@
 import * as ts from 'typescript';
 import * as _ts from '../../ts-internal';
-import * as Path from 'path';
 
 import {ConverterComponent} from '../components';
-import {normalizePath} from '../../utils/fs';
 
 /**
  * Return code of ts.sys.readFile when the file encoding is unsupported.
@@ -52,9 +50,8 @@ export class CompilerHost extends ConverterComponent implements ts.CompilerHost 
      * @returns The full path of the default library.
      */
     getDefaultLibFileName(options: ts.CompilerOptions): string {
-        const lib = this.owner.getDefaultLib();
-        const path = _ts.getDirectoryPath(normalizePath(require.resolve('typescript')));
-        return Path.join(path, lib);
+        const libLocation = _ts.getDirectoryPath(_ts.normalizePath(ts.sys.getExecutingFilePath()));
+        return _ts.combinePaths(libLocation, ts.getDefaultLibFileName(options));
     }
 
     getDirectories(path: string): string[] {

--- a/src/lib/ts-internal.ts
+++ b/src/lib/ts-internal.ts
@@ -56,6 +56,16 @@ export function getDirectoryPath() {
   return tsany.getDirectoryPath.apply(this, arguments);
 }
 
+// https://github.com/Microsoft/TypeScript/blob/v2.2.1/src/compiler/core.ts#L1418
+export function normalizePath(path: string): string {
+  return tsany.normalizePath(path);
+}
+
+// https://github.com/Microsoft/TypeScript/blob/v2.2.1/src/compiler/core.ts#L1628
+export function combinePaths(path1: string, path2: string): string {
+  return tsany.combinePaths(path1, path2);
+}
+
 /**
  * These functions are in "utilities" and are marked as @internal:
  * https://github.com/Microsoft/TypeScript/blob/v2.1.4/src/compiler/utilities.ts#L3-L4


### PR DESCRIPTION
Remove use of `Path.join` in the `getDefaultLibFileName` method that, on Windows, converts '/' in paths to '\\'. TypeScript uses '/' internally so it has trouble locating the default lib location when this is reversed. Fixes #464 where lib directory cannot be found on Windows.

In this PR, I changed the `getDefaultLibFileName` method in compiler-host.ts to more resemble that which would be returned from `ts.getCompilerHost`, which also included exposing a few more methods in ts-internal.ts.