### PR TITLE
Constructor parameters with readonly flag define properties.

### DIFF
--- a/examples/basic/src/classes.ts
+++ b/examples/basic/src/classes.ts
@@ -286,8 +286,9 @@ export class GenericClass<T extends BaseClass>
      * @param p2 Private string property
      * @param p3 Public number property
      * @param p4 Public implicit any property
+     * @param p5 Readonly property
      */
-    constructor(p1, protected p2:T, public p3:number, private p4:number) {
+    constructor(p1, protected p2:T, public p3:number, private p4:number, readonly p5: string) {
     }
 
 

--- a/src/lib/converter/nodes/constructor.ts
+++ b/src/lib/converter/nodes/constructor.ts
@@ -62,7 +62,8 @@ export class ConstructorConverter extends ConverterNodeComponent<ts.ConstructorD
      */
     private addParameterProperty(context: Context, parameter: ts.ParameterDeclaration, comment: Comment) {
         const modifiers = ts.getCombinedModifierFlags(parameter);
-        const visibility = modifiers & (ts.ModifierFlags.Public | ts.ModifierFlags.Protected | ts.ModifierFlags.Private);
+        const visibility = modifiers & (ts.ModifierFlags.Public | ts.ModifierFlags.Protected |
+                                        ts.ModifierFlags.Private | ts.ModifierFlags.Readonly);
         if (!visibility) {
             return;
         }

--- a/src/test/converter/constructor-properties/constructor-properties.ts
+++ b/src/test/converter/constructor-properties/constructor-properties.ts
@@ -6,8 +6,10 @@ class Vector2
     /**
      * @param x  X component of the Vector
      * @param y  Y component of the Vector
+     * @param name Vector name
      */
-    constructor(public x:number, public y:number) {
+    constructor(public x:number, public y:number,
+                readonly name: string) {
     }
 }
 
@@ -21,8 +23,10 @@ class Vector3 extends Vector2
      * @param x  X component of the Vector
      * @param y  Y component of the Vector
      * @param z  Z component of the Vector
+     * @param name Vector name
      */
-    constructor(x:number, public y:number, public z:number) {
-        super(x, y);
+    constructor(x:number, public y:number, public z:number,
+                readonly name: string) {
+        super(x, y, name);
     }
 }

--- a/src/test/converter/constructor-properties/specs.json
+++ b/src/test/converter/constructor-properties/specs.json
@@ -33,7 +33,7 @@
               "comment": {},
               "signatures": [
                 {
-                  "id": 6,
+                  "id": 7,
                   "name": "new Vector2",
                   "kind": 16384,
                   "kindString": "Constructor signature",
@@ -41,7 +41,7 @@
                   "comment": {},
                   "parameters": [
                     {
-                      "id": 7,
+                      "id": 8,
                       "name": "x",
                       "kind": 32768,
                       "kindString": "Parameter",
@@ -55,17 +55,31 @@
                       }
                     },
                     {
-                      "id": 8,
+                      "id": 9,
                       "name": "y",
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {},
                       "comment": {
-                        "shortText": "Y component of the Vector\n"
+                        "shortText": "Y component of the Vector"
                       },
                       "type": {
                         "type": "intrinsic",
                         "name": "number"
+                      }
+                    },
+                    {
+                      "id": 10,
+                      "name": "name",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Vector name\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
                       }
                     }
                   ],
@@ -85,6 +99,29 @@
               ]
             },
             {
+              "id": 6,
+              "name": "name",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isConstructorProperty": true
+              },
+              "comment": {
+                "shortText": "Vector name\n"
+              },
+              "sources": [
+                {
+                  "fileName": "constructor-properties.ts",
+                  "line": 12,
+                  "character": 29
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              }
+            },
+            {
               "id": 4,
               "name": "x",
               "kind": 1024,
@@ -99,7 +136,7 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 10,
+                  "line": 11,
                   "character": 24
                 }
               ],
@@ -118,12 +155,12 @@
                 "isPublic": true
               },
               "comment": {
-                "shortText": "Y component of the Vector\n"
+                "shortText": "Y component of the Vector"
               },
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 10,
+                  "line": 11,
                   "character": 41
                 }
               ],
@@ -145,6 +182,7 @@
               "title": "Properties",
               "kind": 1024,
               "children": [
+                6,
                 4,
                 5
               ]
