### PR TITLE
Add option to remove doublequotes in module names in TOC

### DIFF
--- a/src/lib/converter/plugins/DynamicModulePlugin.ts
+++ b/src/lib/converter/plugins/DynamicModulePlugin.ts
@@ -4,6 +4,8 @@ import * as Path from 'path';
 import {Reflection, ReflectionKind} from '../../models/reflections/abstract';
 import {Component, ConverterComponent} from '../components';
 import {BasePath} from '../utils/base-path';
+import {Option} from '../../utils/component';
+import {ParameterType} from '../../utils/options/declaration';
 import {Converter} from '../converter';
 import {Context} from '../context';
 
@@ -22,6 +24,13 @@ export class DynamicModulePlugin extends ConverterComponent {
      * List of reflections whose name must be trimmed.
      */
     private reflections: Reflection[];
+
+    @Option({
+        name: 'externalModulesOnly',
+        help: 'Assume no internal modules (namespaces) in the output and exclude "" surrounding modules in the table of contents',
+        type: ParameterType.Boolean
+    })
+    externalModulesOnly: boolean;
 
     /**
      * Create a new DynamicModuleHandler instance.
@@ -73,7 +82,8 @@ export class DynamicModulePlugin extends ConverterComponent {
         this.reflections.forEach((reflection) => {
             let name = reflection.name.replace(/"/g, '');
             name = name.substr(0, name.length - Path.extname(name).length);
-            reflection.name = '"' + this.basePath.trim(name) + '"';
+            name = this.basePath.trim(name);
+            reflection.name = this.externalModulesOnly ? name : `"${name}"`;
         });
     }
 }


### PR DESCRIPTION
add `externalModulesOnly` option (boolean) which, if true, will not wrap module names in doublequotes. I was researching why these names are wrapped in quotes and stumbled across #68 discussing this issue, which [suggested a possible CLI flag](https://github.com/TypeStrong/typedoc/issues/68#issuecomment-75469700) to disable this functionality if desired.

Here's a screenshot of the change in a project where I am not using namespaces (internal modules).

![napkin 06-09-17 3 04 00 pm](https://user-images.githubusercontent.com/293805/26992570-e3e1c736-4d24-11e7-9c31-15f356023f9c.png)

Also, I'm open to alternatives for the name of the option. Some others I've thought of include 
- `assumeNoNamespace`
- `removeQuotes`
- `externalModules`

Any help on the naming would be greatly appreciated.