### PR TITLE
Fix --plugin argument parsing

### DIFF
--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -26,7 +26,6 @@ export interface DeclarationOption {
     scope?: ParameterScope;
     map?: {};
     mapError?: string;
-    isArray?: boolean;
     defaultValue?: any;
     convert?: (param: OptionDeclaration, value?: any) => any;
 }

--- a/src/lib/utils/plugins.ts
+++ b/src/lib/utils/plugins.ts
@@ -11,8 +11,7 @@ export class PluginHost extends AbstractComponent<Application> {
     @Option({
         name: 'plugin',
         help: 'Specify the npm plugins that should be loaded. Omit to load all installed plugins, set to \'none\' to load no plugins.',
-        type: ParameterType.String,
-        isArray: true
+        type: ParameterType.Array
     })
     plugins: string[];
 

--- a/src/test/plugin-host.ts
+++ b/src/test/plugin-host.ts
@@ -1,0 +1,15 @@
+import { Application } from '..';
+import Assert = require('assert');
+
+describe('PluginHost', function () {
+  it('parses plugins correctly', function () {
+    let app = new Application({
+      plugin: 'typedoc-plugin-1,typedoc-plugin-2'
+    });
+
+    Assert.deepEqual(app.plugins.plugins, [
+      'typedoc-plugin-1',
+      'typedoc-plugin-2'
+    ]);
+  });
+});


### PR DESCRIPTION
Currently, the `--plugin` argument simply doesn't work because it tries to treat the provided string as an array. For example, if I pass `--plugin foo`, it will try to load three npm packages named `f`, `o`, and `o` respectively.

This commit changes the option declaration to use the `ParameterType.Array` type, which parses a comma-separated string into an array. It also removes the otherwise-unused `isArray` property from the `DeclarationOptions` interface.

Despite the, err… "enterprise-grade" architecture of Typedoc, I had trouble writing a good test for this. Even with the hyper-abstraction of `Component`s, it's impossible to construct an `Application` without kicking off side-effects in the constructor, and it's non-trivial to instantiate and test other classes (like `PluginHost`) without an `Application`, due to lots of implicit coupling.

That said, I did manage to write a test for this, but it does instantiate an app to do so, which actually tries to load the non-existent npm packages specified in the test. Ideally, it would be possible to test the options declarations of components without having to run the application.