### PR TITLE
dont parse comment for tags inside a code block

### DIFF
--- a/src/lib/converter/factories/comment.ts
+++ b/src/lib/converter/factories/comment.ts
@@ -160,16 +160,23 @@ export function parseComment(text: string, comment: Comment = new Comment()): Co
         comment.tags.push(currentTag);
     }
 
+    const CODE_FENCE = /^\s*```(?!.*```)/;
+    let inCode = false;
     function readLine(line: string) {
         line = line.replace(/^\s*\*? ?/, '');
         line = line.replace(/\s*$/, '');
 
-        const tag = /^@(\S+)/.exec(line);
-        if (tag) {
-            readTagLine(line, tag);
-        } else {
-            readBareLine(line);
+        if (CODE_FENCE.test(line) ) {
+          inCode = !inCode;
         }
+
+        if (!inCode) {
+          const tag = /^@(\S+)/.exec(line);
+          if (tag) {
+            return readTagLine(line, tag);
+          }
+        }
+        readBareLine(line);
     }
 
     // text = text.replace(/^\s*\/\*+\s*(\r\n?|\n)/, '');

--- a/src/test/converter/comment/comment.ts
+++ b/src/test/converter/comment/comment.ts
@@ -1,0 +1,29 @@
+/**
+ * A Comment for a class
+ *
+ * ## Some Markup
+ * **with more markup**
+ *
+ * A example with decorators that should not parse to tag
+ * ```
+ * @myDecorator
+ * @FactoryDecorator('a', 'b', 'c')
+ * export class CommentedClass {
+ *   myProp: string = 'myProp';
+ *
+ *   @PropDecorator() decoratedProp: string;
+ *
+ *   constructor(@ParamDecorator public param: string) { }
+ *
+ *   myMethod() { }
+ * }
+ * ```
+ * @deprecated
+ * @todo something
+ */
+export class CommentedClass {
+  /**
+   * The main prop
+   */
+  prop: string;
+}

--- a/src/test/converter/comment/specs.json
+++ b/src/test/converter/comment/specs.json
@@ -1,0 +1,109 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "flags": {},
+  "children": [
+    {
+      "id": 1,
+      "name": "\"comment\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/comment/comment.ts",
+      "children": [
+        {
+          "id": 2,
+          "name": "CommentedClass",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "A Comment for a class",
+            "text": "## Some Markup\n**with more markup**\n\nA example with decorators that should not parse to tag\n```\n@myDecorator\n@FactoryDecorator('a', 'b', 'c')\nexport class CommentedClass {\n  myProp: string = 'myProp';\n\n  @PropDecorator() decoratedProp: string;\n\n  constructor(@ParamDecorator public param: string) { }\n\n  myMethod() { }\n}\n```",
+            "tags": [
+              {
+                "tag": "deprecated",
+                "text": ""
+              },
+              {
+                "tag": "todo",
+                "text": "something\n"
+              }
+            ]
+          },
+          "children": [
+            {
+              "id": 3,
+              "name": "prop",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "The main prop"
+              },
+              "sources": [
+                {
+                  "fileName": "comment.ts",
+                  "line": 28,
+                  "character": 6
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                3
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "comment.ts",
+              "line": 24,
+              "character": 27
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Classes",
+          "kind": 128,
+          "children": [
+            2
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "comment.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "External modules",
+      "kind": 1,
+      "children": [
+        1
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR applies markdown code block areas and prevents parsing for tags in them.

The following comment
```
/**
 * A Comment for a class
 *
 * ## Some Markup
 * **with more markup**
 *
 * A example with decorators that should not parse to tag
 * ```
 * @myDecorator
 * @FactoryDecorator('a', 'b', 'c')
 * export class CommentedClass {
 *   myProp: string = 'myProp';
 *
 *   @PropDecorator() decoratedProp: string;
 *
 *   constructor(@ParamDecorator public param: string) { }
 *
 *   myMethod() { }
 * }
 * ```
 * @deprecated
 * @todo something
 */
```

Will result in 2 tags parsed, `deprecated` and `todo`

Before this commit, 3 more tags are parsed: `myDecorator`, `FactoryDecorator` and `PropDecorator`