### PR TITLE
Change the pattern of --exclude option to Regular Expression

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -9,7 +9,6 @@
 import * as Path from 'path';
 import * as FS from 'fs';
 import * as typescript from 'typescript';
-import {Minimatch, IMinimatch} from 'minimatch';
 
 import {Converter} from './converter/index';
 import {Renderer} from './output/renderer';

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -72,7 +72,7 @@ export class Application extends ChildableComponent<Application, AbstractCompone
 
     @Option({
         name: 'exclude',
-        help: 'Define a pattern for excluded files when specifying paths.',
+        help: 'Define a Regular Expression pattern for excluded files/folders when specifying paths.',
         type: ParameterType.String
     })
     exclude: string;
@@ -238,9 +238,9 @@ export class Application extends ChildableComponent<Application, AbstractCompone
      * @returns  The list of input files with expanded directories.
      */
     public expandInputFiles(inputFiles?: string[]): string[] {
-        let exclude: IMinimatch, files: string[] = [];
+        let excludePattern: string, files: string[] = [];
         if (this.exclude) {
-            exclude = new Minimatch(this.exclude);
+            excludePattern = this.exclude;
         }
 
         function add(dirname: string) {
@@ -249,7 +249,7 @@ export class Application extends ChildableComponent<Application, AbstractCompone
                 if (FS.statSync(realpath).isDirectory()) {
                     add(realpath);
                 } else if (/\.tsx?$/.test(realpath)) {
-                    if (exclude && exclude.match(realpath.replace(/\\/g, '/'))) {
+                    if (excludePattern && realpath.replace(/\\/g, '/').match(excludePattern)) {
                         return;
                     }
 
@@ -262,7 +262,7 @@ export class Application extends ChildableComponent<Application, AbstractCompone
             file = Path.resolve(file);
             if (FS.statSync(file).isDirectory()) {
                 add(file);
-            } else if (!exclude || !exclude.match(file)) {
+            } else if (!excludePattern || !file.match(excludePattern)) {
                 files.push(file);
             }
         });

--- a/src/test/typedoc.ts
+++ b/src/test/typedoc.ts
@@ -24,7 +24,7 @@ describe('TypeDoc', function() {
         });
         it('honors the exclude argument even on a fixed directory list', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class');
-            application.options.setValue('exclude', '**/class.ts');
+            application.options.setValue('exclude', '.*class\\.ts$');
             const expanded = application.expandInputFiles([inputFiles]);
 
             Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class.ts')), -1);
@@ -32,14 +32,14 @@ describe('TypeDoc', function() {
         });
         it('honors the exclude argument even on a fixed file list', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class', 'class.ts');
-            application.options.setValue('exclude', '**/class.ts');
+            application.options.setValue('exclude', '.*class\\.ts$');
             const expanded = application.expandInputFiles([inputFiles]);
 
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
         it('supports multiple excludes', function() {
             const inputFiles = Path.join(__dirname, 'converter');
-            application.options.setValue('exclude', '**/+(class|access).ts');
+            application.options.setValue('exclude', '.*(class|access)\\.ts$');
             const expanded = application.expandInputFiles([inputFiles]);
 
             Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class', 'class.ts')), -1);


### PR DESCRIPTION
The minimatch glob pattern does not properly support multiple exclusions other than a simple (this|that) which is not enough if you need to exclude multiple directories *and* subdirectories. A good solution to this is to change from a minimatch glob pattern to a Regular Expression pattern which is more powerfull and can almost match anything.

Please consider accepting this as it doesn't affect anything other than this file matching and makes it considerably more powerful.