### PR TITLE
fix: check for null variable when excludeNotExported is true

### DIFF
--- a/src/lib/converter/nodes/variable.ts
+++ b/src/lib/converter/nodes/variable.ts
@@ -62,21 +62,23 @@ export class VariableConverter extends ConverterNodeComponent<ts.VariableDeclara
         const kind = scope.kind & ReflectionKind.ClassOrInterface ? ReflectionKind.Property : ReflectionKind.Variable;
         const variable = createDeclaration(context, node, kind, name);
 
-        switch (kind) {
-            case ReflectionKind.Variable:
-                if (node.parent.flags & ts.NodeFlags.Const) {
-                    variable.setFlag(ReflectionFlag.Const, true);
-                } else if (node.parent.flags & ts.NodeFlags.Let) {
-                    variable.setFlag(ReflectionFlag.Let, true);
-                }
-                break;
-            case ReflectionKind.Property:
-                if (variable    // child inheriting will return null on createDeclaration
-                    && node.modifiers
-                    && node.modifiers.some( m => m.kind === ts.SyntaxKind.AbstractKeyword )) {
+        // The variable can be null if `excludeNotExported` is `true`
+        if (variable) {
+            switch (kind) {
+                case ReflectionKind.Variable:
+                    if (node.parent.flags & ts.NodeFlags.Const) {
+                        variable.setFlag(ReflectionFlag.Const, true);
+                    } else if (node.parent.flags & ts.NodeFlags.Let) {
+                        variable.setFlag(ReflectionFlag.Let, true);
+                    }
+                    break;
+                case ReflectionKind.Property:
+                    if (node.modifiers
+                        && node.modifiers.some( m => m.kind === ts.SyntaxKind.AbstractKeyword )) {
                     variable.setFlag(ReflectionFlag.Abstract, true);
-                }
-                break;
+                    }
+                    break;
+            }
         }
 
         context.withScope(variable, () => {

--- a/src/test/converter.ts
+++ b/src/test/converter.ts
@@ -97,3 +97,37 @@ describe('Converter', function() {
         });
     });
 });
+
+describe('Converter with excludeNotExported=true', function() {
+    const base = Path.join(__dirname, 'converter');
+    const path = Path.join(base, 'export-with-local');
+    let app: Application;
+
+    it('constructs', function() {
+        app = new Application({
+            mode:   'Modules',
+            logger: 'none',
+            target: 'ES5',
+            module: 'CommonJS',
+            experimentalDecorators: true,
+            excludeNotExported: true,
+            jsx: 'react'
+        });
+    });
+
+    let result: ProjectReflection;
+
+    it('converts fixtures', function() {
+        resetReflectionID();
+        result = app.convert(app.expandInputFiles([path]));
+        Assert(result instanceof ProjectReflection, 'No reflection returned');
+    });
+
+    it('matches specs', function() {
+        const specs = JSON.parse(FS.readFileSync(Path.join(path, 'specs-without-exported.json')).toString());
+        let data = JSON.stringify(result.toObject(), null, '  ');
+        data = data.split(normalizePath(base)).join('%BASE%');
+
+        compareReflections(JSON.parse(data), specs);
+    });
+});

--- a/src/test/converter/export-with-local/export-with-local.ts
+++ b/src/test/converter/export-with-local/export-with-local.ts
@@ -1,0 +1,13 @@
+export const x = 5;
+
+export function add(x: number, y: number) {
+    return x + y;
+}
+
+// Add a local var/function to make sure typedoc won't choke
+// if excludeNotExported is true
+let localVar = 'local';
+
+function times(x: number, y: number) {
+    return x * y;
+}

