### PR TITLE
Export all internal models for use outside TypeDoc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { CliApplication } from './lib/cli';
 export { EventDispatcher, Event } from './lib/utils/events';
 export { resetReflectionID } from './lib/models/reflections/abstract';
 export { normalizePath } from './lib/utils/fs';
-export * from './lib/models/reflections';
+export * from './lib/models';
 export * from './lib/output/plugins';
 export { Renderer } from './lib/output/renderer';
 export { DefaultTheme } from './lib/output/themes/DefaultTheme';

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -2,3 +2,5 @@ export * from './reflections/index';
 export * from './types/index';
 export * from './comments/index';
 export * from './sources/index';
+export * from './ReflectionCategory';
+export * from './ReflectionGroup';

--- a/src/lib/models/sources/index.ts
+++ b/src/lib/models/sources/index.ts
@@ -1,2 +1,2 @@
-export { SourceDirectory } from './directory';
-export { SourceFile } from './file';
+export * from './directory';
+export * from './file';


### PR DESCRIPTION
I'm currently implementing a documentation renderer on top of TypeDoc and not having access to all internal models from outside of TypeDoc makes for some nasty type hacks when traversing reflections. While the corresponding properties do exist on the reflections, there's no way to access them in a type safe manner due to lack of access to the models.