### PR TITLE
Fix themejs 2

### DIFF
--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -206,14 +206,12 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
                 this.theme = this.addComponent('theme', new DefaultTheme(this, path));
             } else {
                 try {
-                    const themeClass = typeof require(filename) === 'function' ? require(filename) : require(filename).default;
+                    const themeClass = typeof require(filename) === 'function' ? require(filename)() : require(filename).default;
 
                     this.theme = this.addComponent('theme', new (themeClass)(this, path));
                 } catch (err) {
-                    throw new Error(
-                        `Exception while loading "${filename}". You must export a \`new Theme(renderer, basePath)\` compatible class.\n` +
-                        err
-                    );
+                    err.stack = `Exception while loading "${filename}". You must export a \`new Theme(renderer, basePath)\` compatible class.\n\n` + err.stack;
+                    throw err;
                 }
             }
         }

--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -214,10 +214,8 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
 
                     // Using instanceof does not work because the external theme.js has its own 'copy' of Theme,
                     // checking that it has the resources that the base Theme class creates at construction
-                    if (!theme.resources) {
-                        this.application.logger.error('You must export a `new Theme(renderer, basePath)` compatible class in your theme.js.  Using default theme instead.');
-                        theme = new DefaultTheme(this, path);
-                    }
+                    if (!theme.resources)
+                        this.application.logger.error('You must export a `new Theme(renderer, basePath)` compatible class in your theme.js.');
 
                     this.theme = this.addComponent('theme', theme);
                 } catch (err) {


### PR DESCRIPTION
Alright, this one doesn't modify the stack (modifying message has no effect, so I opted for a simple application error log message.

 * I found the way you expected `require(filename)` to work and noted it in the code.  FTR these two ways are *entirely inconsistent* with the way plugins are done, which *I thought was the point* of being consistent.
 * I added a check against the themeClass that it has the resources property upon creation as it will have if derived from Theme.  (instanceof Theme does not work, as noted in the code).
