### PR TITLE
Corrected JSON signature generation to return arrays, fixes #707

### DIFF
--- a/src/lib/serialization/serializers/reflections/abstract.ts
+++ b/src/lib/serialization/serializers/reflections/abstract.ts
@@ -57,19 +57,10 @@ export class ReflectionSerializer extends ReflectionSerializerComponent<Reflecti
       }
       let name = TraverseProperty[property];
       name = name.substr(0, 1).toLowerCase() + name.substr(1);
-      switch (property) {
-        case TraverseProperty.GetSignature:
-        case TraverseProperty.SetSignature:
-        case TraverseProperty.IndexSignature:
-          obj[name] = this.owner.toObject(child);
-          break;
-        default:
-          if (!obj[name]) {
-            obj[name] = [];
-          }
-          obj[name].push(this.owner.toObject(child));
-          break;
+      if (!obj[name]) {
+        obj[name] = [];
       }
+      obj[name].push(this.owner.toObject(child));
     });
 
     return obj;


### PR DESCRIPTION
As discussed in #707, the code that generates the `Index`, `Get` and `Set` signatures (based on its interface [`DeclarationReflectionContainer<T>`](https://github.com/TypeStrong/typedoc/blob/master/src/lib/serialization/browser.ts#L92)) should return arrays instead objects.