### PR TITLE
add the TypeOperatorType that represents an op result on a type ("keyof")

### DIFF
--- a/examples/basic/src/classes.ts
+++ b/examples/basic/src/classes.ts
@@ -73,7 +73,7 @@ export class BaseClass implements INameInterface
     /**
      * This is an instance member of an internal class.
      */
-    private internalClass:InternalClass;
+    private internalClass:InternalClass<keyof BaseClass>;
 
 
     constructor(name:string);
@@ -181,7 +181,7 @@ export class BaseClass implements INameInterface
 /**
  * This is an internal class, it is not exported.
  */
-class InternalClass
+class InternalClass<TTT extends keyof BaseClass>
 {
     constructor(options:{name:string}) {
 

--- a/src/lib/converter/types/index.ts
+++ b/src/lib/converter/types/index.ts
@@ -9,5 +9,6 @@ export { ReferenceConverter } from './reference';
 export { ThisConverter } from './this';
 export { TupleConverter } from './tuple';
 export { TypeParameterConverter } from './type-parameter';
+export { TypeOperatorConverter } from './type-operator';
 export { UnionOrIntersectionConverter } from './union-or-intersection';
 export { UnknownConverter } from './unknown';

--- a/src/lib/converter/types/type-operator.ts
+++ b/src/lib/converter/types/type-operator.ts
@@ -1,0 +1,32 @@
+import * as ts from 'typescript';
+
+import { TypeOperatorType } from '../../models/types/index';
+import { Component, ConverterTypeComponent, TypeNodeConverter } from '../components';
+import { Context } from '../context';
+
+@Component({name: 'type:type-operator'})
+export class TypeOperatorConverter extends ConverterTypeComponent implements TypeNodeConverter<ts.Type, ts.TypeOperatorNode> {
+    /**
+     * we want to run before union
+     */
+    priority = 50;
+
+    /**
+     * Test whether this converter can handle the given TypeScript node.
+     */
+    supportsNode(context: Context, node: ts.TypeOperatorNode, type: ts.Type): boolean {
+        return !!(node.kind === ts.SyntaxKind.TypeOperator);
+    }
+
+    /**
+     * Interpret the given type operator node and convert it into a type representing keys of a type
+     *
+     * @param context  The context object describing the current state the converter is in.
+     * @param node  The type operator node representing keys of a type.
+     * @returns The type representing keys of a type.
+     */
+    convertNode(context: Context, node: ts.TypeOperatorNode): TypeOperatorType {
+        const target = this.owner.convertType(context, node.type);
+        return new TypeOperatorType(target);
+    }
+}

--- a/src/lib/models/types/index.ts
+++ b/src/lib/models/types/index.ts
@@ -6,6 +6,7 @@ export { ReferenceType } from './reference';
 export { ReflectionType } from './reflection';
 export { StringLiteralType } from './string-literal';
 export { TupleType } from './tuple';
+export { TypeOperatorType } from './type-operator';
 export { TypeParameterType } from './type-parameter';
 export { UnionType } from './union';
 export { UnknownType } from './unknown';

--- a/src/lib/models/types/type-operator.ts
+++ b/src/lib/models/types/type-operator.ts
@@ -1,0 +1,67 @@
+import { Type } from './abstract';
+
+/**
+ * Represents a type operator type.
+ *
+ * ~~~
+ * class A {}
+ * class B<T extends keyof A> {}
+ * ~~~
+ */
+export class TypeOperatorType extends Type {
+    /**
+     * The type name identifier.
+     */
+    readonly type: string = 'typeOperator';
+
+    target: Type;
+
+    // currently, there is only one type operator, this is always "keyof"
+    // but, if more types will be added in the future we are ready.
+    operator: 'keyof' = 'keyof';
+
+    constructor(target: Type) {
+        super();
+        this.target = target;
+    }
+
+    /**
+     * Clone this type.
+     *
+     * @return A clone of this type.
+     */
+    clone(): Type {
+        return new TypeOperatorType(this.target.clone());
+    }
+
+    /**
+     * Test whether this type equals the given type.
+     *
+     * @param type  The type that should be checked for equality.
+     * @returns TRUE if the given type equals this type, FALSE otherwise.
+     */
+    equals(type: TypeOperatorType): boolean {
+        if (!(type instanceof TypeOperatorType)) {
+            return false;
+        }
+
+        return type.target.equals(this.target);
+    }
+
+    /**
+     * Return a raw object representation of this type.
+     */
+    toObject(): any {
+        const result: any = super.toObject();
+        result.operator = this.operator;
+        result.target = this.target.toObject();
+        return result;
+    }
+
+    /**
+     * Return a string representation of this type.
+     */
+    toString() {
+        return `keyof ${this.target.toString()}`;
+    }
+}

--- a/src/test/converter/type-operator/specs.json
+++ b/src/test/converter/type-operator/specs.json
@@ -1,0 +1,196 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "flags": {},
+  "children": [
+    {
+      "id": 1,
+      "name": "\"type-operator\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/type-operator/type-operator.ts",
+      "children": [
+        {
+          "id": 5,
+          "name": "GenericClass",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "typeParameter": [
+            {
+              "id": 6,
+              "name": "T",
+              "kind": 131072,
+              "kindString": "Type parameter",
+              "flags": {},
+              "type": {
+                "type": "typeOperator",
+                "operator": "keyof",
+                "target": {
+                  "type": "reference",
+                  "name": "TestClass"
+                }
+              }
+            }
+          ],
+          "children": [
+            {
+              "id": 7,
+              "name": "c",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true
+              },
+              "sources": [
+                {
+                  "fileName": "type-operator.ts",
+                  "line": 14,
+                  "character": 5
+                }
+              ],
+              "type": {
+                "type": "typeParameter",
+                "name": "T",
+                "constraint": {
+                  "type": "typeOperator",
+                  "operator": "keyof",
+                  "target": {
+                    "type": "reference",
+                    "name": "TestClass"
+                  }
+                }
+              }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                7
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "type-operator.ts",
+              "line": 13,
+              "character": 25
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "name": "TestClass",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "TestClass comment short text.",
+            "text": "TestClass comment text.\n",
+            "tags": [
+              {
+                "tag": "see",
+                "text": "[[TestClass]] @ fixtures\n"
+              }
+            ]
+          },
+          "children": [
+            {
+              "id": 3,
+              "name": "a",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true
+              },
+              "sources": [
+                {
+                  "fileName": "type-operator.ts",
+                  "line": 9,
+                  "character": 5
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              }
+            },
+            {
+              "id": 4,
+              "name": "b",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true
+              },
+              "sources": [
+                {
+                  "fileName": "type-operator.ts",
+                  "line": 10,
+                  "character": 5
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                3,
+                4
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "type-operator.ts",
+              "line": 8,
+              "character": 22
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Classes",
+          "kind": 128,
+          "children": [
+            5,
+            2
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "type-operator.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "External modules",
+      "kind": 1,
+      "children": [
+        1
+      ]
+    }
+  ]
+}

--- a/src/test/converter/type-operator/type-operator.ts
+++ b/src/test/converter/type-operator/type-operator.ts
@@ -1,0 +1,15 @@
+/**
+ * TestClass comment short text.
+ *
+ * TestClass comment text.
+ *
+ * @see [[TestClass]] @ fixtures
+ */
+export class TestClass {
+    a: string;
+    b: number;
+}
+
+export class GenericClass<T extends keyof TestClass> {
+    c: T;
+}

--- a/src/test/renderer/specs/classes/_classes_.baseclass.html
+++ b/src/test/renderer/specs/classes/_classes_.baseclass.html
@@ -180,7 +180,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private">
 					<a name="internalclass" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> internal<wbr>Class</h3>
-					<div class="tsd-signature tsd-kind-icon">internal<wbr>Class<span class="tsd-signature-symbol">:</span> <a href="_classes_.internalclass.html" class="tsd-signature-type">InternalClass</a></div>
+					<div class="tsd-signature tsd-kind-icon">internal<wbr>Class<span class="tsd-signature-symbol">:</span> <a href="_classes_.internalclass.html" class="tsd-signature-type">InternalClass</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">keyof BaseClass</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L76">classes.ts:76</a></li>
@@ -560,7 +560,7 @@
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">

--- a/src/test/renderer/specs/classes/_classes_.genericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.genericclass.html
@@ -404,7 +404,7 @@
 					</li>
 				</ul>
 				<ul class="after-current">
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">

--- a/src/test/renderer/specs/classes/_classes_.internalclass.html
+++ b/src/test/renderer/specs/classes/_classes_.internalclass.html
@@ -62,7 +62,7 @@
 					<a href="_classes_.internalclass.html">InternalClass</a>
 				</li>
 			</ul>
-			<h1>Class InternalClass</h1>
+			<h1>Class InternalClass&lt;TTT&gt;</h1>
 		</div>
 	</div>
 </header>
@@ -75,6 +75,14 @@
 						<p>This is an internal class, it is not exported.</p>
 					</div>
 				</div>
+			</section>
+			<section class="tsd-panel tsd-type-parameters">
+				<h3>Type parameters</h3>
+				<ul class="tsd-type-parameters">
+					<li>
+						<h4>TTT<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">keyof BaseClass</span></h4>
+					</li>
+				</ul>
 			</section>
 			<section class="tsd-panel tsd-hierarchy">
 				<h3>Hierarchy</h3>
@@ -183,7 +191,7 @@
 					</li>
 				</ul>
 				<ul class="current">
-					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">

--- a/src/test/renderer/specs/classes/_classes_.nongenericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.nongenericclass.html
@@ -352,7 +352,7 @@
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/classes/_classes_.subclassa.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassa.html
@@ -658,7 +658,7 @@
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">

--- a/src/test/renderer/specs/classes/_classes_.subclassb.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassb.html
@@ -493,7 +493,7 @@
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">

--- a/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
+++ b/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
@@ -74,7 +74,7 @@
 					<div class="lead">
 						<p>This class is exported via es6 export syntax.</p>
 					</div>
-					<pre><code><span class="hljs-builtin-name">export</span><span class="hljs-built_in"> default </span>class DefaultExportedClass
+					<pre><code><span class="hljs-keyword">export</span> <span class="hljs-keyword">default</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">DefaultExportedClass</span></span>
 </code></pre>
 				</div>
 			</section>

--- a/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
@@ -214,7 +214,7 @@
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
@@ -187,7 +187,7 @@
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
@@ -271,7 +271,7 @@
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">

--- a/src/test/renderer/specs/modules/_classes_.html
+++ b/src/test/renderer/specs/modules/_classes_.html
@@ -75,7 +75,7 @@
 							<ul class="tsd-index-list">
 								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a></li>
 								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter"><a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a></li>
 								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a></li>
 								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a></li>
 								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a></li>
@@ -145,7 +145,7 @@
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">


### PR DESCRIPTION
The `TypeOperatorType` represent the typescript `TypeOperator` node type.

```ts
class A {
  a: string;
  b: number;
}

class B<T extends keyof A> {}
class B<T extends A> {}
```

In the example above, the `Reflection` instances for **class B** and **class C** will include a `TypeParameterType` **T** that has a constraint.

For **class C** it will be a `TypeReferenceType` (reference to reflection of **A**)

For **class B** it will be a `TypeOperatorType` with a `target` property holding a `TypeReferenceType` instance (reference to reflection of **A**)

Before this PR the behaviour is to include a union type that contains `IntrinsicType` of string's that represent the properties of **class A** ('a', 'b');

While this is logically true it is not accurate, the actual type is the list of keys of another type.
The documentation should show the connection between T and A and not just show a list of strings.

Some classes or types might have 10-15 or more members, it does not scale