### PR TITLE
ContextAwareRendererComponent, MarkedLinksPlugin and DefaultTheme  to respect absolute urls

### DIFF
--- a/examples/basic/run
+++ b/examples/basic/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd ${0%/*}
-node ../../bin/typedoc --module commonjs --includes inc/ --media media/ --target ES5 --out doc/ src/
+node ../../bin/typedoc --module commonjs --includes inc/ --media media/ --target ES5 --json json.json --out doc/ src/

--- a/src/lib/output/components.ts
+++ b/src/lib/output/components.ts
@@ -29,6 +29,11 @@ export abstract class ContextAwareRendererComponent extends RendererComponent {
     private location: string;
 
     /**
+     * Regular expression to test if a string looks like an external url.
+     */
+    protected urlPrefix: RegExp = /^(http|ftp)s?:\/\//;
+
+    /**
      * Create a new ContextAwareRendererPlugin instance.
      *
      * @param renderer  The renderer this plugin should be attached to.
@@ -47,8 +52,12 @@ export abstract class ContextAwareRendererComponent extends RendererComponent {
      * @returns A path relative to the document currently processed.
      */
     public getRelativeUrl(absolute: string): string {
-        const relative = Path.relative(Path.dirname(this.location), Path.dirname(absolute));
-        return Path.join(relative, Path.basename(absolute)).replace(/\\/g, '/');
+        if (this.urlPrefix.test(absolute)) {
+            return absolute;
+        } else {
+            const relative = Path.relative(Path.dirname(this.location), Path.dirname(absolute));
+            return Path.join(relative, Path.basename(absolute)).replace(/\\/g, '/');
+        }
     }
 
     /**

--- a/src/lib/output/plugins/MarkedLinksPlugin.ts
+++ b/src/lib/output/plugins/MarkedLinksPlugin.ts
@@ -21,11 +21,6 @@ export class MarkedLinksPlugin extends ContextAwareRendererComponent {
      */
     private inlineTag: RegExp = /(?:\[(.+?)\])?\{@(link|linkcode|linkplain)\s+((?:.|\n)+?)\}/gi;
 
-    /**
-     * Regular expression to test if a string looks like an external url.
-     */
-    private urlPrefix: RegExp = /^(http|ftp)s?:\/\//;
-
     @Option({
         name: 'listInvalidSymbolLinks',
         help: 'Emits a list of broken symbol [[navigation]] links after documentation generation',
@@ -110,7 +105,12 @@ export class MarkedLinksPlugin extends ContextAwareRendererComponent {
             }
 
             if (reflection && reflection.url) {
-                target = this.getRelativeUrl(reflection.url);
+                if (this.urlPrefix.test(reflection.url)) {
+                    target = reflection.url;
+                    attributes = ' class="external"';
+                } else {
+                    target = this.getRelativeUrl(reflection.url);
+                }
             } else {
                 reflection = this.reflection || this.project;
                 this.warnings.push(`In ${reflection.getFullName()}: ${original}`);

--- a/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
+++ b/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
@@ -74,7 +74,7 @@
 					<div class="lead">
 						<p>This class is exported via es6 export syntax.</p>
 					</div>
-					<pre><code><span class="hljs-builtin-name">export</span><span class="hljs-built_in"> default </span>class DefaultExportedClass
+					<pre><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">default</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">DefaultExportedClass</span></span>
 </code></pre>
 				</div>
 			</section>


### PR DESCRIPTION
A plugin might set the `url` property on a reflection before the rendering phase.

The rendering plugins (and the theme) does not care, they will overwrite it.

This PR adds a check before overwrite, if the URL is absolute (http, https, ftp) the URL generation will stop since its an external link.

