### PR TITLE
support ES6/ES2015-style import syntax for plugins

### DIFF
--- a/src/lib/utils/plugins.ts
+++ b/src/lib/utils/plugins.ts
@@ -42,8 +42,8 @@ export class PluginHost extends AbstractComponent<Application> {
             const plugin = plugins[i];
             try {
                 const instance = require(plugin);
-                const initFunction = typeof instance.initPlugin === 'function'
-                  ? instance.initPlugin
+                const initFunction = typeof instance.load === 'function'
+                  ? instance.load
                   : instance                // support legacy plugins
                 ;
                 if (typeof initFunction === 'function') {

--- a/src/lib/utils/plugins.ts
+++ b/src/lib/utils/plugins.ts
@@ -42,11 +42,15 @@ export class PluginHost extends AbstractComponent<Application> {
             const plugin = plugins[i];
             try {
                 const instance = require(plugin);
-                if (typeof instance === 'function') {
+                const initFunction = typeof instance.initPlugin === 'function'
+                  ? instance.initPlugin
+                  : instance                // support legacy plugins
+                ;
+                if (typeof initFunction === 'function') {
                     instance(this);
                     logger.write('Loaded plugin %s', plugin);
                 } else {
-                    logger.error('The plugin %s did not return a function.', plugin);
+                    logger.error('Invalid structure in plugin %s, no function found.', plugin);
                 }
             } catch (error) {
                 logger.error('The plugin %s could not be loaded.', plugin);


### PR DESCRIPTION
Currently, plugins must come in the form of a CommonJS module that exports a function.

In TypeScript this might become an issue, especially if a plugin wants to export some symbols, types etc...

```ts
exports = function myPlugin() {};
```

The example above is fine but it will not allow exporting type information.
You can, of course, export other runtime member by setting properties on the function itself but no types.

> Adding runtime members on the function within TS will require declaration merging... a complexity we can avoid...

There are hacky workarounds, using namespaces and/or modules with declaration merging but this is tricky, not trivial and at times create other issues.

This PR add support for plugins that want to implement the ES6/ES2015-style import syntax:
```ts
exports function initPlugin() {
};

export class MyPlugin() { ... }
```

It allows declaring the plugin initialising function under the member `initPlugin` within the module.

If a function is not found it will fallback to the old method for initialising plugins.


For reference see @RyanCavanaugh [post](https://stackoverflow.com/questions/39415661/what-does-resolves-to-a-non-module-entity-and-cannot-be-imported-using-this) on the subject.

Since this is a pure typescript project it does seem right... Some plugins might form an eco-system which requires sharing symbols.