### PR TITLE
Allow JSDoc-style @link inline tags

### DIFF
--- a/src/lib/models/reflections/abstract.ts
+++ b/src/lib/models/reflections/abstract.ts
@@ -417,6 +417,9 @@ export abstract class Reflection {
             if (alias === '') {
                 alias = 'reflection-' + this.id;
             }
+            if (this.flags && this.flags.isStatic) {
+                alias = 'static-' + alias;
+            }
 
             let target = <Reflection> this;
             while (target.parent && !target.parent.isProject() && !target.hasOwnDocument) {
@@ -469,11 +472,17 @@ export abstract class Reflection {
      */
     getChildByName(arg: any): Reflection {
         const names: string[] = Array.isArray(arg) ? arg : arg.split('.');
-        const name = names[0];
+        let name = names[0];
         let result: Reflection = null;
+        // Did the @link tag use static syntax?
+        let staticLink = false;
+        if (name.indexOf('@static-') === 0) {
+            staticLink = true;
+            name = name.slice(8);
+        }
 
         this.traverse((child) => {
-            if (child.name === name) {
+            if (child.name === name && !(staticLink && !child.flags.isStatic)) {
                 if (names.length <= 1) {
                     result = child;
                 } else if (child) {

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -94,11 +94,17 @@ export class ProjectReflection extends ContainerReflection {
      */
     findReflectionByName(arg: any): Reflection {
         const names: string[] = Array.isArray(arg) ? arg : arg.split('.');
-        const name = names.pop();
+        let name = names.pop();
+        // Did the @link tag use static syntax?
+        let staticLink = false;
+        if (name.indexOf('@static-') === 0) {
+            staticLink = true;
+            name = name.slice(8);
+        }
 
         search: for (let key in this.reflections) {
             const reflection = this.reflections[key];
-            if (reflection.name !== name) {
+            if (reflection.name !== name || (staticLink && !reflection.flags.isStatic)) {
                 continue;
             }
 

--- a/src/lib/output/plugins/MarkedLinksPlugin.ts
+++ b/src/lib/output/plugins/MarkedLinksPlugin.ts
@@ -73,8 +73,21 @@ export class MarkedLinksPlugin extends ContextAwareRendererComponent {
     private replaceInlineTags(text: string): string {
         return text.replace(this.inlineTag, (match: string, leading: string, tagName: string, content: string): string => {
             const split   = MarkedLinksPlugin.splitLinkText(content);
-            const target  = split.target;
-            const caption = leading || split.caption;
+            let target  = split.target;
+            let caption = leading || split.caption;
+
+            // Convert any JSDoc-style @link syntax, replacing #s
+            if (caption === target) {
+                caption = caption.replace(/#\./, '.').replace(/#/, '.');
+                // Remove leading ., if there is one
+                if (caption.charAt(0) === '.') {
+                    caption = caption.slice(1);
+                }
+            }
+            target = target.replace(/#\./, '.@static-').replace(/#/, '.');
+            if (target.charAt(0) === '.') {
+                target = target.slice(1);
+            }
 
             let monospace: boolean;
             if (tagName === 'linkcode') {

--- a/src/lib/output/themes/DefaultTheme.ts
+++ b/src/lib/output/themes/DefaultTheme.ts
@@ -410,9 +410,6 @@ export class DefaultTheme extends Theme {
      */
     static applyAnchorUrl(reflection: Reflection, container: Reflection) {
         let anchor = DefaultTheme.getUrl(reflection, container, '.');
-        if (reflection['isStatic']) {
-            anchor = 'static-' + anchor;
-        }
 
         reflection.url = container.url + '#' + anchor;
         reflection.anchor = anchor;


### PR DESCRIPTION
This PR is meant to allow for standard JSDoc syntax of @link tags to be parsed by TypeDoc. JSDoc tags follow the standards laid out here: http://usejsdoc.org/tags-inline-link.html. The main difference between the current TypeDoc implementation (which remains as is), and JSDoc is the use of '#' rather than '.'.

See also https://github.com/TypeStrong/typedoc/issues/488. This is also resolved by this PR. Converting any instance of '#.' in a tag (valid JSDoc syntax to reference a static function) to '.@static', which can then be used to distinguish members of the same name and select the static version.

The last minor change is including 'static-' in the anchor of static members, which didn't work before. It is now done at the alias level to avoid unnecessary suffixes in names.

The overlying goal here is to allow users coming from JS/JSDoc environments to more quickly get up and running with TS/TypeDoc.

As a side note, this is my first PR for this project, so in addition to any flaws, let me know about style issues.