### PR TITLE
Clobber generic/default options with more specific options

### DIFF
--- a/src/lib/utils/options/readers/arguments.ts
+++ b/src/lib/utils/options/readers/arguments.ts
@@ -8,7 +8,7 @@ import { ParameterType } from '../declaration';
 @Component({name: 'options:arguments'})
 export class ArgumentsReader extends OptionsComponent {
     initialize() {
-        this.listenTo(this.owner, DiscoverEvent.DISCOVER, this.onDiscover, -299);
+        this.listenTo(this.owner, DiscoverEvent.DISCOVER, this.onDiscover, -200);
     }
 
     onDiscover(event: DiscoverEvent) {

--- a/src/lib/utils/options/readers/arguments.ts
+++ b/src/lib/utils/options/readers/arguments.ts
@@ -8,7 +8,7 @@ import { ParameterType } from '../declaration';
 @Component({name: 'options:arguments'})
 export class ArgumentsReader extends OptionsComponent {
     initialize() {
-        this.listenTo(this.owner, DiscoverEvent.DISCOVER, this.onDiscover);
+        this.listenTo(this.owner, DiscoverEvent.DISCOVER, this.onDiscover, -299);
     }
 
     onDiscover(event: DiscoverEvent) {
@@ -46,6 +46,7 @@ export class ArgumentsReader extends OptionsComponent {
             }
         }
 
+        const files = [];
         while (index < args.length) {
             const arg = args[index++];
 
@@ -54,8 +55,11 @@ export class ArgumentsReader extends OptionsComponent {
             } else if (arg.charCodeAt(0) === _ts.CharacterCodes.minus) {
                 readArgument(arg.slice(arg.charCodeAt(1) === _ts.CharacterCodes.minus ? 2 : 1).toLowerCase());
             } else {
-                event.addInputFile(arg);
+                files.push(arg);
             }
+        }
+        if (files) {
+            event.inputFiles = files;
         }
     }
 

--- a/src/lib/utils/options/readers/typedoc.ts
+++ b/src/lib/utils/options/readers/typedoc.ts
@@ -22,7 +22,7 @@ export class TypedocReader extends OptionsComponent {
     private static OPTIONS_KEY = 'options';
 
     initialize() {
-        this.listenTo(this.owner, DiscoverEvent.DISCOVER, this.onDiscover, -100);
+        this.listenTo(this.owner, DiscoverEvent.DISCOVER, this.onDiscover, -150);
     }
 
     onDiscover(event: DiscoverEvent) {


### PR DESCRIPTION
This fixes an issue where `typedoc` clobbers the CLI path with the found options from `tsconfig.json` or `typedoc.js`. It took me a bit to figure everything out:

* `ArgumentsReader` has [no priority](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/options/readers/arguments.ts#L11), whereas the priorities for [`TypedocReader`](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/options/readers/typedoc.ts#L25) and [`TSConfigReader`](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/options/readers/tsconfig.ts#L27) are both `-100`.
* [`onApi` sorts](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/events.ts#L112) from biggest to smallest. To verify,
```javascript
[0, -100, -100].sort((a, b) => b - a)
// [0, -100, -100]
new Array(10).fill(0).map((value, index) => index).sort((a, b) => b - a)
// [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
```
* Because `ArgumentsReader` has the largest priority, it executes first. If it encounters [an unknown argument](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/options/options.ts#L37), it [`push`es the filename](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/options/readers/arguments.ts#L57) to `event.inputFiles`.
* Because `TSConfigReader` has a lower priority, it executes second. It searches the [`tsconfig.json` for filenames](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/options/readers/tsconfig.ts#L64). To do so, it uses [`parseJsonConfigFileContent`](https://github.com/Microsoft/TypeScript/blob/release-2.4/src/compiler/commandLineParser.ts#L1104), which [checks for file specs](https://github.com/Microsoft/TypeScript/blob/release-2.4/src/compiler/commandLineParser.ts#L1145). If it doesn't find any, it returns [files matching `**/*`](https://github.com/Microsoft/TypeScript/blob/release-2.4/src/compiler/commandLineParser.ts#L1189) that do not match [common package folders](https://github.com/Microsoft/TypeScript/blob/release-2.4/src/compiler/commandLineParser.ts#L1189). In essence, it will **always** return non-empty `fileNames`. Even were `fileNames` empty, [`event.inputFiles` is still clobbered](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/options/readers/tsconfig.ts#L71).
* Putting all of this together, this means [the usage docs](http://typedoc.org/guides/usage/#arguments) are wrong, as is [the index in `src/test/renderer/specs/index.html`](https://github.com/TypeStrong/typedoc/blob/master/src/test/renderer/specs/index.html#L90). Unless `ArgumentsReader`'s priority is lowered (or a different solution is used), there's absolutely no way to pass in the source directory/files via the command line.

I've been trying to figure this out for too many hours, so I don't have a demo prepped. I can make one later. This folder structure
```
/project
    <optional tsconfig.json>
    some-file.ts
    src/
        some-other-file.ts
    docs/
```
used with this command
```
typedoc --out docs/ src/some-other-file.ts
```
will always generate documentation for both `some-other-file` AND `some-file`.