### PR TITLE
fix #513 - TypeError: Cannot read property 'forEach' of undefined

### DIFF
--- a/src/lib/converter/nodes/export.ts
+++ b/src/lib/converter/nodes/export.ts
@@ -23,7 +23,7 @@ export class ExportConverter extends ConverterNodeComponent<ts.ExportAssignment>
             let type = context.getTypeAtLocation(node.expression);
             symbol = type ? type.symbol : undefined;
         }
-        if (symbol) {
+        if (symbol && symbol.declarations) {
             const project = context.project;
             symbol.declarations.forEach((declaration) => {
                 if (!declaration.symbol) {


### PR DESCRIPTION
Added a check for if symbol.declarations is undefined to avoid the exception described in issue #513.

I reproduced this issue when someone added a file to our project that just exported another module.
````
import { HotkeysTarget } from '@blueprintjs/core';
export default HotkeysTarget;
````

When debugging I found that with this export the symbol object does not have a declarations property. It just has
````
{
  checkFlags: 0,
  flags: 134217732
  name: "unknown"
  type: {checker, flags: 1, id: 3, intrinsicName: "unknown"}
}
````

so I have just added a condition so that we don't try and call forEach on declarations if it doesn't exist.