### PR TITLE
Fix new theme loading and better error display upon failure.

### DIFF
--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -206,14 +206,12 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
                 this.theme = this.addComponent('theme', new DefaultTheme(this, path));
             } else {
                 try {
-                    const themeClass = typeof require(filename) === 'function' ? require(filename) : require(filename).default;
+                    const themeClass = typeof require(filename) === 'function' ? require(filename)() : require(filename).default;
 
                     this.theme = this.addComponent('theme', new (themeClass)(this, path));
                 } catch (err) {
-                    throw new Error(
-                        `Exception while loading "${filename}". You must export a \`new Theme(renderer, basePath)\` compatible class.\n` +
-                        err
-                    );
+                    err.stack = `Exception while loading "${filename}". You must export a \`new Theme(renderer, basePath)\` compatible class.\n\n` + err.stack;
+                    throw err;
                 }
             }
         }


### PR DESCRIPTION
The theme loading via returned function wasn't working (line 209).  Both paths have been tested now.

Also, the error output was suboptimal, the below way yields much more relevant results.

## Error before:
```js
C:\code\node\typedoc\src\lib\output\renderer.ts:215
                    throw new Error(
                          ^
Error: Exception while loading "C:\code\node\hain-docs\typedoc\theme\theme.js". You must export a `new Theme(renderer, basePath)` compatible class.
TypeError: Path must be a string. Received undefined
    at Renderer.prepareTheme (C:\code\node\typedoc\src\lib\output\renderer.ts:215:27)
    at Renderer.render (C:\code\node\typedoc\src\lib\output\renderer.ts:128:19)
    at CliApplication.Application.generateDocs (C:\code\node\typedoc\src\lib\application.ts:191:23)
    at CliApplication.bootstrap (C:\code\node\typedoc\src\lib\cli.ts:73:26)
    at CliApplication.Application (C:\code\node\typedoc\src\lib\application.ts:99:14)
    at new CliApplication (C:\code\node\typedoc\dist\lib\cli.js:35:42)
    at Object.<anonymous> (C:\code\node\typedoc\bin\typedoc:4:1)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
```

## Error After:
```js
Exception while loading "C:\code\node\hain-docs\typedoc\theme\theme.js". You must export a `new Theme(renderer, basePath)` compatible class.

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.resolve (path.js:186:7)
    at Resources.addDirectory (C:\code\node\hain-docs\node_modules\typedoc\src\lib\output\utils\resources.ts:65:21)
    at new Resources (C:\code\node\hain-docs\node_modules\typedoc\src\lib\output\utils\resources.ts:31:14)
    at HainTheme.Theme [as constructor] (C:\code\node\hain-docs\node_modules\typedoc\src\lib\output\theme.ts:71:26)
    at HainTheme.DefaultTheme [as constructor] (C:\code\node\hain-docs\node_modules\typedoc\src\lib\output\themes\DefaultTheme.ts:77:9)
    at HainTheme (C:\code\node\hain-docs\typedoc\theme\theme.ts:43:3)
    at Renderer.ChildableComponent.addComponent (C:\code\node\typedoc\src\lib\utils\component.ts:223:73)
    at Renderer.prepareTheme (C:\code\node\typedoc\src\lib\output\renderer.ts:211:39)
    at Renderer.render (C:\code\node\typedoc\src\lib\output\renderer.ts:128:19)
```

**Note: The error was related to the issue with line 209**