### PR TITLE
tsc option `declarationDir` must be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .tscache
 .baseDir.js
 .baseDir.ts
+yarn.lock
 
 /src/typings/typescript/typescript.js
 

--- a/src/lib/utils/options/sources/typescript.ts
+++ b/src/lib/utils/options/sources/typescript.ts
@@ -14,7 +14,7 @@ export class TypeScriptSource extends OptionsComponent {
      */
     static IGNORED: string[] = [
         'out', 'version', 'help',
-        'watch', 'declaration', 'mapRoot',
+        'watch', 'declaration', 'declarationDir', 'mapRoot',
         'sourceMap', 'inlineSources', 'removeComments'
     ];
 


### PR DESCRIPTION
# Motivation

My project contains following compilerOptions in tsconfig.json

```json
{
  "compilerOptions": {
    "target": "es6",
    "module": "es6",
    "noImplicitAny": false,
    "declaration": true,
    "moduleResolution": "node",
    "outDir": "./lib",
    "declarationDir": "./ref"
  }
}
```

By using this config, typedoc would produce following error.

```bash
$ typedoc --out ./docs/ ./src/

Using TypeScript 2.2.1 from /Users/kyasbal/****/core/node_modules/typedoc/node_modules/typescript/lib
Error: Option 'declarationDir' cannot be specified without specifying option 'declaration'.

npm ERR! Darwin 16.4.0
npm ERR! argv "/Users/kyasbal/.nvm/versions/node/v7.3.0/bin/node" "/Users/kyasbal/.nvm/versions/node/v7.3.0/bin/npm" "run" "doc"
npm ERR! node v7.3.0
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! *** doc: `typedoc --out ./docs/ ./src/`
npm ERR! Exit status 4
npm ERR!
npm ERR! Failed at the *** doc script 'typedoc --out ./docs/ ./src/'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the *** package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     typedoc --out ./docs/ ./src/
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs ***
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls ***
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/kyasbal/***/core/npm-debug.log
```

# Solution

I inspected what is occur in passing tsc compiler options. And, I've found the source to ignore several compilerOptions.
The option `declaration` was ignored. But, `declarationDir` was not ignored.
This is the cause of this problem.