@@ -161,12 +199,12 @@
             {
               "type": "reference",
               "name": "Vector3",
-              "id": 9
+              "id": 11
             }
           ]
         },
         {
-          "id": 9,
+          "id": 11,
           "name": "Vector3",
           "kind": 128,
           "kindString": "Class",
@@ -176,7 +214,7 @@
           },
           "children": [
             {
-              "id": 10,
+              "id": 12,
               "name": "constructor",
               "kind": 512,
               "kindString": "Constructor",
@@ -184,7 +222,7 @@
               "comment": {},
               "signatures": [
                 {
-                  "id": 13,
+                  "id": 16,
                   "name": "new Vector3",
                   "kind": 16384,
                   "kindString": "Constructor signature",
@@ -192,7 +230,7 @@
                   "comment": {},
                   "parameters": [
                     {
-                      "id": 14,
+                      "id": 17,
                       "name": "x",
                       "kind": 32768,
                       "kindString": "Parameter",
@@ -206,7 +244,7 @@
                       }
                     },
                     {
-                      "id": 15,
+                      "id": 18,
                       "name": "y",
                       "kind": 32768,
                       "kindString": "Parameter",
@@ -220,24 +258,38 @@
                       }
                     },
                     {
-                      "id": 16,
+                      "id": 19,
                       "name": "z",
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {},
                       "comment": {
-                        "shortText": "Z component of the Vector\n"
+                        "shortText": "Z component of the Vector"
                       },
                       "type": {
                         "type": "intrinsic",
                         "name": "number"
+                      }
+                    },
+                    {
+                      "id": 20,
+                      "name": "name",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Vector name\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
                       }
                     }
                   ],
                   "type": {
                     "type": "reference",
                     "name": "Vector3",
-                    "id": 9
+                    "id": 11
                   },
                   "overwrites": {
                     "type": "reference",
@@ -249,7 +301,7 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 19,
+                  "line": 21,
                   "character": 1
                 }
               ],
@@ -260,7 +312,35 @@
               }
             },
             {
-              "id": 17,
+              "id": 15,
+              "name": "name",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isConstructorProperty": true
+              },
+              "comment": {
+                "shortText": "Vector name\n"
+              },
+              "sources": [
+                {
+                  "fileName": "constructor-properties.ts",
+                  "line": 29,
+                  "character": 29
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              },
+              "overwrites": {
+                "type": "reference",
+                "name": "Vector2.name",
+                "id": 6
+              }
+            },
+            {
+              "id": 21,
               "name": "x",
               "kind": 1024,
               "kindString": "Property",
@@ -274,7 +354,7 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 10,
+                  "line": 11,
                   "character": 24
                 }
               ],
@@ -289,7 +369,7 @@
               }
             },
             {
-              "id": 11,
+              "id": 13,
               "name": "y",
               "kind": 1024,
               "kindString": "Property",
@@ -303,7 +383,7 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 25,
+                  "line": 28,
                   "character": 34
                 }
               ],
@@ -318,7 +398,7 @@
               }
             },
             {
-              "id": 12,
+              "id": 14,
               "name": "z",
               "kind": 1024,
               "kindString": "Property",
@@ -327,12 +407,12 @@
                 "isPublic": true
               },
               "comment": {
-                "shortText": "Z component of the Vector\n"
+                "shortText": "Z component of the Vector"
               },
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 25,
+                  "line": 28,
                   "character": 51
                 }
               ],
@@ -347,23 +427,24 @@
               "title": "Constructors",
               "kind": 512,
               "children": [
-                10
+                12
               ]
             },
             {
               "title": "Properties",
               "kind": 1024,
               "children": [
-                17,
-                11,
-                12
+                15,
+                21,
+                13,
+                14
               ]
             }
           ],
           "sources": [
             {
               "fileName": "constructor-properties.ts",
-              "line": 18,
+              "line": 20,
               "character": 13
             }
           ],
@@ -382,7 +463,7 @@
           "kind": 128,
           "children": [
             2,
-            9
+            11
           ]
         }
       ],

--- a/src/test/renderer/specs/classes/_classes_.genericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.genericclass.html
@@ -118,6 +118,7 @@
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><a href="_classes_.genericclass.html#p2" class="tsd-kind-icon">p2</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.genericclass.html#p3" class="tsd-kind-icon">p3</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_classes_.genericclass.html#p4" class="tsd-kind-icon">p4</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.genericclass.html#p5" class="tsd-kind-icon">p5</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.genericclass.html#value" class="tsd-kind-icon">value</a></li>
 							</ul>
 						</section>
