### PR TITLE
Use ts project option

### DIFF
--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -22,12 +22,12 @@ export class TSConfigReader extends OptionsComponent {
      * The name of the parameter that specifies the tsconfig file.
      */
     private static OPTIONS_KEY = 'tsconfig';
-    
+
     /**
      * The name of the parameter that specifies the TS project
      *
      * https://github.com/Microsoft/TypeScript/blob/master/src/compiler/commandLineParser.ts#L49
-     */ 
+     */
     private static PROJECT_KEY = 'project';
 
     initialize() {

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -22,6 +22,13 @@ export class TSConfigReader extends OptionsComponent {
      * The name of the parameter that specifies the tsconfig file.
      */
     private static OPTIONS_KEY = 'tsconfig';
+    
+    /**
+     * The name of the parameter that specifies the TS project
+     *
+     * https://github.com/Microsoft/TypeScript/blob/v2.1.4/src/compiler/commandLineParser.ts#L211
+     */ 
+    private static PROJECT_KEY = 'project';
 
     initialize() {
         this.listenTo(this.owner, DiscoverEvent.DISCOVER, this.onDiscover, -100);
@@ -30,6 +37,13 @@ export class TSConfigReader extends OptionsComponent {
     onDiscover(event: DiscoverEvent) {
         if (TSConfigReader.OPTIONS_KEY in event.data) {
             this.load(event, Path.resolve(event.data[TSConfigReader.OPTIONS_KEY]));
+        } else if (TSConfigReader.PROJECT_KEY in event.data) {
+            // The `project` option may be a directory or file, so use TS to find it
+            let file: string = ts.findConfigFile(event.data[TSConfigReader.PROJECT_KEY], ts.sys.fileExists);
+            // If file is undefined, we found no file to load.
+            if (file) {
+                this.load(event, file);
+            }
         } else if (this.application.isCLI) {
             let file: string = ts.findConfigFile('.', ts.sys.fileExists);
             // If file is undefined, we found no file to load.

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -26,7 +26,7 @@ export class TSConfigReader extends OptionsComponent {
     /**
      * The name of the parameter that specifies the TS project
      *
-     * https://github.com/Microsoft/TypeScript/blob/v2.1.4/src/compiler/commandLineParser.ts#L211
+     * https://github.com/Microsoft/TypeScript/blob/master/src/compiler/commandLineParser.ts#L49
      */ 
     private static PROJECT_KEY = 'project';
 


### PR DESCRIPTION
Addresses #539.

TypeScript [defines the `project` option](https://github.com/Microsoft/TypeScript/blob/master/src/compiler/commandLineParser.ts#L49). The `TSConfigReader` [completely ignores this](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/options/readers/tsconfig.ts#L30). In fact, it can erroneously pull a local `tsconfig` instead of the project file as it [searches `.` if `tsconfig` is not set](https://github.com/TypeStrong/typedoc/blob/master/src/lib/utils/options/readers/tsconfig.ts#L34).

I changed the priority to check first for a specified `tsconfig` option, then check for a TS `project` option, and finally, if nothing else was found, search for a local `tsconfig`.