### PR TITLE
Don't write BOM for search index file

### DIFF
--- a/src/lib/output/plugins/JavascriptIndexPlugin.ts
+++ b/src/lib/output/plugins/JavascriptIndexPlugin.ts
@@ -72,6 +72,6 @@ export class JavascriptIndexPlugin extends RendererComponent {
             typedoc.search = typedoc.search || {};
             typedoc.search.data = ${JSON.stringify({kinds: kinds, rows: rows})};`;
 
-        writeFile(fileName, data, true);
+        writeFile(fileName, data, false);
     }
 }


### PR DESCRIPTION
The search doesn't work when `search.js` has a BOM - loading it fails with 
```
Uncaught SyntaxError: Invalid or unexpected token
```
See also https://github.com/cginternals/webgl-operate/issues/22.