### PR TITLE
Move all @types dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,6 @@
     "node": ">= 4.2.0"
   },
   "dependencies": {
-    "@types/fs-extra": "^2.0.0",
-    "@types/handlebars": "^4.0.31",
-    "@types/highlight.js": "^9.1.8",
-    "@types/lodash": "^4.14.37",
-    "@types/marked": "0.0.28",
-    "@types/minimatch": "^2.0.29",
-    "@types/shelljs": "^0.7.0",
     "fs-extra": "^2.0.0",
     "handlebars": "^4.0.6",
     "highlight.js": "^9.0.0",
@@ -49,7 +42,14 @@
     "typescript": "2.2.2"
   },
   "devDependencies": {
+    "@types/fs-extra": "^2.0.0",
+    "@types/handlebars": "^4.0.31",
+    "@types/highlight.js": "^9.1.8",
+    "@types/lodash": "^4.14.37",
+    "@types/marked": "0.0.28",
+    "@types/minimatch": "^2.0.29",
     "@types/mocha": "^2.2.39",
+    "@types/shelljs": "^0.7.0",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",


### PR DESCRIPTION
I've been seeing "bleedover" issues with @types dependencies installed by typedoc. (In my particular case, it's with `@types/lodash` not compiling in my projects for various reasons.) Beyond my specific issues, it seems like a good idea to try to avoid contaminating downstream users of typedoc with extra typings they aren't expecting.