### PR TITLE
update `marked` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "handlebars": "^4.0.6",
     "highlight.js": "^9.0.0",
     "lodash": "^4.13.1",
-    "marked": "^0.3.5",
+    "marked": "^0.3.9",
     "minimatch": "^3.0.0",
     "progress": "^2.0.0",
     "shelljs": "^0.7.0",

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -181,6 +181,8 @@ $ typedoc
 				<ul>
 					<li><a href="https://github.com/christopherthielen/typedoc-plugin-external-module-name">External Module Name</a> - Set the name of TypeDoc external modules</li>
 					<li><a href="https://github.com/gdelmas/typedoc-plugin-sourcefile-url">Sourcefile URL</a> - Set custom source file URL links</li>
+					<li><a href="https://github.com/christopherthielen/typedoc-plugin-internal-external">Internal/External Module</a> - Explicitly mark modules as <code>@internal</code> or <code>@external</code></li>
+					<li><a href="https://github.com/christopherthielen/typedoc-plugin-single-line-tags">Single Line Tags</a> - Process certain <code>@tags</code> as single lines</li>
 				</ul>
 				<h2 id="advanced-guides-and-docs">Advanced guides and docs</h2>
 				<p>Visit our homepage for advanced guides and an extensive API documentation:<br>

--- a/src/test/renderer/specs/modules/_variables_.html
+++ b/src/test/renderer/specs/modules/_variables_.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>DefaultExportedClass | typedoc</title>
+	<title>&quot;variables&quot; | typedoc</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="../assets/css/main.css">
@@ -56,127 +56,77 @@
 					<a href="../globals.html">Globals</a>
 				</li>
 				<li>
-					<a href="../modules/_default_export_.html">&quot;default-export&quot;</a>
-				</li>
-				<li>
-					<a href="_default_export_.defaultexportedclass.html">DefaultExportedClass</a>
+					<a href="_variables_.html">&quot;variables&quot;</a>
 				</li>
 			</ul>
-			<h1>Class DefaultExportedClass</h1>
+			<h1>External module &quot;variables&quot;</h1>
 		</div>
 	</div>
 </header>
 <div class="container container-main">
 	<div class="row">
 		<div class="col-8 col-content">
-			<section class="tsd-panel tsd-comment">
-				<div class="tsd-comment tsd-typography">
-					<div class="lead">
-						<p>This class is exported via es6 export syntax.</p>
-					</div>
-					<pre><code><span class="hljs-builtin-name">export</span><span class="hljs-built_in"> default </span>class DefaultExportedClass
-</code></pre>
-				</div>
-			</section>
-			<section class="tsd-panel tsd-hierarchy">
-				<h3>Hierarchy</h3>
-				<ul class="tsd-hierarchy">
-					<li>
-						<span class="target">DefaultExportedClass</span>
-					</li>
-				</ul>
-			</section>
 			<section class="tsd-panel-group tsd-index-group">
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
 						<section class="tsd-index-section ">
-							<h3>Constructors</h3>
+							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_default_export_.defaultexportedclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
-							</ul>
-						</section>
-						<section class="tsd-index-section ">
-							<h3>Properties</h3>
-							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_default_export_.defaultexportedclass.html#exportedproperty" class="tsd-kind-icon">exported<wbr>Property</a></li>
-							</ul>
-						</section>
-						<section class="tsd-index-section ">
-							<h3>Methods</h3>
-							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_default_export_.defaultexportedclass.html#getexportedproperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_variables_.html#constvariable" class="tsd-kind-icon">const<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_variables_.html#letvariable" class="tsd-kind-icon">let<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_variables_.html#varvariable" class="tsd-kind-icon">var<wbr>Variable</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
 			<section class="tsd-panel-group tsd-member-group ">
-				<h2>Constructors</h2>
-				<section class="tsd-panel tsd-member tsd-kind-constructor tsd-parent-kind-class">
-					<a name="constructor" class="tsd-anchor"></a>
-					<h3>constructor</h3>
-					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Default<wbr>Exported<wbr>Class<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_default_export_.defaultexportedclass.html" class="tsd-signature-type">DefaultExportedClass</a></li>
-					</ul>
-					<ul class="tsd-descriptions">
-						<li class="tsd-description">
-							<aside class="tsd-sources">
-								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/default-export.ts#L44">default-export.ts:44</a></li>
-								</ul>
-							</aside>
-							<div class="tsd-comment tsd-typography">
-								<div class="lead">
-									<p>This is the constructor of the default exported class.</p>
-								</div>
-							</div>
-							<h4 class="tsd-returns-title">Returns <a href="_default_export_.defaultexportedclass.html" class="tsd-signature-type">DefaultExportedClass</a></h4>
-						</li>
-					</ul>
-				</section>
-			</section>
-			<section class="tsd-panel-group tsd-member-group ">
-				<h2>Properties</h2>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
-					<a name="exportedproperty" class="tsd-anchor"></a>
-					<h3>exported<wbr>Property</h3>
-					<div class="tsd-signature tsd-kind-icon">exported<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
+				<h2>Variables</h2>
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
+					<a name="constvariable" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagConst">Const</span> const<wbr>Variable</h3>
+					<div class="tsd-signature tsd-kind-icon">const<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"const"</span><span class="tsd-signature-symbol"> =&nbsp;&quot;const&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/default-export.ts#L44">default-export.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/variables.ts#L4">variables.ts:4</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>Property of default exported class.</p>
+							<p>A const variable</p>
 						</div>
 					</div>
 				</section>
