### PR TITLE
Upgrade tslint to 5.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "grunt-tslint": "^5.0.1",
     "istanbul": "^0.4.1",
     "mocha": "^4.0.0",
-    "tslint": "^5.1.0"
+    "tslint": "^5.9.1"
   },
   "files": [
     "bin",

--- a/src/lib/converter/types/array.ts
+++ b/src/lib/converter/types/array.ts
@@ -18,7 +18,12 @@ export class ArrayConverter extends ConverterTypeComponent implements TypeConver
      */
     supportsType(context: Context, type: ts.TypeReference): boolean {
         // Is there a better way to detect the {"type":"reference","name":"Array","typeArguments":{...}} types that are in fact arrays?
-        return !!(type.flags & ts.TypeFlags.Object) && !!type.symbol && type.symbol.name === 'Array' && !type.symbol.parent && !!type.typeArguments && type.typeArguments.length === 1;
+        return !!(type.flags & ts.TypeFlags.Object)
+          && !!type.symbol
+          && type.symbol.name === 'Array'
+          && !type.symbol.parent
+          && !!type.typeArguments
+          && type.typeArguments.length === 1;
     }
 
     /**

--- a/src/lib/utils/events.ts
+++ b/src/lib/utils/events.ts
@@ -45,6 +45,10 @@ interface EventIteratee<T, U> {
     (events: U, name: string, callback: Function, options: T): U;
 }
 
+interface EventTriggerer {
+    (events: EventHandler[], args: any[]): void;
+}
+
 interface OnApiOptions {
     context: any;
     ctx: any;
@@ -199,7 +203,7 @@ function onceMap(map: EventMap, name: string, callback: EventCallback, offer: Fu
 /**
  * Handles triggering the appropriate event callbacks.
  */
-function triggerApi(objEvents: EventHandlers, name: string, callback: Function, args: any[], triggerer: {(events: EventHandler[], args: any[]): void} = triggerEvents): EventHandlers {
+function triggerApi(objEvents: EventHandlers, name: string, callback: Function, args: any[], triggerer: EventTriggerer = triggerEvents): EventHandlers {
     if (objEvents) {
         const events = objEvents[name];
         let allEvents = objEvents['all'];

--- a/tslint.json
+++ b/tslint.json
@@ -11,7 +11,7 @@
 		"interface-name": [ true, "never-prefix" ],
 		"jsdoc-format": true,
 		"label-position": true,
-		"max-line-length": 120,
+		"max-line-length": [true, 170],
 		"member-access": false,
 		"member-ordering": false,
 		"no-any": false,


### PR DESCRIPTION
A minor release of tslint is currently causing the Typedoc build to fail. The failure is caused by a malformed configuration value that was being silently swallowed before, but causes an exception in tslint 5.9.0 and later.

This PR re-enabled the malformed rule (`max-line-length`) and updates the minimum version of tslint to 5.9.0. To avoid a mega-PR I bumped the maximum line length from 120 to 170, as many lines beyond 120 characters have snuck in since this stopped working.

Given how frustrating it can be for new contributors for builds/tests to fail on a fresh clone, would you be open to including the `yarn.lock` or `package-lock.json` files that are currently in `.gitignore`?