### PR TITLE
Typescript Dep change

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 120
+trim_trailing_whitespace = true

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typedoc-default-themes": "^0.5.0"
   },
   "devDependencies": {
-		"typescript": "2.5.3",
+    "typescript": "2.5.3",
     "@types/mocha": "^2.2.39",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
@@ -62,10 +62,10 @@
     "istanbul": "^0.4.1",
     "mocha": "^4.0.0",
     "tslint": "^5.1.0"
-	},
-	"peerDependencies": {
-		"typescript": "2.x.x"
-	},
+  },
+  "peerDependencies": {
+    "typescript": "2.x.x"
+  },
   "files": [
     "bin",
     "dist",

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "minimatch": "^3.0.0",
     "progress": "^2.0.0",
     "shelljs": "^0.7.0",
-    "typedoc-default-themes": "^0.5.0",
-    "typescript": "2.5.3"
+    "typedoc-default-themes": "^0.5.0"
   },
   "devDependencies": {
+		"typescript": "2.5.3",
     "@types/mocha": "^2.2.39",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
@@ -62,7 +62,10 @@
     "istanbul": "^0.4.1",
     "mocha": "^4.0.0",
     "tslint": "^5.1.0"
-  },
+	},
+	"peerDependencies": {
+		"typescript": "2.x.x"
+	},
   "files": [
     "bin",
     "dist",


### PR DESCRIPTION
I am having an issue with the current version in the npm repository. Because there is a version of typescript local to the module, I can't take advantage of the version of typescript I am using. This is breaking my builds. When I remove the local version and fall back to my version of typescript it works great. I removed typescript as a local dep and made it a dev dependency so it installs when developing, then I made it a peer dependency so that it tells those installing it needs a version of typescript installed.

Lastly I threw in a editor config so that no one else contributing has to go back and reformat cause they don't have their editor setup right, like me :)