### PR TITLE
Implement Abstract, Const and Let flags

### DIFF
--- a/examples/basic/src/classes.ts
+++ b/examples/basic/src/classes.ts
@@ -50,12 +50,12 @@ export interface IPrintNameInterface extends INameInterface, IPrintInterface
  *
  * [[include:class-example.md]]
  */
-export class BaseClass implements INameInterface
+export abstract class BaseClass implements INameInterface
 {
     /**
      * This is a simple public member.
      */
-    public name:string;
+    public abstract name:string;
 
     /**
      * This is a simple protected member.
@@ -90,6 +90,7 @@ export class BaseClass implements INameInterface
         this.checkName();
     }
 
+    public abstract abstractMethod(): void;
 
     /**
      * This is a simple member function.
@@ -197,6 +198,8 @@ class InternalClass
  */
 export class SubClassA extends BaseClass implements IPrintNameInterface
 {
+    public name:string;
+
     /**
      * This is a simple interface function.
      */
@@ -250,6 +253,10 @@ export class SubClassA extends BaseClass implements IPrintNameInterface
     public set writeOnlyNameProperty(value:string) {
         this.name = value;
     }
+
+    public abstractMethod(): void {
+
+    }
 }
 
 
@@ -260,8 +267,14 @@ export class SubClassA extends BaseClass implements IPrintNameInterface
  */
 export class SubClassB extends BaseClass
 {
+    public name: string;
+
     constructor(name:string) {
         super(name);
+    }
+
+    abstractMethod(): void {
+
     }
 
     doSomething(value:[string, SubClassA, SubClassB]) {

--- a/examples/basic/src/variables.ts
+++ b/examples/basic/src/variables.ts
@@ -1,0 +1,14 @@
+/**
+ * A const variable
+ */
+export const constVariable = 'const';
+
+/**
+ * A let variable
+ */
+export let letVariable = 'let';
+
+/**
+ * A var variable
+ */
+export var varVariable= 'var';

--- a/src/lib/converter/nodes/class.ts
+++ b/src/lib/converter/nodes/class.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import * as _ts from '../../ts-internal';
 
-import { Reflection, ReflectionKind, DeclarationReflection } from '../../models/index';
+import { Reflection, ReflectionFlag, ReflectionKind, DeclarationReflection } from '../../models/index';
 import { createDeclaration } from '../factories/index';
 import { Context } from '../context';
 import { Component, ConverterNodeComponent } from '../components';
@@ -29,6 +29,10 @@ export class ClassConverter extends ConverterNodeComponent<ts.ClassDeclaration> 
             reflection = <DeclarationReflection> context.scope;
         } else {
             reflection = createDeclaration(context, node, ReflectionKind.Class);
+            // set possible abstract flag here, where node is not the inherited parent
+            if (node.modifiers && node.modifiers.some( m => m.kind === ts.SyntaxKind.AbstractKeyword )) {
+                reflection.setFlag(ReflectionFlag.Abstract, true);
+            }
         }
 
         context.withScope(reflection, node.typeParameters, () => {

--- a/src/lib/converter/nodes/function.ts
+++ b/src/lib/converter/nodes/function.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 
-import { Reflection, ReflectionKind } from '../../models/index';
+import { Reflection, ReflectionFlag, ReflectionKind } from '../../models/index';
 import { createDeclaration, createSignature } from '../factories/index';
 import { Context } from '../context';
 import { Converter } from '../converter';
@@ -29,6 +29,13 @@ export class FunctionConverter extends ConverterNodeComponent<ts.FunctionDeclara
         const kind    = scope.kind & ReflectionKind.ClassOrInterface ? ReflectionKind.Method : ReflectionKind.Function;
         const hasBody = !!node.body;
         const method  = createDeclaration(context, <ts.Node> node, kind);
+
+        if (method  // child inheriting will return null on createDeclaration
+            && kind & ReflectionKind.Method
+            && node.modifiers
+            && node.modifiers.some( m => m.kind === ts.SyntaxKind.AbstractKeyword )) {
+          method.setFlag(ReflectionFlag.Abstract, true);
+        }
 
         context.withScope(method, () => {
             if (!hasBody || !method.signatures) {

--- a/src/lib/models/reflections/abstract.ts
+++ b/src/lib/models/reflections/abstract.ts
@@ -76,7 +76,10 @@ export enum ReflectionFlag {
     Optional = 128,
     DefaultValue = 256,
     Rest = 512,
-    ConstructorProperty = 1024
+    ConstructorProperty = 1024,
+    Abstract = 2048,
+    Const = 4096,
+    Let = 8192
 }
 
 const relevantFlags: ReflectionFlag[] = [
@@ -86,7 +89,10 @@ const relevantFlags: ReflectionFlag[] = [
     ReflectionFlag.ExportAssignment,
     ReflectionFlag.Optional,
     ReflectionFlag.DefaultValue,
-    ReflectionFlag.Rest
+    ReflectionFlag.Rest,
+    ReflectionFlag.Abstract,
+    ReflectionFlag.Let,
+    ReflectionFlag.Const
 ];
 
 export interface ReflectionFlags extends Array<string> {
@@ -140,6 +146,12 @@ export interface ReflectionFlags extends Array<string> {
     hasExportAssignment?: boolean;
 
     isConstructorProperty?: boolean;
+
+    isAbstract?: boolean;
+
+    isConst?: boolean;
+
+    isLet?: boolean;
 }
 
 export interface DefaultValueContainer extends Reflection {
@@ -404,6 +416,15 @@ export abstract class Reflection {
                 break;
             case ReflectionFlag.ConstructorProperty:
                 this.flags.isConstructorProperty = value;
+                break;
+            case ReflectionFlag.Abstract:
+                this.flags.isAbstract = value;
+                break;
+            case ReflectionFlag.Let:
+                this.flags.isLet = value;
+                break;
+            case ReflectionFlag.Const:
+                this.flags.isConst = value;
                 break;
         }
     }

--- a/src/test/converter/access/specs.json
+++ b/src/test/converter/access/specs.json
@@ -179,7 +179,8 @@
           "kindString": "Variable",
           "flags": {
             "isPrivate": true,
-            "isExported": true
+            "isExported": true,
+            "isConst": true
           },
           "comment": {
             "shortText": "A variable that is made private via comment."
@@ -204,7 +205,8 @@
           "kindString": "Variable",
           "flags": {
             "isExported": true,
-            "isProtected": true
+            "isProtected": true,
+            "isConst": true
           },
           "comment": {
             "shortText": "A variable that is made protected via comment."

--- a/src/test/converter/array/specs.json
+++ b/src/test/converter/array/specs.json
@@ -48,7 +48,8 @@
           "kind": 32,
           "kindString": "Variable",
           "flags": {
-            "isExported": true
+            "isExported": true,
+            "isConst": true
           },
           "comment": {
             "shortText": "A const of a complex type."
@@ -112,7 +113,8 @@
           "kind": 32,
           "kindString": "Variable",
           "flags": {
-            "isExported": true
+            "isExported": true,
+            "isConst": true
           },
           "comment": {
             "shortText": "An exported const of the custom array type."

--- a/src/test/converter/class/class.ts
+++ b/src/test/converter/class/class.ts
@@ -74,3 +74,16 @@ export class TestSubClass extends TestClass
         super();
     }
 }
+
+
+export abstract class TestAbstractClass {
+    abstract myAbstractProperty: string;
+
+    protected abstract myAbstractMethod(): void;
+}
+
+export class TestAbstractClassImplementation extends TestAbstractClass {
+    myAbstractProperty: string;
+
+    protected myAbstractMethod(): void { }
+}

--- a/src/test/converter/class/specs.json
+++ b/src/test/converter/class/specs.json
@@ -15,6 +15,206 @@
       "originalName": "%BASE%/class/class.ts",
       "children": [
         {
+          "id": 34,
+          "name": "TestAbstractClass",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true,
+            "isAbstract": true
+          },
+          "children": [
+            {
+              "id": 35,
+              "name": "myAbstractProperty",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true,
+                "isAbstract": true
+              },
+              "sources": [
+                {
+                  "fileName": "class.ts",
+                  "line": 80,
+                  "character": 31
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              }
+            },
+            {
+              "id": 36,
+              "name": "myAbstractMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true,
+                "isProtected": true,
+                "isAbstract": true
+              },
+              "signatures": [
+                {
+                  "id": 37,
+                  "name": "myAbstractMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "class.ts",
+                  "line": 82,
+                  "character": 39
+                }
+              ]
+            }
+          ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                35
+              ]
+            },
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                36
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "class.ts",
+              "line": 79,
+              "character": 39
+            }
+          ],
+          "extendedBy": [
+            {
+              "type": "reference",
+              "name": "TestAbstractClassImplementation",
+              "id": 38
+            }
+          ]
+        },
+        {
+          "id": 38,
+          "name": "TestAbstractClassImplementation",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "children": [
+            {
+              "id": 39,
+              "name": "myAbstractProperty",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true
+              },
+              "sources": [
+                {
+                  "fileName": "class.ts",
+                  "line": 86,
+                  "character": 22
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              },
+              "overwrites": {
+                "type": "reference",
+                "name": "TestAbstractClass.myAbstractProperty",
+                "id": 35
+              }
+            },
+            {
+              "id": 40,
+              "name": "myAbstractMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true,
+                "isProtected": true
+              },
+              "signatures": [
+                {
+                  "id": 41,
+                  "name": "myAbstractMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "overwrites": {
+                    "type": "reference",
+                    "name": "TestAbstractClass.myAbstractMethod",
+                    "id": 36
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "class.ts",
+                  "line": 88,
+                  "character": 30
+                }
+              ],
+              "overwrites": {
+                "type": "reference",
+                "name": "TestAbstractClass.myAbstractMethod",
+                "id": 36
+              }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                39
+              ]
+            },
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                40
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "class.ts",
+              "line": 85,
+              "character": 44
+            }
+          ],
+          "extendedTypes": [
+            {
+              "type": "reference",
+              "name": "TestAbstractClass",
+              "id": 34
+            }
+          ]
+        },
+        {
           "id": 2,
           "name": "TestClass",
           "kind": 128,
@@ -748,6 +948,8 @@
           "title": "Classes",
           "kind": 128,
           "children": [
+            34,
+            38,
             2,
             16
           ]

--- a/src/test/converter/enum/specs.json
+++ b/src/test/converter/enum/specs.json
@@ -92,7 +92,8 @@
               "kind": 32,
               "kindString": "Variable",
               "flags": {
-                "isExported": true
+                "isExported": true,
+                "isLet": true
               },
               "comment": {
                 "shortText": "This is a variable appended to an enumeration."

--- a/src/test/converter/export-default/specs.json
+++ b/src/test/converter/export-default/specs.json
@@ -20,7 +20,8 @@
           "kind": 32,
           "kindString": "Variable",
           "flags": {
-            "isExported": true
+            "isExported": true,
+            "isConst": true
           },
           "sources": [
             {

--- a/src/test/converter/export/specs.json
+++ b/src/test/converter/export/specs.json
@@ -20,7 +20,8 @@
           "kind": 32,
           "kindString": "Variable",
           "flags": {
-            "isExported": true
+            "isExported": true,
+            "isConst": true
           },
           "sources": [
             {

--- a/src/test/converter/function/specs.json
+++ b/src/test/converter/function/specs.json
@@ -63,7 +63,9 @@
               "name": "functionVariable",
               "kind": 32,
               "kindString": "Variable",
-              "flags": {},
+              "flags": {
+                "isLet": true
+              },
               "comment": {
                 "shortText": "This variable is appended to a function."
               },
@@ -680,7 +682,8 @@
           "kind": 64,
           "kindString": "Function",
           "flags": {
-            "isExported": true
+            "isExported": true,
+            "isConst": true
           },
           "comment": {
             "shortText": "This is a function that is assigned to a variable.",

--- a/src/test/converter/implicit-types/specs.json
+++ b/src/test/converter/implicit-types/specs.json
@@ -87,7 +87,9 @@
           "name": "_breakpoints",
           "kind": 32,
           "kindString": "Variable",
-          "flags": {},
+          "flags": {
+            "isLet": true
+          },
           "sources": [
             {
               "fileName": "implicit-types.ts",

--- a/src/test/converter/literal-object-callbacks/specs.json
+++ b/src/test/converter/literal-object-callbacks/specs.json
@@ -19,7 +19,9 @@
           "name": "onError",
           "kind": 64,
           "kindString": "Function",
-          "flags": {},
+          "flags": {
+            "isLet": true
+          },
           "signatures": [
             {
               "id": 5,
@@ -46,7 +48,9 @@
           "name": "onFinally",
           "kind": 64,
           "kindString": "Function",
-          "flags": {},
+          "flags": {
+            "isLet": true
+          },
           "signatures": [
             {
               "id": 7,
@@ -73,7 +77,9 @@
           "name": "onSuccess",
           "kind": 64,
           "kindString": "Function",
-          "flags": {},
+          "flags": {
+            "isLet": true
+          },
           "signatures": [
             {
               "id": 3,
@@ -100,7 +106,9 @@
           "name": "callbackReturn",
           "kind": 2097152,
           "kindString": "Object literal",
-          "flags": {},
+          "flags": {
+            "isConst": true
+          },
           "children": [
             {
               "id": 14,

--- a/src/test/converter/literal-object/specs.json
+++ b/src/test/converter/literal-object/specs.json
@@ -19,7 +19,9 @@
           "name": "objectLiteral",
           "kind": 2097152,
           "kindString": "Object literal",
-          "flags": {},
+          "flags": {
+            "isConst": true
+          },
           "comment": {
             "shortText": "An object literal."
           },

--- a/src/test/converter/literal-type/specs.json
+++ b/src/test/converter/literal-type/specs.json
@@ -19,7 +19,9 @@
           "name": "typeLiteral",
           "kind": 32,
           "kindString": "Variable",
-          "flags": {},
+          "flags": {
+            "isLet": true
+          },
           "sources": [
             {
               "fileName": "literal-type.ts",

--- a/src/test/converter/variable/specs.json
+++ b/src/test/converter/variable/specs.json
@@ -1,0 +1,112 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "flags": {},
+  "children": [
+    {
+      "id": 1,
+      "name": "\"variable\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/variable/variable.ts",
+      "children": [
+        {
+          "id": 2,
+          "name": "myConst",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isExported": true,
+            "isConst": true
+          },
+          "sources": [
+            {
+              "fileName": "variable.ts",
+              "line": 1,
+              "character": 20
+            }
+          ],
+          "type": {
+            "type": "unknown",
+            "name": "15"
+          },
+          "defaultValue": "15"
+        },
+        {
+          "id": 3,
+          "name": "myLet",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isExported": true,
+            "isLet": true
+          },
+          "sources": [
+            {
+              "fileName": "variable.ts",
+              "line": 2,
+              "character": 16
+            }
+          ],
+          "type": {
+            "type": "intrinsic",
+            "name": "number"
+          },
+          "defaultValue": "15"
+        },
+        {
+          "id": 4,
+          "name": "myVar",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isExported": true
+          },
+          "sources": [
+            {
+              "fileName": "variable.ts",
+              "line": 3,
+              "character": 16
+            }
+          ],
+          "type": {
+            "type": "intrinsic",
+            "name": "number"
+          },
+          "defaultValue": "15"
+        }
+      ],
+      "groups": [
+        {
+          "title": "Variables",
+          "kind": 32,
+          "children": [
+            2,
+            3,
+            4
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "variable.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "External modules",
+      "kind": 1,
+      "children": [
+        1
+      ]
+    }
+  ]
+}

--- a/src/test/converter/variable/variable.ts
+++ b/src/test/converter/variable/variable.ts
@@ -1,0 +1,3 @@
+export const myConst = 15;
+export let myLet = 15;
+export var myVar = 15;

--- a/src/test/renderer/specs/classes/_access_.privateclass.html
+++ b/src/test/renderer/specs/classes/_access_.privateclass.html
@@ -233,6 +233,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/classes/_classes_.baseclass.html
+++ b/src/test/renderer/specs/classes/_classes_.baseclass.html
@@ -122,6 +122,7 @@
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.baseclass.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.baseclass.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_classes_.baseclass.html#checkname" class="tsd-kind-icon">check<wbr>Name</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.baseclass.html#getname" class="tsd-kind-icon">get<wbr>Name</a></li>
@@ -209,7 +210,7 @@
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="name" class="tsd-anchor"></a>
-					<h3>name</h3>
+					<h3><span class="tsd-flag ts-flagAbstract">Abstract</span> name</h3>
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_classes_.inameinterface.html">INameInterface</a>.<a href="../interfaces/_classes_.inameinterface.html#name">name</a></p>
@@ -253,6 +254,23 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
+					<a name="abstractmethod" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagAbstract">Abstract</span> abstract<wbr>Method</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
+						<li class="tsd-signature tsd-kind-icon">abstract<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L93">classes.ts:93</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
 					<a name="arrowfunction" class="tsd-anchor"></a>
 					<h3>arrow<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -262,7 +280,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L140">classes.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L141">classes.ts:141</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -303,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L147">classes.ts:147</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L148">classes.ts:148</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_classes_.inameinterface.html">INameInterface</a>.<a href="../interfaces/_classes_.inameinterface.html#getname">getName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L102">classes.ts:102</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L103">classes.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -351,7 +369,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L127">classes.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L128">classes.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -383,7 +401,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L167">classes.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L168">classes.ts:168</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -422,7 +440,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L159">classes.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L160">classes.ts:160</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -446,7 +464,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L115">classes.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L116">classes.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -505,6 +523,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
@@ -531,6 +552,9 @@
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-static">
 								<a href="_classes_.baseclass.html#instances" class="tsd-kind-icon">instances</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class">
+								<a href="_classes_.baseclass.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
 								<a href="_classes_.baseclass.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a>

--- a/src/test/renderer/specs/classes/_classes_.genericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.genericclass.html
@@ -144,7 +144,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L279">classes.ts:279</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L292">classes.ts:292</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">p2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L304">classes.ts:304</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 					<div class="tsd-signature tsd-kind-icon">p3<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L304">classes.ts:304</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">p4<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L304">classes.ts:304</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">p5<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L304">classes.ts:304</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L279">classes.ts:279</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L292">classes.ts:292</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -285,7 +285,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L303">classes.ts:303</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L316">classes.ts:316</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">T</span></h4>
@@ -302,7 +302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L298">classes.ts:298</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L311">classes.ts:311</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -363,6 +363,9 @@
 					</li>
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_classes_.internalclass.html
+++ b/src/test/renderer/specs/classes/_classes_.internalclass.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L185">classes.ts:185</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L186">classes.ts:186</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -170,6 +170,9 @@
 					</li>
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_classes_.nongenericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.nongenericclass.html
@@ -131,7 +131,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L279">classes.ts:279</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L292">classes.ts:292</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#p2">p2</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L304">classes.ts:304</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#p3">p3</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L304">classes.ts:304</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -228,7 +228,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#p5">p5</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L291">classes.ts:291</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L304">classes.ts:304</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#value">value</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L279">classes.ts:279</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L292">classes.ts:292</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#getvalue">getValue</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L303">classes.ts:303</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L316">classes.ts:316</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></h4>
@@ -280,7 +280,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#setvalue">setValue</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L298">classes.ts:298</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L311">classes.ts:311</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -341,6 +341,9 @@
 					</li>
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_classes_.subclassa.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassa.html
@@ -108,11 +108,11 @@
 								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassa.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-inherited">
+						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_classes_.subclassa.html#kind" class="tsd-kind-icon">kind</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassa.html#name" class="tsd-kind-icon">name</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassa.html#name" class="tsd-kind-icon">name</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassa.html#instance" class="tsd-kind-icon">instance</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassa.html#instances" class="tsd-kind-icon">instances</a></li>
 							</ul>
@@ -128,6 +128,7 @@
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassa.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassa.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassa.html#getname" class="tsd-kind-icon">get<wbr>Name</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.subclassa.html#print" class="tsd-kind-icon">print</a></li>
@@ -184,7 +185,7 @@
 					</ul>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-inherited">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 					<a name="kind" class="tsd-anchor"></a>
@@ -202,22 +203,17 @@
 						</div>
 					</div>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-overwrite">
 					<a name="name" class="tsd-anchor"></a>
 					<h3>name</h3>
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_classes_.iprintnameinterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.iprintnameinterface.html#name">name</a></p>
-						<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#name">name</a></p>
+						<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L58">classes.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L201">classes.ts:201</a></li>
 						</ul>
 					</aside>
-					<div class="tsd-comment tsd-typography">
-						<div class="lead">
-							<p>This is a simple public member.</p>
-						</div>
-					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 					<a name="instance" class="tsd-anchor"></a>
@@ -261,7 +257,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L219">classes.ts:219</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L222">classes.ts:222</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +271,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L229">classes.ts:229</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L232">classes.ts:232</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -309,7 +305,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L239">classes.ts:239</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L242">classes.ts:242</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -332,7 +328,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L250">classes.ts:250</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L253">classes.ts:253</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,6 +355,24 @@
 			</section>
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+					<a name="abstractmethod" class="tsd-anchor"></a>
+					<h3>abstract<wbr>Method</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+						<li class="tsd-signature tsd-kind-icon">abstract<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#abstractmethod">abstractMethod</a></p>
+								<ul>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L257">classes.ts:257</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 					<a name="arrowfunction" class="tsd-anchor"></a>
 					<h3>arrow<wbr>Function</h3>
@@ -370,7 +384,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#arrowfunction">arrowFunction</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L140">classes.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L141">classes.ts:141</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -413,7 +427,7 @@
 								<p>Implementation of <a href="../interfaces/_classes_.iprintnameinterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.iprintnameinterface.html#getname">getName</a></p>
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getname">getName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L102">classes.ts:102</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L103">classes.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -439,7 +453,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_classes_.iprintnameinterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.iprintnameinterface.html#print">print</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L203">classes.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L206">classes.ts:206</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -468,7 +482,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_classes_.iprintnameinterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.iprintnameinterface.html#printname">printName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L209">classes.ts:209</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L212">classes.ts:212</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -491,7 +505,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#setname">setName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L127">classes.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L128">classes.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -524,7 +538,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#catest">caTest</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L167">classes.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L168">classes.ts:168</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -564,7 +578,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getinstance">getInstance</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L159">classes.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L160">classes.ts:160</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -589,7 +603,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getname-1">getName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L115">classes.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L116">classes.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -648,6 +662,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
@@ -675,7 +692,7 @@
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 								<a href="_classes_.subclassa.html#kind" class="tsd-kind-icon">kind</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-overwrite">
 								<a href="_classes_.subclassa.html#name" class="tsd-kind-icon">name</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
@@ -692,6 +709,9 @@
 							</li>
 							<li class=" tsd-kind-set-signature tsd-parent-kind-class">
 								<a href="_classes_.subclassa.html#writeonlynameproperty" class="tsd-kind-icon">write<wbr>Only<wbr>Name<wbr>Property</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+								<a href="_classes_.subclassa.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 								<a href="_classes_.subclassa.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a>

--- a/src/test/renderer/specs/classes/_classes_.subclassb.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassb.html
@@ -106,11 +106,11 @@
 								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassb.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-inherited">
+						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_classes_.subclassb.html#kind" class="tsd-kind-icon">kind</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassb.html#name" class="tsd-kind-icon">name</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassb.html#name" class="tsd-kind-icon">name</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassb.html#instance" class="tsd-kind-icon">instance</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassb.html#instances" class="tsd-kind-icon">instances</a></li>
 							</ul>
@@ -118,6 +118,7 @@
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassb.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassb.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.subclassb.html#dosomething" class="tsd-kind-icon">do<wbr>Something</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassb.html#getname" class="tsd-kind-icon">get<wbr>Name</a></li>
@@ -143,7 +144,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L262">classes.ts:262</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L270">classes.ts:270</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -157,7 +158,7 @@
 					</ul>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-inherited">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 					<a name="kind" class="tsd-anchor"></a>
@@ -175,22 +176,17 @@
 						</div>
 					</div>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-overwrite">
 					<a name="name" class="tsd-anchor"></a>
 					<h3>name</h3>
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_classes_.inameinterface.html">INameInterface</a>.<a href="../interfaces/_classes_.inameinterface.html#name">name</a></p>
-						<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#name">name</a></p>
+						<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L58">classes.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L270">classes.ts:270</a></li>
 						</ul>
 					</aside>
-					<div class="tsd-comment tsd-typography">
-						<div class="lead">
-							<p>This is a simple public member.</p>
-						</div>
-					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 					<a name="instance" class="tsd-anchor"></a>
@@ -223,6 +219,24 @@
 			</section>
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+					<a name="abstractmethod" class="tsd-anchor"></a>
+					<h3>abstract<wbr>Method</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+						<li class="tsd-signature tsd-kind-icon">abstract<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#abstractmethod">abstractMethod</a></p>
+								<ul>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L276">classes.ts:276</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 					<a name="arrowfunction" class="tsd-anchor"></a>
 					<h3>arrow<wbr>Function</h3>
@@ -234,7 +248,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#arrowfunction">arrowFunction</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L140">classes.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L141">classes.ts:141</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +289,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L267">classes.ts:267</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L280">classes.ts:280</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +314,7 @@
 								<p>Implementation of <a href="../interfaces/_classes_.inameinterface.html">INameInterface</a>.<a href="../interfaces/_classes_.inameinterface.html#getname">getName</a></p>
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getname">getName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L102">classes.ts:102</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L103">classes.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +340,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#setname">setName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L127">classes.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L128">classes.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +373,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#catest">caTest</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L167">classes.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L168">classes.ts:168</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -399,7 +413,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getinstance">getInstance</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L159">classes.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L160">classes.ts:160</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -424,7 +438,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getname-1">getName</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L115">classes.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L116">classes.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -483,6 +497,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
@@ -513,7 +530,7 @@
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 								<a href="_classes_.subclassb.html#kind" class="tsd-kind-icon">kind</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-overwrite">
 								<a href="_classes_.subclassb.html#name" class="tsd-kind-icon">name</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
@@ -521,6 +538,9 @@
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 								<a href="_classes_.subclassb.html#instances" class="tsd-kind-icon">instances</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+								<a href="_classes_.subclassb.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 								<a href="_classes_.subclassb.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a>

--- a/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
+++ b/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
@@ -74,7 +74,7 @@
 					<div class="lead">
 						<p>This class is exported via es6 export syntax.</p>
 					</div>
-					<pre><code><span class="hljs-builtin-name">export</span><span class="hljs-built_in"> default </span>class DefaultExportedClass
+					<pre><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">default</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">DefaultExportedClass</span></span>
 </code></pre>
 				</div>
 			</section>
@@ -221,6 +221,9 @@
 					</li>
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_default_export_.notexportedclassname.html
+++ b/src/test/renderer/specs/classes/_default_export_.notexportedclassname.html
@@ -223,6 +223,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
+++ b/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
@@ -404,6 +404,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/classes/_single_export_.notexportedclass.html
+++ b/src/test/renderer/specs/classes/_single_export_.notexportedclass.html
@@ -220,6 +220,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/classes/_single_export_.singleexportedclass.html
+++ b/src/test/renderer/specs/classes/_single_export_.singleexportedclass.html
@@ -222,6 +222,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
@@ -272,6 +272,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
@@ -237,6 +237,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/classes/_typescript_1_4_.simpleclass.html
+++ b/src/test/renderer/specs/classes/_typescript_1_4_.simpleclass.html
@@ -191,6 +191,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/enums/_enumerations_.directions.html
+++ b/src/test/renderer/specs/enums/_enumerations_.directions.html
@@ -230,6 +230,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/enums/_enumerations_.size.html
+++ b/src/test/renderer/specs/enums/_enumerations_.size.html
@@ -249,6 +249,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/globals.html
+++ b/src/test/renderer/specs/globals.html
@@ -82,6 +82,7 @@
 								<li class="tsd-kind-external-module"><a href="modules/_typescript_1_3_.html" class="tsd-kind-icon">"typescript-<wbr>1.3"</a></li>
 								<li class="tsd-kind-external-module"><a href="modules/_typescript_1_4_.html" class="tsd-kind-icon">"typescript-<wbr>1.4"</a></li>
 								<li class="tsd-kind-external-module"><a href="modules/_typescript_1_5_.html" class="tsd-kind-icon">"typescript-<wbr>1.5"</a></li>
+								<li class="tsd-kind-external-module"><a href="modules/_variables_.html" class="tsd-kind-icon">"variables"</a></li>
 							</ul>
 						</section>
 					</div>
@@ -129,6 +130,9 @@
 					</li>
 					<li class=" tsd-kind-external-module">
 						<a href="modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="modules/_variables_.html">"variables"</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -235,6 +235,9 @@ $ typedoc
 					<li class=" tsd-kind-external-module">
 						<a href="modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
@@ -204,6 +204,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
@@ -177,6 +177,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
@@ -261,6 +261,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/interfaces/_generics_.a.html
+++ b/src/test/renderer/specs/interfaces/_generics_.a.html
@@ -184,6 +184,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/interfaces/_generics_.ab.html
+++ b/src/test/renderer/specs/interfaces/_generics_.ab.html
@@ -255,6 +255,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/interfaces/_generics_.abnumber.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abnumber.html
@@ -230,6 +230,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/interfaces/_generics_.abstring.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abstring.html
@@ -230,6 +230,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/interfaces/_generics_.b.html
+++ b/src/test/renderer/specs/interfaces/_generics_.b.html
@@ -224,6 +224,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/interfaces/_typescript_1_4_.runoptions.html
+++ b/src/test/renderer/specs/interfaces/_typescript_1_4_.runoptions.html
@@ -164,6 +164,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_access_.html
+++ b/src/test/renderer/specs/modules/_access_.html
@@ -227,6 +227,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_access_.privatemodule.html
+++ b/src/test/renderer/specs/modules/_access_.privatemodule.html
@@ -157,6 +157,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_classes_.html
+++ b/src/test/renderer/specs/modules/_classes_.html
@@ -135,6 +135,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_default_export_.html
+++ b/src/test/renderer/specs/modules/_default_export_.html
@@ -123,6 +123,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_enumerations_.html
+++ b/src/test/renderer/specs/modules/_enumerations_.html
@@ -123,6 +123,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_flattened_.html
+++ b/src/test/renderer/specs/modules/_flattened_.html
@@ -303,6 +303,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_functions_.html
+++ b/src/test/renderer/specs/modules/_functions_.html
@@ -592,6 +592,9 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_functions_.modulefunction.html
+++ b/src/test/renderer/specs/modules/_functions_.modulefunction.html
@@ -239,6 +239,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_generics_.html
+++ b/src/test/renderer/specs/modules/_generics_.html
@@ -200,6 +200,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_modules_.html
+++ b/src/test/renderer/specs/modules/_modules_.html
@@ -396,6 +396,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_modules_.mymodule.html
+++ b/src/test/renderer/specs/modules/_modules_.mymodule.html
@@ -250,6 +250,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_modules_.mymodule.mysubmodule.html
+++ b/src/test/renderer/specs/modules/_modules_.mymodule.mysubmodule.html
@@ -169,6 +169,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_single_export_.html
+++ b/src/test/renderer/specs/modules/_single_export_.html
@@ -123,6 +123,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_typescript_1_3_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_3_.html
@@ -147,6 +147,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_typescript_1_4_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_4_.html
@@ -430,6 +430,9 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">

--- a/src/test/renderer/specs/modules/_typescript_1_5_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_5_.html
@@ -302,6 +302,9 @@
 					<li class="current tsd-kind-external-module">
 						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_variables_.html">"variables"</a>
+					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">


### PR DESCRIPTION
This PR add the following enums to `ReflectionFlag`:

  - Abstract
  - Const
  - Let

Additionally, each enum has it's implemented converter logic added.

# Why?
No need to explain why `Abstract` symbols should reflect in the UI.
For Let and Const, these are also important, Const is a read only symbol so the user should be aware of that. Let does not have much effect since we expose structure and not implementation hence let and var in that context are the same, however, if we state const we should state let as it's a language feature and should reflect in the UI to be consistent.

### Abstract
In `ClassConverter` added logic to set `Abstract` flag to each `DeclarationReflection` that represents an abstract class, following the same logic for each abstract member of that class (`FunctionConverter`, `VariableConverter`) 

Theming Notes:
  - The theme's does not require change for members as the `Abstract` enum is also set as a relevant flags, hence showing in native themes.
  - The `overwrites` property of a member the overwrites an abstract parent member is left as is. This means it will still show overwrites which is not the right terminology, might require a custom fix in the templates. You can see if you "overwrite" an abstract parent by checking if it has the `Abstract` flag.
  - Abstract classes have no UI representation as it does not exist in the theme's, need to implement in the themes.

### Const & Let
In `VariableConverter` added logic to set `Const` or `Let` flag to each `DeclarationReflection` that represents a variable where the typescript node's parent has Const or Let node flags set.
A `var` variable should be inferred whenever a reflection of kind `ReflectionKind.Variable` has no Let or Const flags.

Theming Notes:
  - The theme's does not require change because `Const` and `Let` enums are also set as a relevant flags, hence showing in native themes. (var will not display, as is now)