-			</section>
-			<section class="tsd-panel-group tsd-member-group ">
-				<h2>Methods</h2>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="getexportedproperty" class="tsd-anchor"></a>
-					<h3>get<wbr>Exported<wbr>Property</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">get<wbr>Exported<wbr>Property<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
-					</ul>
-					<ul class="tsd-descriptions">
-						<li class="tsd-description">
-							<aside class="tsd-sources">
-								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/default-export.ts#L56">default-export.ts:56</a></li>
-								</ul>
-							</aside>
-							<div class="tsd-comment tsd-typography">
-								<div class="lead">
-									<p>Method of default exported class.</p>
-								</div>
-							</div>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
-						</li>
-					</ul>
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
+					<a name="letvariable" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagLet">Let</span> let<wbr>Variable</h3>
+					<div class="tsd-signature tsd-kind-icon">let<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;let&quot;</span></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/variables.ts#L9">variables.ts:9</a></li>
+						</ul>
+					</aside>
+					<div class="tsd-comment tsd-typography">
+						<div class="lead">
+							<p>A let variable</p>
+						</div>
+					</div>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
+					<a name="varvariable" class="tsd-anchor"></a>
+					<h3>var<wbr>Variable</h3>
+					<div class="tsd-signature tsd-kind-icon">var<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;var&quot;</span></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/variables.ts#L14">variables.ts:14</a></li>
+						</ul>
+					</aside>
+					<div class="tsd-comment tsd-typography">
+						<div class="lead">
+							<p>A var variable</p>
+						</div>
+					</div>
 				</section>
 			</section>
 		</div>
@@ -187,68 +137,56 @@
 						<a href="../globals.html"><em>Globals</em></a>
 					</li>
 					<li class=" tsd-kind-external-module">
-						<a href="../modules/_access_.html">"access"</a>
+						<a href="_access_.html">"access"</a>
 					</li>
 					<li class=" tsd-kind-external-module">
-						<a href="../modules/_classes_.html">"classes"</a>
+						<a href="_classes_.html">"classes"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_default_export_.html">"default-<wbr>export"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_enumerations_.html">"enumerations"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_flattened_.html">"flattened"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_functions_.html">"functions"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_generics_.html">"generics"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_modules_.html">"modules"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_single_export_.html">"single-<wbr>export"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_typescript_1_3_.html">"typescript-<wbr>1.3"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_typescript_1_4_.html">"typescript-<wbr>1.4"</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
 					</li>
 					<li class="current tsd-kind-external-module">
-						<a href="../modules/_default_export_.html">"default-<wbr>export"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_enumerations_.html">"enumerations"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_flattened_.html">"flattened"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_functions_.html">"functions"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_generics_.html">"generics"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_modules_.html">"modules"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_single_export_.html">"single-<wbr>export"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_typescript_1_3_.html">"typescript-<wbr>1.3"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_typescript_1_4_.html">"typescript-<wbr>1.4"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_typescript_1_5_.html">"typescript-<wbr>1.5"</a>
-					</li>
-					<li class=" tsd-kind-external-module">
-						<a href="../modules/_variables_.html">"variables"</a>
+						<a href="_variables_.html">"variables"</a>
 					</li>
 				</ul>
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-				</ul>
-				<ul class="current">
-					<li class="current tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_default_export_.defaultexportedclass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a>
-						<ul>
-							<li class=" tsd-kind-constructor tsd-parent-kind-class">
-								<a href="_default_export_.defaultexportedclass.html#constructor" class="tsd-kind-icon">constructor</a>
-							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class">
-								<a href="_default_export_.defaultexportedclass.html#exportedproperty" class="tsd-kind-icon">exported<wbr>Property</a>
-							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_default_export_.defaultexportedclass.html#getexportedproperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a>
-							</li>
-						</ul>
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
+						<a href="_variables_.html#constvariable" class="tsd-kind-icon">const<wbr>Variable</a>
 					</li>
-				</ul>
-				<ul class="after-current">
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_default_export_.notexportedclassname.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class<wbr>Name</a>
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
+						<a href="_variables_.html#letvariable" class="tsd-kind-icon">let<wbr>Variable</a>
+					</li>
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
+						<a href="_variables_.html#varvariable" class="tsd-kind-icon">var<wbr>Variable</a>
 					</li>
 				</ul>
 			</nav>


### PR DESCRIPTION
Thanks for this great tool!

Purpose: This PR updates the `marked` dependency by bumping its patch version.

Background: `marked`@0.3.6 has two security vulnerabilities (https://nvd.nist.gov/vuln/detail/CVE-2017-1000427, https://nvd.nist.gov/vuln/detail/CVE-2017-17461). While these are not exposed given how typedoc uses `marked` - the vulnerability warning is passed through to all repos that depend on `typedoc`. This creates a burden of keeping track of what vulnerabilities are actual - and desensitizes the github tool.

<hr>

It is unclear why files beyond `package.json` changed. I noticed the same changes simply by cloning the repo and installing - so they don't seem related to this PR. If you'd like me to remove them from this PR, I'd be happy. Just let me know!