### PR TITLE
Move @types into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,6 @@
     "node": ">= 4.2.0"
   },
   "dependencies": {
-    "@types/fs-extra": "0.0.33",
-    "@types/handlebars": "^4.0.31",
-    "@types/highlight.js": "^9.1.8",
-    "@types/lodash": "^4.14.37",
-    "@types/marked": "0.0.28",
-    "@types/minimatch": "^2.0.29",
-    "@types/shelljs": "^0.3.32",
     "fs-extra": "^2.0.0",
     "handlebars": "4.0.5",
     "highlight.js": "^9.0.0",
@@ -49,7 +42,14 @@
     "typescript": "2.2.2"
   },
   "devDependencies": {
+    "@types/fs-extra": "0.0.33",
+    "@types/handlebars": "^4.0.31",
+    "@types/highlight.js": "^9.1.8",
+    "@types/lodash": "^4.14.37",
+    "@types/marked": "0.0.28",
+    "@types/minimatch": "^2.0.29",
     "@types/mocha": "^2.2.39",
+    "@types/shelljs": "^0.3.32",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",


### PR DESCRIPTION
Hey there, these `@types/x` dependencies are being shipped to all library consumers of typedoc. I can understand why you would want to include them in dependencies (so they match) but simply including typedoc in my project makes tsc fail.

If you want to make this a systemic thing, in Danger [we check](https://github.com/danger/danger-js/blob/master/dangerfile.ts#L88-L109) to make sure no-one ships `@types` inside the dependencies section of the package in each PR.