### PR TITLE
make `traverse` safe for delete operations

### DIFF
--- a/src/lib/models/reflections/container.ts
+++ b/src/lib/models/reflections/container.ts
@@ -46,7 +46,7 @@ export class ContainerReflection extends Reflection {
      */
     traverse(callback: TraverseCallback) {
         if (this.children) {
-            this.children.forEach((child: DeclarationReflection) => {
+            this.children.slice().forEach((child: DeclarationReflection) => {
                 callback(child, TraverseProperty.Children);
             });
         }

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -153,7 +153,7 @@ export class DeclarationReflection extends ContainerReflection implements Defaul
      */
     traverse(callback: TraverseCallback) {
         if (this.typeParameters) {
-            this.typeParameters.forEach((parameter) => callback(parameter, TraverseProperty.TypeParameter));
+            this.typeParameters.slice().forEach((parameter) => callback(parameter, TraverseProperty.TypeParameter));
         }
 
         if (this.type instanceof ReflectionType) {
@@ -161,7 +161,7 @@ export class DeclarationReflection extends ContainerReflection implements Defaul
         }
 
         if (this.signatures) {
-            this.signatures.forEach((signature) => callback(signature, TraverseProperty.Signatures));
+            this.signatures.slice().forEach((signature) => callback(signature, TraverseProperty.Signatures));
         }
 
         if (this.indexSignature) {

--- a/src/lib/models/reflections/signature.ts
+++ b/src/lib/models/reflections/signature.ts
@@ -58,11 +58,11 @@ export class SignatureReflection extends Reflection implements TypeContainer, Ty
         }
 
         if (this.typeParameters) {
-            this.typeParameters.forEach((parameter) => callback(parameter, TraverseProperty.TypeParameter));
+            this.typeParameters.slice().forEach((parameter) => callback(parameter, TraverseProperty.TypeParameter));
         }
 
         if (this.parameters) {
-            this.parameters.forEach((parameter) => callback(parameter, TraverseProperty.Parameters));
+            this.parameters.slice().forEach((parameter) => callback(parameter, TraverseProperty.Parameters));
         }
 
         super.traverse(callback);


### PR DESCRIPTION
Currently, traverse does not play nice when mutating the children, signature, etc, of a reflection while traversing.

A current issue happens silently [here](https://github.com/TypeStrong/typedoc/blob/master/src/lib/converter/plugins/CommentPlugin.ts#L319)

Every child is removed, but the iteration is done on the children collection:
```ts
    traverse(callback: TraverseCallback) {
        if (this.children) {
            this.children.forEach((child: DeclarationReflection) => {
                callback(child, TraverseProperty.Children);
            });
        }
    }
```
So the first child with **index 0** is removed, then the index increments to 1 but because we altered the collection index 1 points to what used to be in index 2, i.e. we skipped an item.

The fix is simple, when working with collection work on a copy.
```ts
    traverse(callback: TraverseCallback) {
        if (this.children) {
            this.children.slice().forEach((child: DeclarationReflection) => {
                callback(child, TraverseProperty.Children);
            });
        }
    }
```