### PR TITLE
Support for multidimensional arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "minimatch": "^3.0.0",
     "progress": "^2.0.0",
     "shelljs": "^0.7.0",
-    "typedoc-default-themes": "^0.4.2",
+    "typedoc-default-themes": "^0.4.4",
     "typescript": "2.3.2"
   },
   "devDependencies": {

--- a/src/lib/converter/plugins/TypePlugin.ts
+++ b/src/lib/converter/plugins/TypePlugin.ts
@@ -1,5 +1,5 @@
 import {Reflection, ReflectionKind, Decorator, DeclarationReflection, DeclarationHierarchy} from '../../models/reflections/index';
-import {Type, ReferenceType, TupleType, UnionType, IntersectionType} from '../../models/types/index';
+import {Type, ReferenceType, TupleType, UnionType, IntersectionType, ArrayType} from '../../models/types/index';
 import {Component, ConverterComponent} from '../components';
 import {Converter} from '../converter';
 import {Context} from '../context';
@@ -113,6 +113,8 @@ export class TypePlugin extends ConverterComponent {
                 for (let index = 0, count = unionOrIntersectionType.types.length; index < count; index++) {
                     resolveType(reflection, unionOrIntersectionType.types[index]);
                 }
+            } else if (type instanceof ArrayType) {
+                resolveType(reflection, type.elementType);
             }
         }
     }

--- a/src/lib/converter/types/array.ts
+++ b/src/lib/converter/types/array.ts
@@ -1,16 +1,24 @@
 import * as ts from 'typescript';
 
-import {Type, IntrinsicType} from '../../models/index';
-import {Component, ConverterTypeComponent, TypeNodeConverter} from '../components';
+import {Type, ArrayType} from '../../models/index';
+import {Component, ConverterTypeComponent, TypeConverter} from '../components';
 import {Context} from '../context';
 
 @Component({name: 'type:array'})
