### PR TITLE
fix wrong enum type conversion

### DIFF
--- a/src/lib/converter/types/enum.ts
+++ b/src/lib/converter/types/enum.ts
@@ -11,7 +11,7 @@ export class EnumConverter extends ConverterTypeComponent implements TypeTypeCon
      * Test whether this converter can handle the given TypeScript type.
      */
     supportsType(context: Context, type: ts.Type): boolean {
-        return !!(type.flags & ts.TypeFlags.Enum);
+        return !!(type.flags & ts.TypeFlags.EnumLike);
     }
 
     /**

--- a/src/lib/converter/types/union-or-intersection.ts
+++ b/src/lib/converter/types/union-or-intersection.ts
@@ -17,7 +17,7 @@ export class UnionOrIntersectionConverter extends ConverterTypeComponent impleme
      * Test whether this converter can handle the given TypeScript type.
      */
     supportsType(context: Context, type: ts.UnionOrIntersectionType): boolean {
-        return !!(type.flags & ts.TypeFlags.UnionOrIntersection);
+        return !!(type.flags & ts.TypeFlags.UnionOrIntersection) && !(type.flags & ts.TypeFlags.EnumLiteral);
     }
 
     /**


### PR DESCRIPTION
Running the [enumerations basic example](https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/enumerations.ts) the enums are evaluated as they should but member, variables, signatures and every other reflection that contains a type will resolve the wrong type.

If we look at the enumerations example, this is a short version of the code: 
```ts
export enum Size
{
    Small,

    Medium,

    Large
}

export module Size
{
    var defaultSize:Size = Size.Medium;
    
    function isSmall(value:Size):boolean {
        return value == Size.Small;
    }
}
``` 

Looking at the JSON output (slimmed down) for the `isSmell` member:
```json
{
  "id": 367,
  "name": "isSmall",
  "kind": 64,
  "kindString": "Function",
  "flags": {
    "isExported": true
  },
  "signatures": [
    {
      "id": 368,
      "name": "isSmall",
      "kind": 4096,
      "kindString": "Call signature",
      "parameters": [
        {
          "id": 369,
          "name": "value",
          "kind": 32768,
          "kindString": "Parameter",
          "type": {
            "type": "union",
            "types": [
              {
                "type": "unknown",
                "name": "Size.Small"
              },
              {
                "type": "unknown",
                "name": "Size.Medium"
              },
              {
                "type": "unknown",
                "name": "Size.Large"
              }
            ]
          }
        }
      ],
      "type": {
        "type": "intrinsic",
        "name": "boolean"
      }
    }
  ]
}
```

The type for the parameter is wrong, it treats it as union type instead of the right type which is reference type to the enum reflection.

Also see visually from a rendered page:
![image](https://user-images.githubusercontent.com/5377501/30254994-28c5caf6-96a8-11e7-8f5f-af65d3826152.png)

After applying the fix:

```json
{
  "id": 205,
  "name": "isSmall",
  "kind": 64,
  "kindString": "Function",
  "flags": {
    "isExported": true
  },
  "signatures": [
    {
      "id": 206,
      "name": "isSmall",
      "kind": 4096,
      "kindString": "Call signature",
      "parameters": [
        {
          "id": 207,
          "name": "value",
          "kind": 32768,
          "kindString": "Parameter",
          "type": {
            "type": "reference",
            "name": "Size",
            "id": 200
          }
        }
      ],
      "type": {
        "type": "intrinsic",
        "name": "boolean"
      }
    }
  ]
}
```
![image](https://user-images.githubusercontent.com/5377501/30255009-5666dd06-96a8-11e7-80b6-2f7089272c53.png)