@@ -137,7 +138,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Generic<wbr>Class<span class="tsd-signature-symbol">(</span>p1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, p2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span>, p3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.genericclass.html" class="tsd-signature-type">GenericClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Generic<wbr>Class<span class="tsd-signature-symbol">(</span>p1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, p2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span>, p3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.genericclass.html" class="tsd-signature-type">GenericClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -185,6 +186,14 @@
 										</div>
 									</div>
 								</li>
+								<li>
+									<h5>p5: <span class="tsd-signature-type">string</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<div class="lead">
+											<p>Readonly property</p>
+										</div>
+									</div>
+								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="_classes_.genericclass.html" class="tsd-signature-type">GenericClass</a></h4>
 						</li>
@@ -199,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">p2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L290">classes.ts:290</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -214,7 +223,7 @@
 					<div class="tsd-signature tsd-kind-icon">p3<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L290">classes.ts:290</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -229,12 +238,27 @@
 					<div class="tsd-signature tsd-kind-icon">p4<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L290">classes.ts:290</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>Public implicit any property</p>
+						</div>
+					</div>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
+					<a name="p5" class="tsd-anchor"></a>
+					<h3>p5</h3>
+					<div class="tsd-signature tsd-kind-icon">p5<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
+						</ul>
+					</aside>
+					<div class="tsd-comment tsd-typography">
+						<div class="lead">
+							<p>Readonly property</p>
 						</div>
 					</div>
 				</section>
@@ -261,7 +285,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L302">classes.ts:302</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L303">classes.ts:303</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">T</span></h4>
@@ -278,7 +302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L297">classes.ts:297</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L298">classes.ts:298</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -363,6 +387,9 @@
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private">
 								<a href="_classes_.genericclass.html#p4" class="tsd-kind-icon">p4</a>
+							</li>
+							<li class=" tsd-kind-property tsd-parent-kind-class">
+								<a href="_classes_.genericclass.html#p5" class="tsd-kind-icon">p5</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class">
 								<a href="_classes_.genericclass.html#value" class="tsd-kind-icon">value</a>

--- a/src/test/renderer/specs/classes/_classes_.nongenericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.nongenericclass.html
@@ -104,6 +104,7 @@
 							<ul class="tsd-index-list">
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_classes_.nongenericclass.html#p2" class="tsd-kind-icon">p2</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.nongenericclass.html#p3" class="tsd-kind-icon">p3</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.nongenericclass.html#p5" class="tsd-kind-icon">p5</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.nongenericclass.html#value" class="tsd-kind-icon">value</a></li>
 							</ul>
 						</section>
@@ -123,7 +124,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Non<wbr>Generic<wbr>Class<span class="tsd-signature-symbol">(</span>p1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, p2<span class="tsd-signature-symbol">: </span><a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a>, p3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.nongenericclass.html" class="tsd-signature-type">NonGenericClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Non<wbr>Generic<wbr>Class<span class="tsd-signature-symbol">(</span>p1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, p2<span class="tsd-signature-symbol">: </span><a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a>, p3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.nongenericclass.html" class="tsd-signature-type">NonGenericClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -172,6 +173,14 @@
 										</div>
 									</div>
 								</li>
+								<li>
+									<h5>p5: <span class="tsd-signature-type">string</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<div class="lead">
+											<p>Readonly property</p>
+										</div>
+									</div>
+								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="_classes_.nongenericclass.html" class="tsd-signature-type">NonGenericClass</a></h4>
 						</li>
@@ -187,7 +196,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#p2">p2</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L290">classes.ts:290</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -203,12 +212,28 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#p3">p3</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L290">classes.ts:290</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>Public number property</p>
+						</div>
+					</div>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
+					<a name="p5" class="tsd-anchor"></a>
+					<h3>p5</h3>
+					<div class="tsd-signature tsd-kind-icon">p5<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
+					<aside class="tsd-sources">
+						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#p5">p5</a></p>
+						<ul>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
+						</ul>
+					</aside>
+					<div class="tsd-comment tsd-typography">
+						<div class="lead">
+							<p>Readonly property</p>
 						</div>
 					</div>
 				</section>
@@ -237,7 +262,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#getvalue">getValue</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L302">classes.ts:302</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L303">classes.ts:303</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></h4>
@@ -255,7 +280,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#setvalue">setValue</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L297">classes.ts:297</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L298">classes.ts:298</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -343,6 +368,9 @@
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
 								<a href="_classes_.nongenericclass.html#p3" class="tsd-kind-icon">p3</a>
+							</li>
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
+								<a href="_classes_.nongenericclass.html#p5" class="tsd-kind-icon">p5</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
 								<a href="_classes_.nongenericclass.html#value" class="tsd-kind-icon">value</a>


### PR DESCRIPTION
The signature ``constructor(public foo: string)`` defines a public property corresponding to the parameter. The signature ``constructor(readonly foo: string)`` defines a public readonly property but prior to this commit, typedoc would not show this property in the generated documentation.

Fixes #352.