-export class ArrayConverter extends ConverterTypeComponent implements TypeNodeConverter<ts.Type, ts.ArrayTypeNode> {
+export class ArrayConverter extends ConverterTypeComponent implements TypeConverter<ts.TypeReference, ts.ArrayTypeNode> {
     /**
      * Test whether this converter can handle the given TypeScript node.
      */
     supportsNode(context: Context, node: ts.ArrayTypeNode): boolean {
         return node.kind === ts.SyntaxKind.ArrayType;
+    }
+
+    /**
+     * Test whether this converter can handle the given TypeScript type.
+     */
+    supportsType(context: Context, type: ts.TypeReference): boolean {
+        // Is there a better way to detect the {"type":"reference","name":"Array","typeArguments":{...}} types that are in fact arrays?
+        return !!(type.flags & ts.TypeFlags.Object) && !!type.symbol && type.symbol.name === 'Array' && !type.symbol.parent && !!type.typeArguments && type.typeArguments.length === 1;
     }
 
     /**
@@ -27,14 +35,28 @@ export class ArrayConverter extends ConverterTypeComponent implements TypeNodeCo
      * @returns The type reflection representing the given array type node.
      */
     convertNode(context: Context, node: ts.ArrayTypeNode): Type {
-        let result = this.owner.convertType(context, node.elementType);
+        const result = this.owner.convertType(context, node.elementType);
 
-        if (result) {
-            result.isArray = true;
-        } else {
-            result = new IntrinsicType('Array');
-        }
+        return new ArrayType(result);
+    }
 
-        return result;
+    /**
+     * Convert the given type reference to its type reflection.
+     *
+     * This is a type based converter, see [[convertTypeReference]] for the node equivalent.
+     *
+     * ```
+     * class SomeClass { }
+     * let someValue: SomeClass;
+     * ```
+     *
+     * @param context  The context object describing the current state the converter is in.
+     * @param type  The type reference that should be converted.
+     * @returns The type reflection representing the given type reference.
+     */
+    convertType(context: Context, type: ts.TypeReference): Type {
+        const result = this.owner.convertType(context, null, type.typeArguments[0]);
+
+        return new ArrayType(result);
     }
 }

--- a/src/lib/models/types/abstract.ts
+++ b/src/lib/models/types/abstract.ts
@@ -4,10 +4,6 @@
  * Instances of this class are also used to represent the type `void`.
  */
 export abstract class Type {
-    /**
-     * Is this an array type?
-     */
-    isArray = false;
 
     /**
      * The type name identifier.
@@ -37,10 +33,6 @@ export abstract class Type {
     toObject(): any {
         let result: any = {};
         result.type = this.type;
-
-        if (this.isArray) {
-            result.isArray = this.isArray;
-        }
 
         return result;
     }

--- a/src/lib/models/types/array.ts
+++ b/src/lib/models/types/array.ts
@@ -1,0 +1,75 @@
+import {Type, UnionType, IntersectionType} from './index';
+
+/**
+ * Represents an array type.
+ *
+ * ~~~
+ * let value: string[];
+ * ~~~
+ */
+export class ArrayType extends Type {
+
+    /**
+     * The type of the array elements.
+     */
+    elementType: Type;
+
+    /**
+     * The type name identifier.
+     */
+    readonly type: string = 'array';
+
+    /**
+     * Create a new TupleType instance.
+     *
+     * @param elementType  The type of the array's elements.
+     */
+    constructor(elementType: Type) {
+        super();
+        this.elementType = elementType;
+    }
+
+    /**
+     * Clone this type.
+     *
+     * @return A clone of this type.
+     */
+    clone(): Type {
+        return new ArrayType(this.elementType);
+    }
+
+    /**
+     * Test whether this type equals the given type.
+     *
+     * @param type  The type that should be checked for equality.
+     * @returns TRUE if the given type equals this type, FALSE otherwise.
+     */
+    equals(type: Type): boolean {
+        if (!(type instanceof ArrayType)) {
+            return false;
+        }
+        return type.elementType.equals(this.elementType);
+    }
+
+    /**
+     * Return a raw object representation of this type.
+     */
+    toObject(): any {
+        const result: any = super.toObject();
+        result.elementType = this.elementType.toObject();
+
+        return result;
+    }
+
+    /**
+     * Return a string representation of this type.
+     */
+    toString() {
+        const elementTypeStr = this.elementType.toString();
+        if (this.elementType instanceof UnionType || this.elementType instanceof IntersectionType) {
+            return '(' + elementTypeStr + ')[]';
+        } else {
+            return elementTypeStr + '[]';
+        }
+    }
+}

--- a/src/lib/models/types/index.ts
+++ b/src/lib/models/types/index.ts
@@ -1,4 +1,5 @@
 export {Type} from './abstract';
+export {ArrayType} from './array';
 export {IntrinsicType} from './intrinsic';
 export {IntersectionType} from './intersection';
 export {ReferenceType} from './reference';

--- a/src/lib/models/types/intersection.ts
+++ b/src/lib/models/types/intersection.ts
@@ -34,9 +34,7 @@ export class IntersectionType extends Type {
      * @return A clone of this type.
      */
     clone(): Type {
-        const clone = new IntersectionType(this.types);
-        clone.isArray = this.isArray;
-        return clone;
+        return new IntersectionType(this.types);
     }
 
     /**
@@ -47,9 +45,6 @@ export class IntersectionType extends Type {
      */
     equals(type: IntersectionType): boolean {
         if (!(type instanceof IntersectionType)) {
-            return false;
-        }
-        if (type.isArray !== this.isArray) {
             return false;
         }
         return Type.isTypeListSimiliar(type.types, this.types);

--- a/src/lib/models/types/intrinsic.ts
+++ b/src/lib/models/types/intrinsic.ts
@@ -34,9 +34,7 @@ export class IntrinsicType extends Type {
      * @return A clone of this type.
      */
     clone(): Type {
-        const clone = new IntrinsicType(this.name);
-        clone.isArray = this.isArray;
-        return clone;
+        return new IntrinsicType(this.name);
     }
 
     /**
@@ -47,7 +45,6 @@ export class IntrinsicType extends Type {
      */
     equals(type: IntrinsicType): boolean {
         return type instanceof IntrinsicType &&
-            type.isArray === this.isArray &&
             type.name === this.name;
     }
 
@@ -64,6 +61,6 @@ export class IntrinsicType extends Type {
      * Return a string representation of this type.
      */
     toString() {
-        return this.name + (this.isArray ? '[]' : '');
+        return this.name;
     }
 }

--- a/src/lib/models/types/reference.ts
+++ b/src/lib/models/types/reference.ts
@@ -73,7 +73,6 @@ export class ReferenceType extends Type {
      */
     clone(): Type {
         const clone = new ReferenceType(this.name, this.symbolID, this.reflection);
-        clone.isArray = this.isArray;
         clone.typeArguments = this.typeArguments;
         return clone;
     }
@@ -86,7 +85,6 @@ export class ReferenceType extends Type {
      */
     equals(type: ReferenceType): boolean {
         return type instanceof ReferenceType &&
-            type.isArray === this.isArray &&
             (type.symbolID === this.symbolID || type.reflection === this.reflection);
     }
 
@@ -114,7 +112,6 @@ export class ReferenceType extends Type {
      */
     toString() {
         const name = this.reflection ? this.reflection.name : this.name;
-        const arraySuffix = this.isArray ? '[]' : '';
         let typeArgs = '';
         if (this.typeArguments) {
             typeArgs += '<';
@@ -122,6 +119,6 @@ export class ReferenceType extends Type {
             typeArgs += '>';
         }
 
-        return name + typeArgs + arraySuffix;
+        return name + typeArgs;
     }
 }

--- a/src/lib/models/types/reflection.ts
+++ b/src/lib/models/types/reflection.ts
@@ -35,9 +35,7 @@ export class ReflectionType extends Type {
      * @return A clone of this type.
      */
     clone(): Type {
-        const clone = new ReflectionType(this.declaration);
-        clone.isArray = this.isArray;
-        return clone;
+        return new ReflectionType(this.declaration);
     }
 
     /**

--- a/src/lib/models/types/string-literal.ts
+++ b/src/lib/models/types/string-literal.ts
@@ -34,9 +34,7 @@ export class StringLiteralType extends Type {
      * @return A clone of this type.
      */
     clone(): Type {
-        const clone = new StringLiteralType(this.value);
-        clone.isArray = this.isArray;
-        return clone;
+        return new StringLiteralType(this.value);
     }
 
     /**
@@ -47,7 +45,6 @@ export class StringLiteralType extends Type {
      */
     equals(type: StringLiteralType): boolean {
         return type instanceof StringLiteralType &&
-            type.isArray === this.isArray &&
             type.value === this.value;
     }
 

--- a/src/lib/models/types/tuple.ts
+++ b/src/lib/models/types/tuple.ts
@@ -34,9 +34,7 @@ export class TupleType extends Type {
      * @return A clone of this type.
      */
     clone(): Type {
-        const clone = new TupleType(this.elements);
-        clone.isArray = this.isArray;
-        return clone;
+        return new TupleType(this.elements);
     }
 
     /**
@@ -47,9 +45,6 @@ export class TupleType extends Type {
      */
     equals(type: TupleType): boolean {
         if (!(type instanceof TupleType)) {
-            return false;
-        }
-        if (type.isArray !== this.isArray) {
             return false;
         }
         return Type.isTypeListEqual(type.elements, this.elements);

--- a/src/lib/models/types/type-parameter.ts
+++ b/src/lib/models/types/type-parameter.ts
@@ -27,7 +27,6 @@ export class TypeParameterType extends Type {
      */
     clone(): Type {
         const clone = new TypeParameterType();
-        clone.isArray = this.isArray;
         clone.name = this.name;
         clone.constraint = this.constraint;
         return clone;
@@ -44,17 +43,13 @@ export class TypeParameterType extends Type {
             return false;
         }
 
-        let constraintEquals: boolean;
         if (this.constraint && type.constraint) {
-            constraintEquals = type.constraint.equals(this.constraint);
+            return type.constraint.equals(this.constraint);
         } else if (!this.constraint && !type.constraint) {
-            constraintEquals = true;
+            return true;
         } else {
             return false;
         }
-
-        return constraintEquals &&
-            type.isArray === this.isArray;
     }
 
     /**

--- a/src/lib/models/types/union.ts
+++ b/src/lib/models/types/union.ts
@@ -34,9 +34,7 @@ export class UnionType extends Type {
      * @return A clone of this type.
      */
     clone(): Type {
-        const clone = new UnionType(this.types);
-        clone.isArray = this.isArray;
-        return clone;
+        return new UnionType(this.types);
     }
 
     /**
@@ -47,9 +45,6 @@ export class UnionType extends Type {
      */
     equals(type: UnionType): boolean {
         if (!(type instanceof UnionType)) {
-            return false;
-        }
-        if (type.isArray !== this.isArray) {
             return false;
         }
         return Type.isTypeListSimiliar(type.types, this.types);

--- a/src/lib/models/types/unknown.ts
+++ b/src/lib/models/types/unknown.ts
@@ -30,9 +30,7 @@ export class UnknownType extends Type {
      * @return A clone of this type.
      */
     clone(): Type {
-        const clone = new UnknownType(this.name);
-        clone.isArray = this.isArray;
-        return clone;
+        return new UnknownType(this.name);
     }
 
     /**
@@ -43,7 +41,6 @@ export class UnknownType extends Type {
      */
     equals(type: UnknownType): boolean {
         return type instanceof UnknownType &&
-            type.isArray === this.isArray &&
             type.name === this.name;
     }
 

--- a/src/test/converter/array/array.ts
+++ b/src/test/converter/array/array.ts
@@ -1,0 +1,16 @@
+/**
+ * A custom array interface.
+ */
+export interface Array<T>
+{
+}
+
+/**
+ * A const of a complex type.
+ */
+export const complex: ((Array<string>[] | number[])[] | string)[][] = [];
+
+/**
+ * An exported const of the custom array type.
+ */
+export const custom: Array<number> = {};

--- a/src/test/converter/array/specs.json
+++ b/src/test/converter/array/specs.json
@@ -1,0 +1,175 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "flags": {},
+  "children": [
+    {
+      "id": 1,
+      "name": "\"array\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/array/array.ts",
+      "children": [
+        {
+          "id": 2,
+          "name": "Array",
+          "kind": 256,
+          "kindString": "Interface",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "A custom array interface."
+          },
+          "typeParameter": [
+            {
+              "id": 3,
+              "name": "T",
+              "kind": 131072,
+              "kindString": "Type parameter",
+              "flags": {}
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "array.ts",
+              "line": 4,
+              "character": 22
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "name": "complex",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "A const of a complex type."
+          },
+          "sources": [
+            {
+              "fileName": "array.ts",
+              "line": 11,
+              "character": 20
+            }
+          ],
+          "type": {
+            "type": "array",
+            "elementType": {
+              "type": "array",
+              "elementType": {
+                "type": "union",
+                "types": [
+                  {
+                    "type": "intrinsic",
+                    "name": "string"
+                  },
+                  {
+                    "type": "array",
+                    "elementType": {
+                      "type": "union",
+                      "types": [
+                        {
+                          "type": "array",
+                          "elementType": {
+                            "type": "reference",
+                            "name": "Array",
+                            "id": 2,
+                            "typeArguments": [
+                              {
+                                "type": "intrinsic",
+                                "name": "string"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "array",
+                          "elementType": {
+                            "type": "intrinsic",
+                            "name": "number"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "defaultValue": " []"
+        },
+        {
+          "id": 5,
+          "name": "custom",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "An exported const of the custom array type."
+          },
+          "sources": [
+            {
+              "fileName": "array.ts",
+              "line": 16,
+              "character": 19
+            }
+          ],
+          "type": {
+            "type": "reference",
+            "name": "Array",
+            "id": 2,
+            "typeArguments": [
+              {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            ]
+          }
+        }
+      ],
+      "groups": [
+        {
+          "title": "Interfaces",
+          "kind": 256,
+          "children": [
+            2
+          ]
+        },
+        {
+          "title": "Variables",
+          "kind": 32,
+          "children": [
+            4,
+            5
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "array.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "External modules",
+      "kind": 1,
+      "children": [
+        1
+      ]
+    }
+  ]
+}

--- a/src/test/converter/class/specs.json
+++ b/src/test/converter/class/specs.json
@@ -89,9 +89,11 @@
                 }
               ],
               "type": {
-                "type": "intrinsic",
-                "isArray": true,
-                "name": "number"
+                "type": "array",
+                "elementType": {
+                  "type": "intrinsic",
+                  "name": "number"
+                }
               }
             },
             {

--- a/src/test/converter/destructuring/specs.json
+++ b/src/test/converter/destructuring/specs.json
@@ -110,14 +110,11 @@
             }
           ],
           "type": {
-            "type": "reference",
-            "name": "Array",
-            "typeArguments": [
-              {
-                "type": "intrinsic",
-                "name": "number"
-              }
-            ]
+            "type": "array",
+            "elementType": {
+              "type": "intrinsic",
+              "name": "number"
+            }
           }
         },
         {
@@ -134,14 +131,11 @@
             }
           ],
           "type": {
-            "type": "reference",
-            "name": "Array",
-            "typeArguments": [
-              {
-                "type": "intrinsic",
-                "name": "number"
-              }
-            ]
+            "type": "array",
+            "elementType": {
+              "type": "intrinsic",
+              "name": "number"
+            }
           }
         },
         {

--- a/src/test/converter/function/specs.json
+++ b/src/test/converter/function/specs.json
@@ -483,9 +483,11 @@
                     "text": "The rest parameter."
                   },
                   "type": {
-                    "type": "intrinsic",
-                    "isArray": true,
-                    "name": "string"
+                    "type": "array",
+                    "elementType": {
+                      "type": "intrinsic",
+                      "name": "string"
+                    }
                   }
                 }
               ],

--- a/src/test/converter/generic-class/specs.json
+++ b/src/test/converter/generic-class/specs.json
@@ -128,9 +128,11 @@
                 }
               ],
               "type": {
-                "type": "typeParameter",
-                "isArray": true,
-                "name": "T"
+                "type": "array",
+                "elementType": {
+                  "type": "typeParameter",
+                  "name": "T"
+                }
               }
             },
             {
@@ -321,9 +323,11 @@
                 }
               ],
               "type": {
-                "type": "intrinsic",
-                "isArray": true,
-                "name": "string"
+                "type": "array",
+                "elementType": {
+                  "type": "intrinsic",
+                  "name": "string"
+                }
               },
               "inheritedFrom": {
                 "type": "reference",

--- a/src/test/converter/generic-function/specs.json
+++ b/src/test/converter/generic-function/specs.json
@@ -65,16 +65,20 @@
                     "text": "A generic array parameter."
                   },
                   "type": {
-                    "type": "typeParameter",
-                    "isArray": true,
-                    "name": "T"
+                    "type": "array",
+                    "elementType": {
+                      "type": "typeParameter",
+                      "name": "T"
+                    }
                   }
                 }
               ],
               "type": {
-                "type": "typeParameter",
-                "isArray": true,
-                "name": "T"
+                "type": "array",
+                "elementType": {
+                  "type": "typeParameter",
+                  "name": "T"
+                }
               }
             }
           ],

--- a/src/test/converter/interface-implementation/specs.json
+++ b/src/test/converter/interface-implementation/specs.json
@@ -65,16 +65,18 @@
                     }
                   ],
                   "type": {
-                    "type": "reference",
-                    "isArray": true,
-                    "name": "ISubscription",
-                    "id": 7,
-                    "typeArguments": [
-                      {
-                        "type": "typeParameter",
-                        "name": "T"
-                      }
-                    ]
+                    "type": "array",
+                    "elementType": {
+                      "type": "reference",
+                      "name": "ISubscription",
+                      "id": 7,
+                      "typeArguments": [
+                        {
+                          "type": "typeParameter",
+                          "name": "T"
+                        }
+                      ]
+                    }
                   }
                 },
                 {

--- a/src/test/converter/literal-object/specs.json
+++ b/src/test/converter/literal-object/specs.json
@@ -129,14 +129,11 @@
                     }
                   ],
                   "type": {
-                    "type": "reference",
-                    "name": "Array",
-                    "typeArguments": [
-                      {
-                        "type": "intrinsic",
-                        "name": "number"
-                      }
-                    ]
+                    "type": "array",
+                    "elementType": {
+                      "type": "intrinsic",
+                      "name": "number"
+                    }
                   },
                   "defaultValue": " [100, 200, 300]"
                 },

--- a/src/test/converter/literal-type/specs.json
+++ b/src/test/converter/literal-type/specs.json
@@ -112,9 +112,11 @@
                             }
                           ],
                           "type": {
-                            "type": "intrinsic",
-                            "isArray": true,
-                            "name": "number"
+                            "type": "array",
+                            "elementType": {
+                              "type": "intrinsic",
+                              "name": "number"
+                            }
                           }
                         },
                         {

--- a/src/test/converter/union-or-intersection/specs.json
+++ b/src/test/converter/union-or-intersection/specs.json
@@ -151,18 +151,17 @@
                 }
               ],
               "type": {
-                "type": "union",
-                "isArray": true,
-                "types": [
-                  {
-                    "type": "intrinsic",
-                    "name": "string"
-                  },
-                  {
-                    "type": "reference",
-                    "name": "Array",
-                    "typeArguments": [
-                      {
+                "type": "array",
+                "elementType": {
+                  "type": "union",
+                  "types": [
+                    {
+                      "type": "intrinsic",
+                      "name": "string"
+                    },
+                    {
+                      "type": "array",
+                      "elementType": {
                         "type": "intersection",
                         "types": [
                           {
@@ -177,9 +176,9 @@
                           }
                         ]
                       }
-                    ]
-                  }
-                ]
+                    }
+                  ]
+                }
               }
             },
             {

--- a/src/test/renderer/specs/modules/_modules_.html
+++ b/src/test/renderer/specs/modules/_modules_.html
@@ -297,7 +297,7 @@
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal tsd-is-not-exported">
 							<a name="objectliteral.valuex-1.valuea-3" class="tsd-anchor"></a>
 							<h3>valueA</h3>
-							<div class="tsd-signature tsd-kind-icon">valueA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;[100, 200, 300]</span></div>
+							<div class="tsd-signature tsd-kind-icon">valueA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[100, 200, 300]</span></div>
 							<aside class="tsd-sources">
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/modules.ts#L70">modules.ts:70</a></li>

--- a/src/test/renderer/specs/modules/_modules_.mymodule.html
+++ b/src/test/renderer/specs/modules/_modules_.mymodule.html
@@ -118,7 +118,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
 					<a name="modulevariable" class="tsd-anchor"></a>
 					<h3>module<wbr>Variable</h3>
-					<div class="tsd-signature tsd-kind-icon">module<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;[100, 200]</span></div>
+					<div class="tsd-signature tsd-kind-icon">module<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[100, 200]</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/modules.ts#L37">modules.ts:37</a></li>

--- a/src/test/renderer/specs/modules/_typescript_1_5_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_5_.html
@@ -140,7 +140,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
 					<a name="destructarraywithignoresrest" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</h3>
-					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></div>
+					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.5.ts#L20">typescript-1.5.ts:20</a></li>
@@ -150,7 +150,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
 					<a name="destructarraywithrest" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>Rest</h3>
-					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></div>
+					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.5.ts#L15">typescript-1.5.ts:15</a></li>


### PR DESCRIPTION
This PR adds the support for multidimensional arrays.

Therefore the isArray flag was removed in favor of a new array type model.

This is necessary because setting the isArray flag of a type that is already an array - which in fact happened for multidimensional arrays - has no effect.
```ts
convertNode(context: Context, node: ts.ArrayTypeNode): Type {
        let result = this.owner.convertType(context, node.elementType);

        if (result) { // What if isArray is already true here?
            result.isArray = true;
        } else {
            result = new IntrinsicType('Array');
        }

        return result;
}
```

Please consider the corresponding PR for themes: TypeStrong/typedoc-default-themes#48