### PR TITLE
fix: whitespaces in multiline comments

### DIFF
--- a/src/lib/converter/factories/comment.ts
+++ b/src/lib/converter/factories/comment.ts
@@ -119,9 +119,9 @@ export function parseComment(text: string, comment: Comment = new Comment()): Co
         return line.trim();
     }
 
-    function readBareLine(line: string) {
+    function readBareLine(line: string, rawLine: string) {
         if (currentTag) {
-            currentTag.text += '\n' + line;
+            currentTag.text += '\n' + rawLine;
         } else if (line === '' && shortText === 0) {
             // Ignore
         } else if (line === '' && shortText === 1) {
@@ -161,6 +161,7 @@ export function parseComment(text: string, comment: Comment = new Comment()): Co
     }
 
     function readLine(line: string) {
+        const rawLine = line;
         line = line.replace(/^\s*\*? ?/, '');
         line = line.replace(/\s*$/, '');
 
@@ -168,7 +169,7 @@ export function parseComment(text: string, comment: Comment = new Comment()): Co
         if (tag) {
             readTagLine(line, tag);
         } else {
-            readBareLine(line);
+            readBareLine(line, rawLine);
         }
     }
 


### PR DESCRIPTION
There was a problem when you have multiple lines in a comment which breaks the intendation of highlighted example code.

Code:
`````javascript
/**
  * testing intendation
  * @example

```javascript

// testing intendation
var test = new Test();

// bla bla bla
var settings = {
  test: 'test'
};

// foo bar
test.test().done(function () {
  // 42
  test.load({
    test: 'test'
  });
}

```
*/
`````

Output:
- Current behavior:
![current](https://user-images.githubusercontent.com/1519341/31077929-a2545b88-a780-11e7-8ecf-175245064d8e.png)

- After fix:
![expected](https://user-images.githubusercontent.com/1519341/31077933-a8186a82-a780-11e7-8891-f7b739b6496f.png)
