### PR TITLE
Allow exclusion of directories starting with a dot

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -248,7 +248,7 @@ export class Application extends ChildableComponent<Application, AbstractCompone
      */
     public expandInputFiles(inputFiles?: string[]): string[] {
         let files: string[] = [];
-        const exclude: Array<IMinimatch> = this.exclude ? this.exclude.map(pattern => new Minimatch(pattern)) : [];
+        const exclude: Array<IMinimatch> = this.exclude ? this.exclude.map(pattern => new Minimatch(pattern, {dot: true})) : [];
 
         function isExcluded(fileName: string): boolean {
             return exclude.some(mm => mm.match(fileName));

--- a/src/test/.dot/index.ts
+++ b/src/test/.dot/index.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/src/test/typedoc.ts
+++ b/src/test/typedoc.ts
@@ -1,6 +1,7 @@
 import { Application } from '..';
 import * as Path from 'path';
 import Assert = require('assert');
+import './.dot';
 
 describe('TypeDoc', function() {
     let application: Application;
@@ -53,6 +54,14 @@ describe('TypeDoc', function() {
 
             Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class', 'class.ts')), -1);
             Assert.equal(expanded.indexOf(Path.join(inputFiles, 'access', 'access.ts')), -1);
+            Assert.equal(expanded.indexOf(inputFiles), -1);
+        });
+        it('supports excluding directories beginning with dots', function() {
+            const inputFiles = __dirname;
+            application.options.setValue('exclude', '**/+(.dot)/**');
+            const expanded = application.expandInputFiles([inputFiles]);
+
+            Assert.equal(expanded.indexOf(Path.join(inputFiles, '.dot', 'index.d.ts')), -1);
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
     });


### PR DESCRIPTION
Resolves #710 

Essentially just adds a test for this behavior, and sets `{dot: true}` for the exclude file `Minimatch` instance.