--- a/src/test/converter/export-with-local/specs-without-exported.json
+++ b/src/test/converter/export-with-local/specs-without-exported.json
@@ -1,0 +1,127 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "flags": {},
+  "children": [
+    {
+      "id": 1,
+      "name": "\"export-with-local\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/export-with-local/export-with-local.ts",
+      "children": [
+        {
+          "id": 2,
+          "name": "x",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isExported": true,
+            "isConst": true
+          },
+          "sources": [
+            {
+              "fileName": "export-with-local.ts",
+              "line": 1,
+              "character": 14
+            }
+          ],
+          "type": {
+            "type": "unknown",
+            "name": "5"
+          },
+          "defaultValue": "5"
+        },
+        {
+          "id": 3,
+          "name": "add",
+          "kind": 64,
+          "kindString": "Function",
+          "flags": {
+            "isExported": true
+          },
+          "signatures": [
+            {
+              "id": 4,
+              "name": "add",
+              "kind": 4096,
+              "kindString": "Call signature",
+              "flags": {},
+              "parameters": [
+                {
+                  "id": 5,
+                  "name": "x",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                },
+                {
+                  "id": 6,
+                  "name": "y",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "export-with-local.ts",
+              "line": 3,
+              "character": 19
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Variables",
+          "kind": 32,
+          "children": [
+            2
+          ]
+        },
+        {
+          "title": "Functions",
+          "kind": 64,
+          "children": [
+            3
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "export-with-local.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "External modules",
+      "kind": 1,
+      "children": [
+        1
+      ]
+    }
+  ]
+}

--- a/src/test/converter/export-with-local/specs.json
+++ b/src/test/converter/export-with-local/specs.json
@@ -1,0 +1,201 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "flags": {},
+  "children": [
+    {
+      "id": 1,
+      "name": "\"export-with-local\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/export-with-local/export-with-local.ts",
+      "children": [
+        {
+          "id": 7,
+          "name": "localVar",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isLet": true
+          },
+          "sources": [
+            {
+              "fileName": "export-with-local.ts",
+              "line": 9,
+              "character": 12
+            }
+          ],
+          "type": {
+            "type": "intrinsic",
+            "name": "string"
+          },
+          "defaultValue": "\"local\""
+        },
+        {
+          "id": 2,
+          "name": "x",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isExported": true,
+            "isConst": true
+          },
+          "sources": [
+            {
+              "fileName": "export-with-local.ts",
+              "line": 1,
+              "character": 14
+            }
+          ],
+          "type": {
+            "type": "unknown",
+            "name": "5"
+          },
+          "defaultValue": "5"
+        },
+        {
+          "id": 3,
+          "name": "add",
+          "kind": 64,
+          "kindString": "Function",
+          "flags": {
+            "isExported": true
+          },
+          "signatures": [
+            {
+              "id": 4,
+              "name": "add",
+              "kind": 4096,
+              "kindString": "Call signature",
+              "flags": {},
+              "parameters": [
+                {
+                  "id": 5,
+                  "name": "x",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                },
+                {
+                  "id": 6,
+                  "name": "y",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "export-with-local.ts",
+              "line": 3,
+              "character": 19
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "name": "times",
+          "kind": 64,
+          "kindString": "Function",
+          "flags": {},
+          "signatures": [
+            {
+              "id": 9,
+              "name": "times",
+              "kind": 4096,
+              "kindString": "Call signature",
+              "flags": {},
+              "parameters": [
+                {
+                  "id": 10,
+                  "name": "x",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                },
+                {
+                  "id": 11,
+                  "name": "y",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "export-with-local.ts",
+              "line": 11,
+              "character": 14
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Variables",
+          "kind": 32,
+          "children": [
+            7,
+            2
+          ]
+        },
+        {
+          "title": "Functions",
+          "kind": 64,
+          "children": [
+            3,
+            8
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "export-with-local.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "External modules",
+      "kind": 1,
+      "children": [
+        1
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The PR fixes the TypeError when `excludeNotExported` option is set to `true` against the following TS file:
```ts
export const x = 5;

export function add(x: number, y: number) {
    return x + y;
}

// Add a local var/function to make sure typedoc won't choke
// if excludeNotExported is true
let localVar = 'local';

function times(x: number, y: number) {
    return x * y;
}
```

The stack trace was:
```
TypeError: Cannot read property 'setFlag' of null
      at VariableConverter.convert (node_modules/typedoc/dist/lib/converter/nodes/variable.js:79:30)
      at Converter.convertNode (node_modules/typedoc/dist/lib/converter/converter.js:127:53)
      at node_modules/typedoc/dist/lib/converter/nodes/variable-statement.js:39:33
      at Array.forEach (<anonymous>)
      at VariableStatementConverter.convert (node_modules/typedoc/dist/lib/converter/nodes/variable-statement.js:34:47)
      at Converter.convertNode (node_modules/typedoc/dist/lib/converter/converter.js:127:53)
      at node_modules/typedoc/dist/lib/converter/nodes/block.js:85:29
      at Array.forEach (<anonymous>)
      at BlockConverter.convertStatements (node_modules/typedoc/dist/lib/converter/nodes/block.js:84:26)
      at node_modules/typedoc/dist/lib/converter/nodes/block.js:62:27
      at Context.withScope (node_modules/typedoc/dist/lib/converter/context.js:107:9)
      at node_modules/typedoc/dist/lib/converter/nodes/block.js:61:25
      at Context.withSourceFile (node_modules/typedoc/dist/lib/converter/context.js:87:9)
      at BlockConverter.convertSourceFile (node_modules/typedoc/dist/lib/converter/nodes/block.js:58:17)
      at BlockConverter.convert (node_modules/typedoc/dist/lib/converter/nodes/block.js:48:18)
      at Converter.convertNode (node_modules/typedoc/dist/lib/converter/converter.js:127:53)
      at node_modules/typedoc/dist/lib/converter/converter.js:155:19
      at Array.forEach (<anonymous>)
      at Converter.compile (node_modules/typedoc/dist/lib/converter/converter.js:154:34)
      at Converter.convert (node_modules/typedoc/dist/lib/converter/converter.js:110:27)
```