### PR TITLE
Corrects @tag capture regular expression pattern.

### DIFF
--- a/src/lib/converter/factories/comment.ts
+++ b/src/lib/converter/factories/comment.ts
@@ -164,7 +164,7 @@ export function parseComment(text: string, comment: Comment = new Comment()): Co
         line = line.replace(/^\s*\*? ?/, '');
         line = line.replace(/\s*$/, '');
 
-        const tag = /^@(\w+)/.exec(line);
+        const tag = /^@(\S+)/.exec(line);
         if (tag) {
             readTagLine(line, tag);
         } else {


### PR DESCRIPTION
This allows for non-whitespace characters in a tag name.  This
specifically, does not correct for inline tags such as {@link http...}
which should probably be handled differently.