### PR TITLE
Upgrade typescript to 2.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "progress": "^2.0.0",
     "shelljs": "^0.7.0",
     "typedoc-default-themes": "^0.5.0",
-    "typescript": "2.4.1"
+    "typescript": "2.5.3"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.39",

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -91,8 +91,8 @@ export class Application extends ChildableComponent<Application, AbstractCompone
         super(null);
 
         this.logger    = new ConsoleLogger();
-        this.converter = this.addComponent('converter', Converter);
-        this.renderer  = this.addComponent('renderer', Renderer);
+        this.converter = this.addComponent<Converter>('converter', Converter);
+        this.renderer  = this.addComponent<Renderer>('renderer', Renderer);
         this.plugins   = this.addComponent('plugins', PluginHost);
         this.options   = this.addComponent('options', Options);
 

--- a/src/lib/converter/nodes/variable-statement.ts
+++ b/src/lib/converter/nodes/variable-statement.ts
@@ -42,7 +42,7 @@ export class VariableStatementConverter extends ConverterNodeComponent<ts.Variab
      * @param node     The binding pattern node that should be analyzed.
      */
     convertBindingPattern(context: Context, node: ts.BindingPattern) {
-        (node.elements as ReadonlyArray<ts.BindingElement>).forEach((element: ts.BindingElement) => {
+        (node.elements as ts.NodeArray<ts.BindingElement>).forEach((element: ts.BindingElement) => {
             this.owner.convertNode(context, element);
 
             if (_ts.isBindingPattern(element.name)) {

--- a/src/lib/converter/nodes/variable-statement.ts
+++ b/src/lib/converter/nodes/variable-statement.ts
@@ -42,7 +42,7 @@ export class VariableStatementConverter extends ConverterNodeComponent<ts.Variab
      * @param node     The binding pattern node that should be analyzed.
      */
     convertBindingPattern(context: Context, node: ts.BindingPattern) {
-        (node.elements as ts.BindingElement[]).forEach((element: ts.BindingElement) => {
+        (node.elements as ReadonlyArray<ts.BindingElement>).forEach((element: ts.BindingElement) => {
             this.owner.convertNode(context, element);
 
             if (_ts.isBindingPattern(element.name)) {

--- a/src/lib/converter/types/binding-array.ts
+++ b/src/lib/converter/types/binding-array.ts
@@ -23,7 +23,7 @@ export class BindingArrayConverter extends ConverterTypeComponent implements Typ
     convertNode(context: Context, node: ts.BindingPattern): Type {
         const types: Type[] = [];
 
-        (node.elements as ts.BindingElement[]).forEach((element) => {
+        (node.elements as ReadonlyArray<ts.BindingElement>).forEach((element) => {
             types.push(this.owner.convertType(context, element));
         });
 

--- a/src/lib/converter/types/binding-array.ts
+++ b/src/lib/converter/types/binding-array.ts
@@ -23,7 +23,7 @@ export class BindingArrayConverter extends ConverterTypeComponent implements Typ
     convertNode(context: Context, node: ts.BindingPattern): Type {
         const types: Type[] = [];
 
-        (node.elements as ReadonlyArray<ts.BindingElement>).forEach((element) => {
+        (node.elements as ts.NodeArray<ts.BindingElement>).forEach((element) => {
             types.push(this.owner.convertType(context, element));
         });
 

--- a/src/lib/converter/types/binding-object.ts
+++ b/src/lib/converter/types/binding-object.ts
@@ -30,7 +30,7 @@ export class BindingObjectConverter extends ConverterTypeComponent implements Ty
         context.registerReflection(declaration, null);
         context.trigger(Converter.EVENT_CREATE_DECLARATION, declaration, node);
         context.withScope(declaration, () => {
-            (node.elements as ts.BindingElement[]).forEach((element) => {
+            (node.elements as ReadonlyArray<ts.BindingElement>).forEach((element) => {
                 this.owner.convertNode(context, element);
             });
         });

--- a/src/lib/converter/types/binding-object.ts
+++ b/src/lib/converter/types/binding-object.ts
@@ -30,7 +30,7 @@ export class BindingObjectConverter extends ConverterTypeComponent implements Ty
         context.registerReflection(declaration, null);
         context.trigger(Converter.EVENT_CREATE_DECLARATION, declaration, node);
         context.withScope(declaration, () => {
-            (node.elements as ReadonlyArray<ts.BindingElement>).forEach((element) => {
+            (node.elements as ts.NodeArray<ts.BindingElement>).forEach((element) => {
                 this.owner.convertNode(context, element);
             });
         });


### PR DESCRIPTION
## Overview

Upgrades Typescript to 2.5.3. Closes https://github.com/TypeStrong/typedoc/issues/624, https://github.com/TypeStrong/typedoc/pull/586, and https://github.com/TypeStrong/typedoc/pull/573 (as it's gone stale).