### PR TITLE
Allow multiple excludes

### DIFF
--- a/src/test/typedoc.ts
+++ b/src/test/typedoc.ts
@@ -46,5 +46,14 @@ describe('TypeDoc', function() {
             Assert.equal(expanded.indexOf(Path.join(inputFiles, 'access', 'access.ts')), -1);
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
+        it('supports array of excludes', function() {
+            const inputFiles = Path.join(__dirname, 'converter');
+            application.options.setValue('exclude', [ '**/class.ts', '**/access.ts' ]);
+            const expanded = application.expandInputFiles([inputFiles]);
+
+            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class', 'class.ts')), -1);
+            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'access', 'access.ts')), -1);
+            Assert.equal(expanded.indexOf(inputFiles), -1);
+        });
     });
 });


### PR DESCRIPTION
Allow the exclude parameter to be an Array as well as a
minimatch string. This allows for greater flexibility when excluding
files as minimatch regexs with 'or' patterns quickly become unreadable /
unmaintainable.