### PR TITLE
Gracefully handle GitHub plugin git exec failures

### DIFF
--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -129,7 +129,7 @@ class Repository {
         const out = <ShellJS.ExecOutputReturnValue> ShellJS.exec('git rev-parse --show-toplevel', {silent: true});
         ShellJS.popd();
 
-        if (out.code !== 0) {
+        if (!out || out.code !== 0) {
             return null;
         }
         return new Repository(BasePath.normalize(out.stdout.replace('\n', '')), gitRevision);


### PR DESCRIPTION
If shelljs exec of git rev-parse fails at the exec level, return null to add to ignored paths and continue.