### PR TITLE
refactor `removeReflection` + future work notes

### DIFF
--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -1,14 +1,12 @@
 import * as ts from 'typescript';
 
 import { Comment, CommentTag } from '../../models/comments/index';
-import { IntrinsicType } from '../../models/types/index';
-import { Reflection, ReflectionFlag, ReflectionKind, TraverseProperty,
-    TypeParameterReflection, DeclarationReflection, ProjectReflection,
-    SignatureReflection, ParameterReflection } from '../../models/reflections/index';
+import { Reflection, ReflectionFlag, ReflectionKind, TypeParameterReflection, DeclarationReflection,
+    ProjectReflection } from '../../models/reflections/index';
 import { Component, ConverterComponent } from '../components';
 import { parseComment, getRawComment } from '../factories/comment';
 import { Converter } from '../converter';
-import { Context } from '../context';
+import { Context, removeReflection } from '../context';
 
 /**
  * Structure used by [[ContainerCommentHandler]] to store discovered module comments.
@@ -314,69 +312,12 @@ export class CommentPlugin extends ConverterComponent {
 
     /**
      * Remove the given reflection from the project.
+     *
+     * @deprecated use [[Context.removeReflection]]
      */
     static removeReflection(project: ProjectReflection, reflection: Reflection) {
-        reflection.traverse((child) => CommentPlugin.removeReflection(project, child));
-
-        const parent = <DeclarationReflection> reflection.parent;
-        parent.traverse((child: Reflection, property: TraverseProperty) => {
-            if (child === reflection) {
-                switch (property) {
-                    case TraverseProperty.Children:
-                        if (parent.children) {
-                            const index = parent.children.indexOf(<DeclarationReflection> reflection);
-                            if (index !== -1) {
-                                parent.children.splice(index, 1);
-                            }
-                        }
-                        break;
-                    case TraverseProperty.GetSignature:
-                        delete parent.getSignature;
-                        break;
-                    case TraverseProperty.IndexSignature:
-                        delete parent.indexSignature;
-                        break;
-                    case TraverseProperty.Parameters:
-                        if ((<SignatureReflection> reflection.parent).parameters) {
-                            const index = (<SignatureReflection> reflection.parent).parameters.indexOf(<ParameterReflection> reflection);
-                            if (index !== -1) {
-                                (<SignatureReflection> reflection.parent).parameters.splice(index, 1);
-                            }
-                        }
-                        break;
-                    case TraverseProperty.SetSignature:
-                        delete parent.setSignature;
-                        break;
-                    case TraverseProperty.Signatures:
-                        if (parent.signatures) {
-                            const index = parent.signatures.indexOf(<SignatureReflection> reflection);
-                            if (index !== -1) {
-                                parent.signatures.splice(index, 1);
-                            }
-                        }
-                        break;
-                    case TraverseProperty.TypeLiteral:
-                        parent.type = new IntrinsicType('Object');
-                        break;
-                    case TraverseProperty.TypeParameter:
-                        if (parent.typeParameters) {
-                            const index = parent.typeParameters.indexOf(<TypeParameterReflection> reflection);
-                            if (index !== -1) {
-                                parent.typeParameters.splice(index, 1);
-                            }
-                        }
-                        break;
-                }
-            }
-        });
-
-        let id = reflection.id;
-        delete project.reflections[id];
-
-        for (let key in project.symbolMapping) {
-            if (project.symbolMapping.hasOwnProperty(key) && project.symbolMapping[key] === id) {
-                delete project.symbolMapping[key];
-            }
-        }
+        /* TODO: deprecate in 1.x.x */
+        /* TODO: when removing, apply TODO in [[Context.removeReflection]] */
+        return removeReflection(project, reflection);
     }
 }


### PR DESCRIPTION
  - set `removeReflection` as core operation
  - allow auto-removal of stale parents when running `removeReflection`

This PR try's to normalize the `removeReflection` operation and add it as a core method for `Context` instead of it being part of `CommentPlugin` which makes no sense.

Because `Context` has a `registerReflection` method it makes sense to have a `removeReflection` method as well.

**Additionally**
An optional parameter has been added to `removeReflection` called **removeStaleParent**.
When set to true it will automatically remove stale parents.
A stale parent is a `DeclarationReflection` that is invalid without child reflections.
When a reflection is removed and `removeStaleParent` is true the parent is checked to see if it is invalid (stale), if so it is removed.

#### Examples:
  - Removing a reflection of kind `ReflectionKind.GetSignature` or `ReflectionKind.SetSignature`
will remove the signature from the parent, `ReflectionKind.Accessor`. If the removal
leaves the parent without a signature (get or set) it is stale/invalid thus requires removal as well.

  - Removing a reflection of kind`ReflectionKind.CallSignature` or `ReflectionKind.ConstructorSignature`
will remove the signature from the parent, function, method or constructor.
If the removal leaves the parent without a single signature it is stale/invalid thus
requires removal as well.

## Notes:
  - CommentPlugin#removeReflection` is still supported but with a `@deprecated` flag.
  - The added optional parameter `removeStaleParent` does not break API as it is optional and off by default (same behaviour unless opt-in)

# Future work:
This is the first step towards a safe reflection removal operation, further fixes are required to make it safe.

The main issue i've identified is that **plugins are not aware of a reflection removal operation (they are aware of adding)**

This has clear impact with the following:
  1. groups added by the `GroupPlugin` 
  2. `ReferenceType` instance.

(1) `GroupPlugin` set reflections in the `groups` property, if a reflection is removed and it's a child of a group it does not get removed in the group which leaves a stale reflection.
To solve this, each project needs to have a list of all the removed reflections so at the end the plugin can apply changes.

(2) Some of the converters as well as the `TypePlugin` create `ReferenceType` instances to reflections (`type`, `overwrites`, `inheritedFrom`, `extendedTypes`, `extendedBy`, etc.). When a reflection is removed they are unaware and so leave the reference in place.
To solve this, we can use the solution for (1) and traverse all reflection to remove types with references to removed reflections.

The solutions might not be optimal as they require full traversal of all reflections and perhaps someone can find a better idea.
A remove event will not help because the removed reflection has no reference to reflections/types pointing at it....
