### PR TITLE
"exclude" option is not taken into account when passed through constructor

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -249,6 +249,9 @@ export class Application extends ChildableComponent<Application, AbstractCompone
      */
     public expandInputFiles(inputFiles?:string[]):string[] {
         var exclude:IMinimatch, files:string[] = [];
+
+        // exclude can be set in the constructor options. CLI has preferencece, though.
+        this.exclude = this.exclude || this.options.getValue('exclude');
         if (this.exclude) {
             exclude = new Minimatch(this.exclude);
         }

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -248,12 +248,15 @@ export class Application extends ChildableComponent<Application, AbstractCompone
      * @returns  The list of input files with expanded directories.
      */
     public expandInputFiles(inputFiles?:string[]):string[] {
-        var exclude:IMinimatch, files:string[] = [];
+        var exclude:IMinimatch, 
+            files:string[] = [], 
+            excludeInConstructor:string  = this.options.getValue('exclude');
 
         // exclude can be set in the constructor options. CLI has preferencece, though.
-        this.exclude = this.exclude || this.options.getValue('exclude');
         if (this.exclude) {
             exclude = new Minimatch(this.exclude);
+        } else if (excludeInConstructor) {
+            exclude = new Minimatch(excludeInConstructor);
         }
 
         function add(dirname:string) {

--- a/test/typedoc.js
+++ b/test/typedoc.js
@@ -17,4 +17,13 @@ describe('TypeDoc', function() {
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
     });
+
+    describe('Application', function() {
+        it('constructs', function() {
+            application = new TypeDoc.Application({exclude: '**/*.*'});
+        });
+        it('exclude is set in constructor', function() {
+            Assert.equal(application.exclude, '**/*.*');
+        });
+    });
 });

--- a/test/typedoc.js
+++ b/test/typedoc.js
@@ -17,13 +17,4 @@ describe('TypeDoc', function() {
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
     });
-
-    describe('Application', function() {
-        it('constructs', function() {
-            application = new TypeDoc.Application({exclude: '**/*.*'});
-        });
-        it('exclude is set in constructor', function() {
-            Assert.equal(application.exclude, '**/*.*');
-        });
-    });
 });


### PR DESCRIPTION
The "exclude" option is not taken into account when passed through constructor.
This is important when using typedoc through the API. For instance when typedoc is used together with gulp-typedoc. 