### PR TITLE
don't cast files to lower case

### DIFF
--- a/src/lib/models/reflections/abstract.ts
+++ b/src/lib/models/reflections/abstract.ts
@@ -434,12 +434,12 @@ export abstract class Reflection {
      */
     getAlias(): string {
         if (!this._alias) {
-            let alias = this.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+      let alias = this.name.replace(/[^a-z0-9]/gi, '_');
             if (alias === '') {
                 alias = 'reflection-' + this.id;
             }
 
-            let target = <Reflection> this;
+      let target = this as Reflection;
             while (target.parent && !target.parent.isProject() && !target.hasOwnDocument) {
                 target = target.parent;
             }
@@ -466,7 +466,7 @@ export abstract class Reflection {
      * @returns TRUE when this reflection has a visible comment.
      */
     hasComment(): boolean {
-        return <boolean> (this.comment && this.comment.hasVisibleComponent());
+    return (this.comment && this.comment.hasVisibleComponent()) as boolean;
     }
 
     hasGetterOrSetter(): boolean {
@@ -572,7 +572,7 @@ export abstract class Reflection {
 
         for (let key in this.flags) {
             // tslint:disable-next-line:triple-equals
-            if (parseInt(key, 10) == <any> key || key === 'flags') {
+      if (parseInt(key, 10) == (key as any) || key === 'flags') {
                 continue;
             }
             if (this.flags[key]) {

--- a/src/test/converter/decorators/specs.json
+++ b/src/test/converter/decorators/specs.json
@@ -32,7 +32,7 @@
                 "id": 13
               },
               "arguments": {
-                "options": "{\n    name: 'Name of class'\n}"
+                "options": "{\r\n    name: 'Name of class'\r\n}"
               }
             }
           ],

--- a/src/test/renderer/specs/classes/_access_.privateclass.html
+++ b/src/test/renderer/specs/classes/_access_.privateclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_access_.html">&quot;access&quot;</a>
 				</li>
 				<li>
-					<a href="_access_.privateclass.html">PrivateClass</a>
+					<a href="_access_.PrivateClass.html">PrivateClass</a>
 				</li>
 			</ul>
 			<h1>Class PrivateClass</h1>
@@ -91,15 +91,15 @@
 						<section class="tsd-index-section tsd-is-private-protected">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_access_.privateclass.html#fakeprivatevariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><a href="_access_.privateclass.html#fakeprotectedvariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_access_.PrivateClass.html#fakePrivateVariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><a href="_access_.PrivateClass.html#fakeProtectedVariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-private-protected">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_access_.privateclass.html#fakeprivatefunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected"><a href="_access_.privateclass.html#fakeprotectedfunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_access_.PrivateClass.html#fakePrivateFunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected"><a href="_access_.PrivateClass.html#fakeProtectedFunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a></li>
 							</ul>
 						</section>
 					</div>
@@ -108,7 +108,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-private-protected">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private">
-					<a name="fakeprivatevariable" class="tsd-anchor"></a>
+					<a name="fakePrivateVariable" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> fake<wbr>Private<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">fake<wbr>Private<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -123,7 +123,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-protected">
-					<a name="fakeprotectedvariable" class="tsd-anchor"></a>
+					<a name="fakeProtectedVariable" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> fake<wbr>Protected<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">fake<wbr>Protected<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -141,7 +141,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-private-protected">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private">
-					<a name="fakeprivatefunction" class="tsd-anchor"></a>
+					<a name="fakePrivateFunction" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> fake<wbr>Private<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private">
 						<li class="tsd-signature tsd-kind-icon">fake<wbr>Private<wbr>Function<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -163,7 +163,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-protected">
-					<a name="fakeprotectedfunction" class="tsd-anchor"></a>
+					<a name="fakeProtectedFunction" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> fake<wbr>Protected<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-protected">
 						<li class="tsd-signature tsd-kind-icon">fake<wbr>Protected<wbr>Function<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -196,7 +196,7 @@
 						<a href="../modules/_access_.html">"access"</a>
 						<ul>
 							<li class=" tsd-kind-module tsd-parent-kind-external-module tsd-is-private">
-								<a href="../modules/_access_.privatemodule.html">Private<wbr>Module</a>
+								<a href="../modules/_access_.PrivateModule.html">Private<wbr>Module</a>
 							</li>
 						</ul>
 					</li>
@@ -243,35 +243,35 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-private">
-						<a href="_access_.privateclass.html" class="tsd-kind-icon">Private<wbr>Class</a>
+						<a href="_access_.PrivateClass.html" class="tsd-kind-icon">Private<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private">
-								<a href="_access_.privateclass.html#fakeprivatevariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a>
+								<a href="_access_.PrivateClass.html#fakePrivateVariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-protected">
-								<a href="_access_.privateclass.html#fakeprotectedvariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a>
+								<a href="_access_.PrivateClass.html#fakeProtectedVariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private">
-								<a href="_access_.privateclass.html#fakeprivatefunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a>
+								<a href="_access_.PrivateClass.html#fakePrivateFunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-protected">
-								<a href="_access_.privateclass.html#fakeprotectedfunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a>
+								<a href="_access_.PrivateClass.html#fakeProtectedFunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-private">
-						<a href="../modules/_access_.html#fakeprivatevariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a>
+						<a href="../modules/_access_.html#fakePrivateVariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-protected">
-						<a href="../modules/_access_.html#fakeprotectedvariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a>
+						<a href="../modules/_access_.html#fakeProtectedVariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-private">
-						<a href="../modules/_access_.html#fakeprivatefunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a>
+						<a href="../modules/_access_.html#fakePrivateFunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-protected">
-						<a href="../modules/_access_.html#fakeprotectedfunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a>
+						<a href="../modules/_access_.html#fakeProtectedFunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_classes_.baseclass.html
+++ b/src/test/renderer/specs/classes/_classes_.baseclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_classes_.html">&quot;classes&quot;</a>
 				</li>
 				<li>
-					<a href="_classes_.baseclass.html">BaseClass</a>
+					<a href="_classes_.BaseClass.html">BaseClass</a>
 				</li>
 			</ul>
 			<h1>Class BaseClass</h1>
@@ -84,10 +84,10 @@
 						<span class="target">BaseClass</span>
 						<ul class="tsd-hierarchy">
 							<li>
-								<a href="_classes_.subclassa.html" class="tsd-signature-type">SubClassA</a>
+								<a href="_classes_.SubClassA.html" class="tsd-signature-type">SubClassA</a>
 							</li>
 							<li>
-								<a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a>
+								<a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a>
 							</li>
 						</ul>
 					</li>
@@ -96,7 +96,7 @@
 			<section class="tsd-panel">
 				<h3>Implements</h3>
 				<ul class="tsd-hierarchy">
-					<li><a href="../interfaces/_classes_.inameinterface.html" class="tsd-signature-type">INameInterface</a></li>
+					<li><a href="../interfaces/_classes_.INameInterface.html" class="tsd-signature-type">INameInterface</a></li>
 				</ul>
 			</section>
 			<section class="tsd-panel-group tsd-index-group">
@@ -106,30 +106,30 @@
 						<section class="tsd-index-section ">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_classes_.baseclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_classes_.BaseClass.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_classes_.baseclass.html#internalclass" class="tsd-kind-icon">internal<wbr>Class</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><a href="_classes_.baseclass.html#kind" class="tsd-kind-icon">kind</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.baseclass.html#name" class="tsd-kind-icon">name</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-static"><a href="_classes_.baseclass.html#instance" class="tsd-kind-icon">instance</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-static"><a href="_classes_.baseclass.html#instances" class="tsd-kind-icon">instances</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_classes_.BaseClass.html#internalClass" class="tsd-kind-icon">internal<wbr>Class</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><a href="_classes_.BaseClass.html#kind" class="tsd-kind-icon">kind</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.BaseClass.html#name" class="tsd-kind-icon">name</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-static"><a href="_classes_.BaseClass.html#instance" class="tsd-kind-icon">instance</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-static"><a href="_classes_.BaseClass.html#instances" class="tsd-kind-icon">instances</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.baseclass.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.baseclass.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_classes_.baseclass.html#checkname" class="tsd-kind-icon">check<wbr>Name</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.baseclass.html#getname" class="tsd-kind-icon">get<wbr>Name</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.baseclass.html#setname" class="tsd-kind-icon">set<wbr>Name</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-static"><a href="_classes_.baseclass.html#catest" class="tsd-kind-icon">ca<wbr>Test</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-static"><a href="_classes_.baseclass.html#getinstance" class="tsd-kind-icon">get<wbr>Instance</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-static"><a href="_classes_.baseclass.html#getname-1" class="tsd-kind-icon">get<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.BaseClass.html#abstractMethod" class="tsd-kind-icon">abstract<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.BaseClass.html#arrowFunction" class="tsd-kind-icon">arrow<wbr>Function</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_classes_.BaseClass.html#checkName" class="tsd-kind-icon">check<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.BaseClass.html#getName" class="tsd-kind-icon">get<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.BaseClass.html#setName" class="tsd-kind-icon">set<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-static"><a href="_classes_.BaseClass.html#caTest" class="tsd-kind-icon">ca<wbr>Test</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-static"><a href="_classes_.BaseClass.html#getInstance" class="tsd-kind-icon">get<wbr>Instance</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-static"><a href="_classes_.BaseClass.html#getName-1" class="tsd-kind-icon">get<wbr>Name</a></li>
 							</ul>
 						</section>
 					</div>
@@ -141,8 +141,8 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Base<wbr>Class<span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></li>
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Base<wbr>Class<span class="tsd-signature-symbol">(</span>source<span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Base<wbr>Class<span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Base<wbr>Class<span class="tsd-signature-symbol">(</span>source<span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -157,7 +157,7 @@
 									<h5>name: <span class="tsd-signature-type">string</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h4>
 						</li>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
@@ -168,10 +168,10 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>source: <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h5>
+									<h5>source: <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -179,9 +179,9 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private">
-					<a name="internalclass" class="tsd-anchor"></a>
+					<a name="internalClass" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> internal<wbr>Class</h3>
-					<div class="tsd-signature tsd-kind-icon">internal<wbr>Class<span class="tsd-signature-symbol">:</span> <a href="_classes_.internalclass.html" class="tsd-signature-type">InternalClass</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">keyof BaseClass</span><span class="tsd-signature-symbol">&gt;</span></div>
+					<div class="tsd-signature tsd-kind-icon">internal<wbr>Class<span class="tsd-signature-symbol">:</span> <a href="_classes_.InternalClass.html" class="tsd-signature-type">InternalClass</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">keyof BaseClass</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L76">classes.ts:76</a></li>
@@ -213,7 +213,7 @@
 					<h3>name</h3>
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
-						<p>Implementation of <a href="../interfaces/_classes_.inameinterface.html">INameInterface</a>.<a href="../interfaces/_classes_.inameinterface.html#name">name</a></p>
+						<p>Implementation of <a href="../interfaces/_classes_.INameInterface.html">INameInterface</a>.<a href="../interfaces/_classes_.INameInterface.html#name">name</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L58">classes.ts:58</a></li>
 						</ul>
@@ -227,7 +227,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-static">
 					<a name="instance" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> instance</h3>
-					<div class="tsd-signature tsd-kind-icon">instance<span class="tsd-signature-symbol">:</span> <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></div>
+					<div class="tsd-signature tsd-kind-icon">instance<span class="tsd-signature-symbol">:</span> <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L70">classes.ts:70</a></li>
@@ -243,7 +243,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-static">
 					<a name="instances" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> instances</h3>
-					<div class="tsd-signature tsd-kind-icon">instances<span class="tsd-signature-symbol">:</span> <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">[]</span></div>
+					<div class="tsd-signature tsd-kind-icon">instances<span class="tsd-signature-symbol">:</span> <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L71">classes.ts:71</a></li>
@@ -254,7 +254,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="abstractmethod" class="tsd-anchor"></a>
+					<a name="abstractMethod" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagAbstract">Abstract</span> abstract<wbr>Method</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">abstract<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -271,7 +271,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="arrowfunction" class="tsd-anchor"></a>
+					<a name="arrowFunction" class="tsd-anchor"></a>
 					<h3>arrow<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">arrow<wbr>Function<span class="tsd-signature-symbol">(</span>param2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, param1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -312,7 +312,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private">
-					<a name="checkname" class="tsd-anchor"></a>
+					<a name="checkName" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> check<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private">
 						<li class="tsd-signature tsd-kind-icon">check<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
@@ -334,7 +334,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="getname" class="tsd-anchor"></a>
+					<a name="getName" class="tsd-anchor"></a>
 					<h3>get<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -342,7 +342,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/_classes_.inameinterface.html">INameInterface</a>.<a href="../interfaces/_classes_.inameinterface.html#getname">getName</a></p>
+								<p>Implementation of <a href="../interfaces/_classes_.INameInterface.html">INameInterface</a>.<a href="../interfaces/_classes_.INameInterface.html#getName">getName</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L103">classes.ts:103</a></li>
 								</ul>
@@ -360,7 +360,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="setname" class="tsd-anchor"></a>
+					<a name="setName" class="tsd-anchor"></a>
 					<h3>set<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">set<wbr>Name<span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -392,10 +392,10 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-static">
-					<a name="catest" class="tsd-anchor"></a>
+					<a name="caTest" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> ca<wbr>Test</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-static">
-						<li class="tsd-signature tsd-kind-icon">ca<wbr>Test<span class="tsd-signature-symbol">(</span>originalValues<span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a>, newRecord<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, fieldNames<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, mandatoryFields<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
+						<li class="tsd-signature tsd-kind-icon">ca<wbr>Test<span class="tsd-signature-symbol">(</span>originalValues<span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a>, newRecord<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, fieldNames<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, mandatoryFields<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -414,7 +414,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>originalValues: <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h5>
+									<h5>originalValues: <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h5>
 								</li>
 								<li>
 									<h5>newRecord: <span class="tsd-signature-type">any</span></h5>
@@ -431,10 +431,10 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-static">
-					<a name="getinstance" class="tsd-anchor"></a>
+					<a name="getInstance" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> get<wbr>Instance</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-static">
-						<li class="tsd-signature tsd-kind-icon">get<wbr>Instance<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">get<wbr>Instance<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -449,13 +449,13 @@
 								</div>
 								<p>Static functions should not be inherited.</p>
 							</div>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h4>
 							<p>An instance of BaseClass.</p>
 						</li>
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-static">
-					<a name="getname-1" class="tsd-anchor"></a>
+					<a name="getName-1" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> get<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-static">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -533,77 +533,77 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class">
-								<a href="_classes_.baseclass.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_classes_.BaseClass.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private">
-								<a href="_classes_.baseclass.html#internalclass" class="tsd-kind-icon">internal<wbr>Class</a>
+								<a href="_classes_.BaseClass.html#internalClass" class="tsd-kind-icon">internal<wbr>Class</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-protected">
-								<a href="_classes_.baseclass.html#kind" class="tsd-kind-icon">kind</a>
+								<a href="_classes_.BaseClass.html#kind" class="tsd-kind-icon">kind</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class">
-								<a href="_classes_.baseclass.html#name" class="tsd-kind-icon">name</a>
+								<a href="_classes_.BaseClass.html#name" class="tsd-kind-icon">name</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-static">
-								<a href="_classes_.baseclass.html#instance" class="tsd-kind-icon">instance</a>
+								<a href="_classes_.BaseClass.html#instance" class="tsd-kind-icon">instance</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-static">
-								<a href="_classes_.baseclass.html#instances" class="tsd-kind-icon">instances</a>
+								<a href="_classes_.BaseClass.html#instances" class="tsd-kind-icon">instances</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_classes_.baseclass.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a>
+								<a href="_classes_.BaseClass.html#abstractMethod" class="tsd-kind-icon">abstract<wbr>Method</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_classes_.baseclass.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a>
+								<a href="_classes_.BaseClass.html#arrowFunction" class="tsd-kind-icon">arrow<wbr>Function</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private">
-								<a href="_classes_.baseclass.html#checkname" class="tsd-kind-icon">check<wbr>Name</a>
+								<a href="_classes_.BaseClass.html#checkName" class="tsd-kind-icon">check<wbr>Name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_classes_.baseclass.html#getname" class="tsd-kind-icon">get<wbr>Name</a>
+								<a href="_classes_.BaseClass.html#getName" class="tsd-kind-icon">get<wbr>Name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_classes_.baseclass.html#setname" class="tsd-kind-icon">set<wbr>Name</a>
+								<a href="_classes_.BaseClass.html#setName" class="tsd-kind-icon">set<wbr>Name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-static">
-								<a href="_classes_.baseclass.html#catest" class="tsd-kind-icon">ca<wbr>Test</a>
+								<a href="_classes_.BaseClass.html#caTest" class="tsd-kind-icon">ca<wbr>Test</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-static">
-								<a href="_classes_.baseclass.html#getinstance" class="tsd-kind-icon">get<wbr>Instance</a>
+								<a href="_classes_.BaseClass.html#getInstance" class="tsd-kind-icon">get<wbr>Instance</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-static">
-								<a href="_classes_.baseclass.html#getname-1" class="tsd-kind-icon">get<wbr>Name</a>
+								<a href="_classes_.BaseClass.html#getName-1" class="tsd-kind-icon">get<wbr>Name</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="../interfaces/_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_classes_.genericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.genericclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_classes_.html">&quot;classes&quot;</a>
 				</li>
 				<li>
-					<a href="_classes_.genericclass.html">GenericClass</a>
+					<a href="_classes_.GenericClass.html">GenericClass</a>
 				</li>
 			</ul>
 			<h1>Class GenericClass&lt;T&gt;</h1>
@@ -80,7 +80,7 @@
 				<h3>Type parameters</h3>
 				<ul class="tsd-type-parameters">
 					<li>
-						<h4>T<span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h4>
+						<h4>T<span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h4>
 						<div class="tsd-comment tsd-typography">
 							<div class="lead">
 								<p>This a type parameter.</p>
@@ -96,7 +96,7 @@
 						<span class="target">GenericClass</span>
 						<ul class="tsd-hierarchy">
 							<li>
-								<a href="_classes_.nongenericclass.html" class="tsd-signature-type">NonGenericClass</a>
+								<a href="_classes_.NonGenericClass.html" class="tsd-signature-type">NonGenericClass</a>
 							</li>
 						</ul>
 					</li>
@@ -109,24 +109,24 @@
 						<section class="tsd-index-section ">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_classes_.genericclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_classes_.GenericClass.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><a href="_classes_.genericclass.html#p2" class="tsd-kind-icon">p2</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.genericclass.html#p3" class="tsd-kind-icon">p3</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_classes_.genericclass.html#p4" class="tsd-kind-icon">p4</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.genericclass.html#p5" class="tsd-kind-icon">p5</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.genericclass.html#value" class="tsd-kind-icon">value</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><a href="_classes_.GenericClass.html#p2" class="tsd-kind-icon">p2</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.GenericClass.html#p3" class="tsd-kind-icon">p3</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_classes_.GenericClass.html#p4" class="tsd-kind-icon">p4</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.GenericClass.html#p5" class="tsd-kind-icon">p5</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_classes_.GenericClass.html#value" class="tsd-kind-icon">value</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.genericclass.html#getvalue" class="tsd-kind-icon">get<wbr>Value</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.genericclass.html#setvalue" class="tsd-kind-icon">set<wbr>Value</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.GenericClass.html#getValue" class="tsd-kind-icon">get<wbr>Value</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.GenericClass.html#setValue" class="tsd-kind-icon">set<wbr>Value</a></li>
 							</ul>
 						</section>
 					</div>
@@ -138,7 +138,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Generic<wbr>Class<span class="tsd-signature-symbol">(</span>p1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, p2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span>, p3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.genericclass.html" class="tsd-signature-type">GenericClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Generic<wbr>Class<span class="tsd-signature-symbol">(</span>p1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, p2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span>, p3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.GenericClass.html" class="tsd-signature-type">GenericClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -195,7 +195,7 @@
 									</div>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.genericclass.html" class="tsd-signature-type">GenericClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.GenericClass.html" class="tsd-signature-type">GenericClass</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -276,7 +276,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="getvalue" class="tsd-anchor"></a>
+					<a name="getValue" class="tsd-anchor"></a>
 					<h3>get<wbr>Value</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Value<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span></li>
@@ -293,7 +293,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="setvalue" class="tsd-anchor"></a>
+					<a name="setValue" class="tsd-anchor"></a>
 					<h3>set<wbr>Value</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">set<wbr>Value<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -312,7 +312,7 @@
 								<li>
 									<h5>value: <span class="tsd-signature-type">T</span></h5>
 									<div class="tsd-comment tsd-typography">
-										<p><a href="_classes_.genericclass.html#getvalue">getValue</a> is the counterpart.</p>
+										<p><a href="_classes_.GenericClass.html#getValue">getValue</a> is the counterpart.</p>
 									</div>
 								</li>
 							</ul>
@@ -372,61 +372,61 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class">
-								<a href="_classes_.genericclass.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_classes_.GenericClass.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-protected">
-								<a href="_classes_.genericclass.html#p2" class="tsd-kind-icon">p2</a>
+								<a href="_classes_.GenericClass.html#p2" class="tsd-kind-icon">p2</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class">
-								<a href="_classes_.genericclass.html#p3" class="tsd-kind-icon">p3</a>
+								<a href="_classes_.GenericClass.html#p3" class="tsd-kind-icon">p3</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private">
-								<a href="_classes_.genericclass.html#p4" class="tsd-kind-icon">p4</a>
+								<a href="_classes_.GenericClass.html#p4" class="tsd-kind-icon">p4</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class">
-								<a href="_classes_.genericclass.html#p5" class="tsd-kind-icon">p5</a>
+								<a href="_classes_.GenericClass.html#p5" class="tsd-kind-icon">p5</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class">
-								<a href="_classes_.genericclass.html#value" class="tsd-kind-icon">value</a>
+								<a href="_classes_.GenericClass.html#value" class="tsd-kind-icon">value</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_classes_.genericclass.html#getvalue" class="tsd-kind-icon">get<wbr>Value</a>
+								<a href="_classes_.GenericClass.html#getValue" class="tsd-kind-icon">get<wbr>Value</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_classes_.genericclass.html#setvalue" class="tsd-kind-icon">set<wbr>Value</a>
+								<a href="_classes_.GenericClass.html#setValue" class="tsd-kind-icon">set<wbr>Value</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="../interfaces/_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_classes_.internalclass.html
+++ b/src/test/renderer/specs/classes/_classes_.internalclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_classes_.html">&quot;classes&quot;</a>
 				</li>
 				<li>
-					<a href="_classes_.internalclass.html">InternalClass</a>
+					<a href="_classes_.InternalClass.html">InternalClass</a>
 				</li>
 			</ul>
 			<h1>Class InternalClass&lt;TTT&gt;</h1>
@@ -99,7 +99,7 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported"><a href="_classes_.internalclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported"><a href="_classes_.InternalClass.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 					</div>
@@ -111,7 +111,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Internal<wbr>Class<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.internalclass.html" class="tsd-signature-type">InternalClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Internal<wbr>Class<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.InternalClass.html" class="tsd-signature-type">InternalClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -131,7 +131,7 @@
 									</ul>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.internalclass.html" class="tsd-signature-type">InternalClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.InternalClass.html" class="tsd-signature-type">InternalClass</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -187,40 +187,40 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_classes_.internalclass.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_classes_.InternalClass.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="../interfaces/_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_classes_.nongenericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.nongenericclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_classes_.html">&quot;classes&quot;</a>
 				</li>
 				<li>
-					<a href="_classes_.nongenericclass.html">NonGenericClass</a>
+					<a href="_classes_.NonGenericClass.html">NonGenericClass</a>
 				</li>
 			</ul>
 			<h1>Class NonGenericClass</h1>
@@ -72,7 +72,7 @@
 			<section class="tsd-panel tsd-comment">
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<p>This a non generic class derived from a <a href="_classes_.genericclass.html">generic class</a>.</p>
+						<p>This a non generic class derived from a <a href="_classes_.GenericClass.html">generic class</a>.</p>
 					</div>
 				</div>
 			</section>
@@ -80,7 +80,7 @@
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<a href="_classes_.genericclass.html" class="tsd-signature-type">GenericClass</a><span class="tsd-signature-symbol">&lt;</span><a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a><span class="tsd-signature-symbol">&gt;</span>
+						<a href="_classes_.GenericClass.html" class="tsd-signature-type">GenericClass</a><span class="tsd-signature-symbol">&lt;</span><a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a><span class="tsd-signature-symbol">&gt;</span>
 						<ul class="tsd-hierarchy">
 							<li>
 								<span class="target">NonGenericClass</span>
@@ -96,23 +96,23 @@
 						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.nongenericclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.NonGenericClass.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_classes_.nongenericclass.html#p2" class="tsd-kind-icon">p2</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.nongenericclass.html#p3" class="tsd-kind-icon">p3</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.nongenericclass.html#p5" class="tsd-kind-icon">p5</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.nongenericclass.html#value" class="tsd-kind-icon">value</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_classes_.NonGenericClass.html#p2" class="tsd-kind-icon">p2</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.NonGenericClass.html#p3" class="tsd-kind-icon">p3</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.NonGenericClass.html#p5" class="tsd-kind-icon">p5</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.NonGenericClass.html#value" class="tsd-kind-icon">value</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.nongenericclass.html#getvalue" class="tsd-kind-icon">get<wbr>Value</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.nongenericclass.html#setvalue" class="tsd-kind-icon">set<wbr>Value</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.NonGenericClass.html#getValue" class="tsd-kind-icon">get<wbr>Value</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.NonGenericClass.html#setValue" class="tsd-kind-icon">set<wbr>Value</a></li>
 							</ul>
 						</section>
 					</div>
@@ -124,12 +124,12 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Non<wbr>Generic<wbr>Class<span class="tsd-signature-symbol">(</span>p1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, p2<span class="tsd-signature-symbol">: </span><a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a>, p3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.nongenericclass.html" class="tsd-signature-type">NonGenericClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Non<wbr>Generic<wbr>Class<span class="tsd-signature-symbol">(</span>p1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, p2<span class="tsd-signature-symbol">: </span><a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a>, p3<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p4<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, p5<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.NonGenericClass.html" class="tsd-signature-type">NonGenericClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#constructor">constructor</a></p>
+								<p>Inherited from <a href="_classes_.GenericClass.html">GenericClass</a>.<a href="_classes_.GenericClass.html#constructor">constructor</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L284">classes.ts:284</a></li>
 								</ul>
@@ -150,7 +150,7 @@
 									</div>
 								</li>
 								<li>
-									<h5>p2: <a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></h5>
+									<h5>p2: <a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a></h5>
 									<div class="tsd-comment tsd-typography">
 										<div class="lead">
 											<p>Private string property</p>
@@ -182,7 +182,7 @@
 									</div>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.nongenericclass.html" class="tsd-signature-type">NonGenericClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.NonGenericClass.html" class="tsd-signature-type">NonGenericClass</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -192,9 +192,9 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 					<a name="p2" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> p2</h3>
-					<div class="tsd-signature tsd-kind-icon">p2<span class="tsd-signature-symbol">:</span> <a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></div>
+					<div class="tsd-signature tsd-kind-icon">p2<span class="tsd-signature-symbol">:</span> <a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#p2">p2</a></p>
+						<p>Inherited from <a href="_classes_.GenericClass.html">GenericClass</a>.<a href="_classes_.GenericClass.html#p2">p2</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L295">classes.ts:295</a></li>
 						</ul>
@@ -210,7 +210,7 @@
 					<h3>p3</h3>
 					<div class="tsd-signature tsd-kind-icon">p3<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#p3">p3</a></p>
+						<p>Inherited from <a href="_classes_.GenericClass.html">GenericClass</a>.<a href="_classes_.GenericClass.html#p3">p3</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L295">classes.ts:295</a></li>
 						</ul>
@@ -226,7 +226,7 @@
 					<h3>p5</h3>
 					<div class="tsd-signature tsd-kind-icon">p5<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#p5">p5</a></p>
+						<p>Inherited from <a href="_classes_.GenericClass.html">GenericClass</a>.<a href="_classes_.GenericClass.html#p5">p5</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L295">classes.ts:295</a></li>
 						</ul>
@@ -240,9 +240,9 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
 					<a name="value" class="tsd-anchor"></a>
 					<h3>value</h3>
-					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></div>
+					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#value">value</a></p>
+						<p>Inherited from <a href="_classes_.GenericClass.html">GenericClass</a>.<a href="_classes_.GenericClass.html#value">value</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L284">classes.ts:284</a></li>
 						</ul>
@@ -252,33 +252,33 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-inherited">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-					<a name="getvalue" class="tsd-anchor"></a>
+					<a name="getValue" class="tsd-anchor"></a>
 					<h3>get<wbr>Value</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">get<wbr>Value<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></li>
+						<li class="tsd-signature tsd-kind-icon">get<wbr>Value<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#getvalue">getValue</a></p>
+								<p>Inherited from <a href="_classes_.GenericClass.html">GenericClass</a>.<a href="_classes_.GenericClass.html#getValue">getValue</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L305">classes.ts:305</a></li>
 								</ul>
 							</aside>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a></h4>
 						</li>
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-					<a name="setvalue" class="tsd-anchor"></a>
+					<a name="setValue" class="tsd-anchor"></a>
 					<h3>set<wbr>Value</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">set<wbr>Value<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">set<wbr>Value<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.genericclass.html">GenericClass</a>.<a href="_classes_.genericclass.html#setvalue">setValue</a></p>
+								<p>Inherited from <a href="_classes_.GenericClass.html">GenericClass</a>.<a href="_classes_.GenericClass.html#setValue">setValue</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L301">classes.ts:301</a></li>
 								</ul>
@@ -288,9 +288,9 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>value: <a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></h5>
+									<h5>value: <a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a></h5>
 									<div class="tsd-comment tsd-typography">
-										<p><a href="_classes_.nongenericclass.html#getvalue">getValue</a> is the counterpart.</p>
+										<p><a href="_classes_.NonGenericClass.html#getValue">getValue</a> is the counterpart.</p>
 									</div>
 								</li>
 							</ul>
@@ -350,58 +350,58 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.nongenericclass.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_classes_.NonGenericClass.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
-								<a href="_classes_.nongenericclass.html#p2" class="tsd-kind-icon">p2</a>
+								<a href="_classes_.NonGenericClass.html#p2" class="tsd-kind-icon">p2</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.nongenericclass.html#p3" class="tsd-kind-icon">p3</a>
+								<a href="_classes_.NonGenericClass.html#p3" class="tsd-kind-icon">p3</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.nongenericclass.html#p5" class="tsd-kind-icon">p5</a>
+								<a href="_classes_.NonGenericClass.html#p5" class="tsd-kind-icon">p5</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.nongenericclass.html#value" class="tsd-kind-icon">value</a>
+								<a href="_classes_.NonGenericClass.html#value" class="tsd-kind-icon">value</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.nongenericclass.html#getvalue" class="tsd-kind-icon">get<wbr>Value</a>
+								<a href="_classes_.NonGenericClass.html#getValue" class="tsd-kind-icon">get<wbr>Value</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.nongenericclass.html#setvalue" class="tsd-kind-icon">set<wbr>Value</a>
+								<a href="_classes_.NonGenericClass.html#setValue" class="tsd-kind-icon">set<wbr>Value</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="../interfaces/_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_classes_.subclassa.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassa.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_classes_.html">&quot;classes&quot;</a>
 				</li>
 				<li>
-					<a href="_classes_.subclassa.html">SubClassA</a>
+					<a href="_classes_.SubClassA.html">SubClassA</a>
 				</li>
 			</ul>
 			<h1>Class SubClassA</h1>
@@ -82,7 +82,7 @@
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a>
+						<a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a>
 						<ul class="tsd-hierarchy">
 							<li>
 								<span class="target">SubClassA</span>
@@ -94,8 +94,8 @@
 			<section class="tsd-panel">
 				<h3>Implements</h3>
 				<ul class="tsd-hierarchy">
-					<li><a href="../interfaces/_classes_.inameinterface.html" class="tsd-signature-type">INameInterface</a></li>
-					<li><a href="../interfaces/_classes_.iprintnameinterface.html" class="tsd-signature-type">IPrintNameInterface</a></li>
+					<li><a href="../interfaces/_classes_.INameInterface.html" class="tsd-signature-type">INameInterface</a></li>
+					<li><a href="../interfaces/_classes_.IPrintNameInterface.html" class="tsd-signature-type">IPrintNameInterface</a></li>
 				</ul>
 			</section>
 			<section class="tsd-panel-group tsd-index-group">
@@ -105,38 +105,38 @@
 						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassa.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.SubClassA.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_classes_.subclassa.html#kind" class="tsd-kind-icon">kind</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassa.html#name" class="tsd-kind-icon">name</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassa.html#instance" class="tsd-kind-icon">instance</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassa.html#instances" class="tsd-kind-icon">instances</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_classes_.SubClassA.html#kind" class="tsd-kind-icon">kind</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.SubClassA.html#name" class="tsd-kind-icon">name</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassA.html#instance" class="tsd-kind-icon">instance</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassA.html#instances" class="tsd-kind-icon">instances</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Accessors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-accessor tsd-parent-kind-class"><a href="_classes_.subclassa.html#nameproperty" class="tsd-kind-icon">name<wbr>Property</a></li>
-								<li class="tsd-kind-get-signature tsd-parent-kind-class"><a href="_classes_.subclassa.html#readonlynameproperty" class="tsd-kind-icon">read<wbr>Only<wbr>Name<wbr>Property</a></li>
-								<li class="tsd-kind-set-signature tsd-parent-kind-class"><a href="_classes_.subclassa.html#writeonlynameproperty" class="tsd-kind-icon">write<wbr>Only<wbr>Name<wbr>Property</a></li>
+								<li class="tsd-kind-accessor tsd-parent-kind-class"><a href="_classes_.SubClassA.html#nameProperty" class="tsd-kind-icon">name<wbr>Property</a></li>
+								<li class="tsd-kind-get-signature tsd-parent-kind-class"><a href="_classes_.SubClassA.html#readOnlyNameProperty" class="tsd-kind-icon">read<wbr>Only<wbr>Name<wbr>Property</a></li>
+								<li class="tsd-kind-set-signature tsd-parent-kind-class"><a href="_classes_.SubClassA.html#writeOnlyNameProperty" class="tsd-kind-icon">write<wbr>Only<wbr>Name<wbr>Property</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassa.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassa.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassa.html#getname" class="tsd-kind-icon">get<wbr>Name</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.subclassa.html#print" class="tsd-kind-icon">print</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.subclassa.html#printname" class="tsd-kind-icon">print<wbr>Name</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassa.html#setname" class="tsd-kind-icon">set<wbr>Name</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassa.html#catest" class="tsd-kind-icon">ca<wbr>Test</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassa.html#getinstance" class="tsd-kind-icon">get<wbr>Instance</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassa.html#getname-1" class="tsd-kind-icon">get<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.SubClassA.html#abstractMethod" class="tsd-kind-icon">abstract<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.SubClassA.html#arrowFunction" class="tsd-kind-icon">arrow<wbr>Function</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.SubClassA.html#getName" class="tsd-kind-icon">get<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.SubClassA.html#print" class="tsd-kind-icon">print</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.SubClassA.html#printName" class="tsd-kind-icon">print<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.SubClassA.html#setName" class="tsd-kind-icon">set<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassA.html#caTest" class="tsd-kind-icon">ca<wbr>Test</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassA.html#getInstance" class="tsd-kind-icon">get<wbr>Instance</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassA.html#getName-1" class="tsd-kind-icon">get<wbr>Name</a></li>
 							</ul>
 						</section>
 					</div>
@@ -148,13 +148,13 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Sub<wbr>ClassA<span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.subclassa.html" class="tsd-signature-type">SubClassA</a></li>
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Sub<wbr>ClassA<span class="tsd-signature-symbol">(</span>source<span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.subclassa.html" class="tsd-signature-type">SubClassA</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Sub<wbr>ClassA<span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.SubClassA.html" class="tsd-signature-type">SubClassA</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Sub<wbr>ClassA<span class="tsd-signature-symbol">(</span>source<span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.SubClassA.html" class="tsd-signature-type">SubClassA</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#constructor">constructor</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#constructor">constructor</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L76">classes.ts:76</a></li>
 								</ul>
@@ -165,11 +165,11 @@
 									<h5>name: <span class="tsd-signature-type">string</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.subclassa.html" class="tsd-signature-type">SubClassA</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.SubClassA.html" class="tsd-signature-type">SubClassA</a></h4>
 						</li>
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#constructor">constructor</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#constructor">constructor</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L79">classes.ts:79</a></li>
 								</ul>
@@ -177,10 +177,10 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>source: <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h5>
+									<h5>source: <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.subclassa.html" class="tsd-signature-type">SubClassA</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.SubClassA.html" class="tsd-signature-type">SubClassA</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -192,7 +192,7 @@
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> kind</h3>
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#kind">kind</a></p>
+						<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#kind">kind</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L63">classes.ts:63</a></li>
 						</ul>
@@ -208,8 +208,8 @@
 					<h3>name</h3>
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
-						<p>Implementation of <a href="../interfaces/_classes_.iprintnameinterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.iprintnameinterface.html#name">name</a></p>
-						<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#name">name</a></p>
+						<p>Implementation of <a href="../interfaces/_classes_.IPrintNameInterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.IPrintNameInterface.html#name">name</a></p>
+						<p>Overrides <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#name">name</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L199">classes.ts:199</a></li>
 						</ul>
@@ -218,9 +218,9 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 					<a name="instance" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> instance</h3>
-					<div class="tsd-signature tsd-kind-icon">instance<span class="tsd-signature-symbol">:</span> <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></div>
+					<div class="tsd-signature tsd-kind-icon">instance<span class="tsd-signature-symbol">:</span> <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#instance">instance</a></p>
+						<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#instance">instance</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L70">classes.ts:70</a></li>
 						</ul>
@@ -235,9 +235,9 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 					<a name="instances" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> instances</h3>
-					<div class="tsd-signature tsd-kind-icon">instances<span class="tsd-signature-symbol">:</span> <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">[]</span></div>
+					<div class="tsd-signature tsd-kind-icon">instances<span class="tsd-signature-symbol">:</span> <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#instances">instances</a></p>
+						<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#instances">instances</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L71">classes.ts:71</a></li>
 						</ul>
@@ -247,7 +247,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Accessors</h2>
 				<section class="tsd-panel tsd-member tsd-kind-accessor tsd-parent-kind-class">
-					<a name="nameproperty" class="tsd-anchor"></a>
+					<a name="nameProperty" class="tsd-anchor"></a>
 					<h3>name<wbr>Property</h3>
 					<ul class="tsd-signatures tsd-kind-accessor tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">get</span> nameProperty<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -262,7 +262,7 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Returns the name. See <a href="_classes_.baseclass.html#name">BaseClass.name</a>.</p>
+									<p>Returns the name. See <a href="_classes_.BaseClass.html#name">BaseClass.name</a>.</p>
 								</div>
 							</div>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -276,7 +276,7 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Sets the name. See <a href="_classes_.baseclass.html#name">BaseClass.name</a>.</p>
+									<p>Sets the name. See <a href="_classes_.BaseClass.html#name">BaseClass.name</a>.</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -296,7 +296,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-get-signature tsd-parent-kind-class">
-					<a name="readonlynameproperty" class="tsd-anchor"></a>
+					<a name="readOnlyNameProperty" class="tsd-anchor"></a>
 					<h3>read<wbr>Only<wbr>Name<wbr>Property</h3>
 					<ul class="tsd-signatures tsd-kind-get-signature tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">get</span> readOnlyNameProperty<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -310,7 +310,7 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Returns the name. See <a href="_classes_.baseclass.html#name">BaseClass.name</a>.</p>
+									<p>Returns the name. See <a href="_classes_.BaseClass.html#name">BaseClass.name</a>.</p>
 								</div>
 							</div>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -319,7 +319,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-set-signature tsd-parent-kind-class">
-					<a name="writeonlynameproperty" class="tsd-anchor"></a>
+					<a name="writeOnlyNameProperty" class="tsd-anchor"></a>
 					<h3>write<wbr>Only<wbr>Name<wbr>Property</h3>
 					<ul class="tsd-signatures tsd-kind-set-signature tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">set</span> writeOnlyNameProperty<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -333,7 +333,7 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Sets the name. See <a href="_classes_.baseclass.html#name">BaseClass.name</a>.</p>
+									<p>Sets the name. See <a href="_classes_.BaseClass.html#name">BaseClass.name</a>.</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -356,7 +356,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
-					<a name="abstractmethod" class="tsd-anchor"></a>
+					<a name="abstractMethod" class="tsd-anchor"></a>
 					<h3>abstract<wbr>Method</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
 						<li class="tsd-signature tsd-kind-icon">abstract<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -364,7 +364,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#abstractmethod">abstractMethod</a></p>
+								<p>Overrides <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#abstractMethod">abstractMethod</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L251">classes.ts:251</a></li>
 								</ul>
@@ -374,7 +374,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-					<a name="arrowfunction" class="tsd-anchor"></a>
+					<a name="arrowFunction" class="tsd-anchor"></a>
 					<h3>arrow<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">arrow<wbr>Function<span class="tsd-signature-symbol">(</span>param2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, param1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -382,7 +382,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#arrowfunction">arrowFunction</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#arrowFunction">arrowFunction</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L141">classes.ts:141</a></li>
 								</ul>
@@ -416,7 +416,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-					<a name="getname" class="tsd-anchor"></a>
+					<a name="getName" class="tsd-anchor"></a>
 					<h3>get<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -424,8 +424,8 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/_classes_.iprintnameinterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.iprintnameinterface.html#getname">getName</a></p>
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getname">getName</a></p>
+								<p>Implementation of <a href="../interfaces/_classes_.IPrintNameInterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.IPrintNameInterface.html#getName">getName</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#getName">getName</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L103">classes.ts:103</a></li>
 								</ul>
@@ -451,7 +451,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/_classes_.iprintnameinterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.iprintnameinterface.html#print">print</a></p>
+								<p>Implementation of <a href="../interfaces/_classes_.IPrintNameInterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.IPrintNameInterface.html#print">print</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L204">classes.ts:204</a></li>
 								</ul>
@@ -472,7 +472,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="printname" class="tsd-anchor"></a>
+					<a name="printName" class="tsd-anchor"></a>
 					<h3>print<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">print<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -480,7 +480,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/_classes_.iprintnameinterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.iprintnameinterface.html#printname">printName</a></p>
+								<p>Implementation of <a href="../interfaces/_classes_.IPrintNameInterface.html">IPrintNameInterface</a>.<a href="../interfaces/_classes_.IPrintNameInterface.html#printName">printName</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L209">classes.ts:209</a></li>
 								</ul>
@@ -495,7 +495,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-					<a name="setname" class="tsd-anchor"></a>
+					<a name="setName" class="tsd-anchor"></a>
 					<h3>set<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">set<wbr>Name<span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -503,7 +503,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#setname">setName</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#setName">setName</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L128">classes.ts:128</a></li>
 								</ul>
@@ -528,15 +528,15 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-					<a name="catest" class="tsd-anchor"></a>
+					<a name="caTest" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> ca<wbr>Test</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-						<li class="tsd-signature tsd-kind-icon">ca<wbr>Test<span class="tsd-signature-symbol">(</span>originalValues<span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a>, newRecord<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, fieldNames<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, mandatoryFields<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
+						<li class="tsd-signature tsd-kind-icon">ca<wbr>Test<span class="tsd-signature-symbol">(</span>originalValues<span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a>, newRecord<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, fieldNames<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, mandatoryFields<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#catest">caTest</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#caTest">caTest</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L168">classes.ts:168</a></li>
 								</ul>
@@ -551,7 +551,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>originalValues: <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h5>
+									<h5>originalValues: <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h5>
 								</li>
 								<li>
 									<h5>newRecord: <span class="tsd-signature-type">any</span></h5>
@@ -568,15 +568,15 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-					<a name="getinstance" class="tsd-anchor"></a>
+					<a name="getInstance" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> get<wbr>Instance</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-						<li class="tsd-signature tsd-kind-icon">get<wbr>Instance<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">get<wbr>Instance<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getinstance">getInstance</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#getInstance">getInstance</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L160">classes.ts:160</a></li>
 								</ul>
@@ -587,13 +587,13 @@
 								</div>
 								<p>Static functions should not be inherited.</p>
 							</div>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h4>
 							<p>An instance of BaseClass.</p>
 						</li>
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-					<a name="getname-1" class="tsd-anchor"></a>
+					<a name="getName-1" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> get<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -601,7 +601,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getname-1">getName</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#getName-1">getName</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L116">classes.ts:116</a></li>
 								</ul>
@@ -670,88 +670,88 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.subclassa.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_classes_.SubClassA.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
-								<a href="_classes_.subclassa.html#kind" class="tsd-kind-icon">kind</a>
+								<a href="_classes_.SubClassA.html#kind" class="tsd-kind-icon">kind</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-overwrite">
-								<a href="_classes_.subclassa.html#name" class="tsd-kind-icon">name</a>
+								<a href="_classes_.SubClassA.html#name" class="tsd-kind-icon">name</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassa.html#instance" class="tsd-kind-icon">instance</a>
+								<a href="_classes_.SubClassA.html#instance" class="tsd-kind-icon">instance</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassa.html#instances" class="tsd-kind-icon">instances</a>
+								<a href="_classes_.SubClassA.html#instances" class="tsd-kind-icon">instances</a>
 							</li>
 							<li class=" tsd-kind-accessor tsd-parent-kind-class">
-								<a href="_classes_.subclassa.html#nameproperty" class="tsd-kind-icon">name<wbr>Property</a>
+								<a href="_classes_.SubClassA.html#nameProperty" class="tsd-kind-icon">name<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-get-signature tsd-parent-kind-class">
-								<a href="_classes_.subclassa.html#readonlynameproperty" class="tsd-kind-icon">read<wbr>Only<wbr>Name<wbr>Property</a>
+								<a href="_classes_.SubClassA.html#readOnlyNameProperty" class="tsd-kind-icon">read<wbr>Only<wbr>Name<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-set-signature tsd-parent-kind-class">
-								<a href="_classes_.subclassa.html#writeonlynameproperty" class="tsd-kind-icon">write<wbr>Only<wbr>Name<wbr>Property</a>
+								<a href="_classes_.SubClassA.html#writeOnlyNameProperty" class="tsd-kind-icon">write<wbr>Only<wbr>Name<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
-								<a href="_classes_.subclassa.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a>
+								<a href="_classes_.SubClassA.html#abstractMethod" class="tsd-kind-icon">abstract<wbr>Method</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.subclassa.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a>
+								<a href="_classes_.SubClassA.html#arrowFunction" class="tsd-kind-icon">arrow<wbr>Function</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.subclassa.html#getname" class="tsd-kind-icon">get<wbr>Name</a>
+								<a href="_classes_.SubClassA.html#getName" class="tsd-kind-icon">get<wbr>Name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_classes_.subclassa.html#print" class="tsd-kind-icon">print</a>
+								<a href="_classes_.SubClassA.html#print" class="tsd-kind-icon">print</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_classes_.subclassa.html#printname" class="tsd-kind-icon">print<wbr>Name</a>
+								<a href="_classes_.SubClassA.html#printName" class="tsd-kind-icon">print<wbr>Name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.subclassa.html#setname" class="tsd-kind-icon">set<wbr>Name</a>
+								<a href="_classes_.SubClassA.html#setName" class="tsd-kind-icon">set<wbr>Name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassa.html#catest" class="tsd-kind-icon">ca<wbr>Test</a>
+								<a href="_classes_.SubClassA.html#caTest" class="tsd-kind-icon">ca<wbr>Test</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassa.html#getinstance" class="tsd-kind-icon">get<wbr>Instance</a>
+								<a href="_classes_.SubClassA.html#getInstance" class="tsd-kind-icon">get<wbr>Instance</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassa.html#getname-1" class="tsd-kind-icon">get<wbr>Name</a>
+								<a href="_classes_.SubClassA.html#getName-1" class="tsd-kind-icon">get<wbr>Name</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="../interfaces/_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_classes_.subclassb.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassb.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_classes_.html">&quot;classes&quot;</a>
 				</li>
 				<li>
-					<a href="_classes_.subclassb.html">SubClassB</a>
+					<a href="_classes_.SubClassB.html">SubClassB</a>
 				</li>
 			</ul>
 			<h1>Class SubClassB</h1>
@@ -81,7 +81,7 @@
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a>
+						<a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a>
 						<ul class="tsd-hierarchy">
 							<li>
 								<span class="target">SubClassB</span>
@@ -93,7 +93,7 @@
 			<section class="tsd-panel">
 				<h3>Implements</h3>
 				<ul class="tsd-hierarchy">
-					<li><a href="../interfaces/_classes_.inameinterface.html" class="tsd-signature-type">INameInterface</a></li>
+					<li><a href="../interfaces/_classes_.INameInterface.html" class="tsd-signature-type">INameInterface</a></li>
 				</ul>
 			</section>
 			<section class="tsd-panel-group tsd-index-group">
@@ -103,29 +103,29 @@
 						<section class="tsd-index-section ">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassb.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.SubClassB.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_classes_.subclassb.html#kind" class="tsd-kind-icon">kind</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassb.html#name" class="tsd-kind-icon">name</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassb.html#instance" class="tsd-kind-icon">instance</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassb.html#instances" class="tsd-kind-icon">instances</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_classes_.SubClassB.html#kind" class="tsd-kind-icon">kind</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.SubClassB.html#name" class="tsd-kind-icon">name</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassB.html#instance" class="tsd-kind-icon">instance</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassB.html#instances" class="tsd-kind-icon">instances</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.subclassb.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassb.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.subclassb.html#dosomething" class="tsd-kind-icon">do<wbr>Something</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassb.html#getname" class="tsd-kind-icon">get<wbr>Name</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.subclassb.html#setname" class="tsd-kind-icon">set<wbr>Name</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassb.html#catest" class="tsd-kind-icon">ca<wbr>Test</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassb.html#getinstance" class="tsd-kind-icon">get<wbr>Instance</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.subclassb.html#getname-1" class="tsd-kind-icon">get<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite"><a href="_classes_.SubClassB.html#abstractMethod" class="tsd-kind-icon">abstract<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.SubClassB.html#arrowFunction" class="tsd-kind-icon">arrow<wbr>Function</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_classes_.SubClassB.html#doSomething" class="tsd-kind-icon">do<wbr>Something</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.SubClassB.html#getName" class="tsd-kind-icon">get<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_classes_.SubClassB.html#setName" class="tsd-kind-icon">set<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassB.html#caTest" class="tsd-kind-icon">ca<wbr>Test</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassB.html#getInstance" class="tsd-kind-icon">get<wbr>Instance</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static"><a href="_classes_.SubClassB.html#getName-1" class="tsd-kind-icon">get<wbr>Name</a></li>
 							</ul>
 						</section>
 					</div>
@@ -137,12 +137,12 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Sub<wbr>ClassB<span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Sub<wbr>ClassB<span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#constructor">constructor</a></p>
+								<p>Overrides <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#constructor">constructor</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L263">classes.ts:263</a></li>
 								</ul>
@@ -153,7 +153,7 @@
 									<h5>name: <span class="tsd-signature-type">string</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -165,7 +165,7 @@
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> kind</h3>
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#kind">kind</a></p>
+						<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#kind">kind</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L63">classes.ts:63</a></li>
 						</ul>
@@ -181,8 +181,8 @@
 					<h3>name</h3>
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
-						<p>Implementation of <a href="../interfaces/_classes_.inameinterface.html">INameInterface</a>.<a href="../interfaces/_classes_.inameinterface.html#name">name</a></p>
-						<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#name">name</a></p>
+						<p>Implementation of <a href="../interfaces/_classes_.INameInterface.html">INameInterface</a>.<a href="../interfaces/_classes_.INameInterface.html#name">name</a></p>
+						<p>Overrides <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#name">name</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L263">classes.ts:263</a></li>
 						</ul>
@@ -191,9 +191,9 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 					<a name="instance" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> instance</h3>
-					<div class="tsd-signature tsd-kind-icon">instance<span class="tsd-signature-symbol">:</span> <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></div>
+					<div class="tsd-signature tsd-kind-icon">instance<span class="tsd-signature-symbol">:</span> <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#instance">instance</a></p>
+						<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#instance">instance</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L70">classes.ts:70</a></li>
 						</ul>
@@ -208,9 +208,9 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 					<a name="instances" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> instances</h3>
-					<div class="tsd-signature tsd-kind-icon">instances<span class="tsd-signature-symbol">:</span> <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">[]</span></div>
+					<div class="tsd-signature tsd-kind-icon">instances<span class="tsd-signature-symbol">:</span> <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#instances">instances</a></p>
+						<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#instances">instances</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L71">classes.ts:71</a></li>
 						</ul>
@@ -220,7 +220,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
-					<a name="abstractmethod" class="tsd-anchor"></a>
+					<a name="abstractMethod" class="tsd-anchor"></a>
 					<h3>abstract<wbr>Method</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
 						<li class="tsd-signature tsd-kind-icon">abstract<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -228,7 +228,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Overrides <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#abstractmethod">abstractMethod</a></p>
+								<p>Overrides <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#abstractMethod">abstractMethod</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L269">classes.ts:269</a></li>
 								</ul>
@@ -238,7 +238,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-					<a name="arrowfunction" class="tsd-anchor"></a>
+					<a name="arrowFunction" class="tsd-anchor"></a>
 					<h3>arrow<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">arrow<wbr>Function<span class="tsd-signature-symbol">(</span>param2<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, param1<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -246,7 +246,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#arrowfunction">arrowFunction</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#arrowFunction">arrowFunction</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L141">classes.ts:141</a></li>
 								</ul>
@@ -280,10 +280,10 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="dosomething" class="tsd-anchor"></a>
+					<a name="doSomething" class="tsd-anchor"></a>
 					<h3>do<wbr>Something</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">do<wbr>Something<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><a href="_classes_.subclassa.html" class="tsd-signature-type">SubClassA</a><span class="tsd-signature-symbol">, </span><a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">do<wbr>Something<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><a href="_classes_.SubClassA.html" class="tsd-signature-type">SubClassA</a><span class="tsd-signature-symbol">, </span><a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -295,7 +295,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>value: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><a href="_classes_.subclassa.html" class="tsd-signature-type">SubClassA</a><span class="tsd-signature-symbol">, </span><a href="_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a><span class="tsd-signature-symbol">]</span></h5>
+									<h5>value: <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><a href="_classes_.SubClassA.html" class="tsd-signature-type">SubClassA</a><span class="tsd-signature-symbol">, </span><a href="_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a><span class="tsd-signature-symbol">]</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -303,7 +303,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-					<a name="getname" class="tsd-anchor"></a>
+					<a name="getName" class="tsd-anchor"></a>
 					<h3>get<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -311,8 +311,8 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/_classes_.inameinterface.html">INameInterface</a>.<a href="../interfaces/_classes_.inameinterface.html#getname">getName</a></p>
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getname">getName</a></p>
+								<p>Implementation of <a href="../interfaces/_classes_.INameInterface.html">INameInterface</a>.<a href="../interfaces/_classes_.INameInterface.html#getName">getName</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#getName">getName</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L103">classes.ts:103</a></li>
 								</ul>
@@ -330,7 +330,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-					<a name="setname" class="tsd-anchor"></a>
+					<a name="setName" class="tsd-anchor"></a>
 					<h3>set<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">set<wbr>Name<span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -338,7 +338,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#setname">setName</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#setName">setName</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L128">classes.ts:128</a></li>
 								</ul>
@@ -363,15 +363,15 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-					<a name="catest" class="tsd-anchor"></a>
+					<a name="caTest" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> ca<wbr>Test</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-						<li class="tsd-signature tsd-kind-icon">ca<wbr>Test<span class="tsd-signature-symbol">(</span>originalValues<span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a>, newRecord<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, fieldNames<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, mandatoryFields<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
+						<li class="tsd-signature tsd-kind-icon">ca<wbr>Test<span class="tsd-signature-symbol">(</span>originalValues<span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a>, newRecord<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, fieldNames<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, mandatoryFields<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#catest">caTest</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#caTest">caTest</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L168">classes.ts:168</a></li>
 								</ul>
@@ -386,7 +386,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>originalValues: <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h5>
+									<h5>originalValues: <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h5>
 								</li>
 								<li>
 									<h5>newRecord: <span class="tsd-signature-type">any</span></h5>
@@ -403,15 +403,15 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-					<a name="getinstance" class="tsd-anchor"></a>
+					<a name="getInstance" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> get<wbr>Instance</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-						<li class="tsd-signature tsd-kind-icon">get<wbr>Instance<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">get<wbr>Instance<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getinstance">getInstance</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#getInstance">getInstance</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L160">classes.ts:160</a></li>
 								</ul>
@@ -422,13 +422,13 @@
 								</div>
 								<p>Static functions should not be inherited.</p>
 							</div>
-							<h4 class="tsd-returns-title">Returns <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></h4>
 							<p>An instance of BaseClass.</p>
 						</li>
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-					<a name="getname-1" class="tsd-anchor"></a>
+					<a name="getName-1" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> get<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -436,7 +436,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.baseclass.html">BaseClass</a>.<a href="_classes_.baseclass.html#getname-1">getName</a></p>
+								<p>Inherited from <a href="_classes_.BaseClass.html">BaseClass</a>.<a href="_classes_.BaseClass.html#getName-1">getName</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L116">classes.ts:116</a></li>
 								</ul>
@@ -505,76 +505,76 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite">
-								<a href="_classes_.subclassb.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_classes_.SubClassB.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
-								<a href="_classes_.subclassb.html#kind" class="tsd-kind-icon">kind</a>
+								<a href="_classes_.SubClassB.html#kind" class="tsd-kind-icon">kind</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-overwrite">
-								<a href="_classes_.subclassb.html#name" class="tsd-kind-icon">name</a>
+								<a href="_classes_.SubClassB.html#name" class="tsd-kind-icon">name</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassb.html#instance" class="tsd-kind-icon">instance</a>
+								<a href="_classes_.SubClassB.html#instance" class="tsd-kind-icon">instance</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassb.html#instances" class="tsd-kind-icon">instances</a>
+								<a href="_classes_.SubClassB.html#instances" class="tsd-kind-icon">instances</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
-								<a href="_classes_.subclassb.html#abstractmethod" class="tsd-kind-icon">abstract<wbr>Method</a>
+								<a href="_classes_.SubClassB.html#abstractMethod" class="tsd-kind-icon">abstract<wbr>Method</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.subclassb.html#arrowfunction" class="tsd-kind-icon">arrow<wbr>Function</a>
+								<a href="_classes_.SubClassB.html#arrowFunction" class="tsd-kind-icon">arrow<wbr>Function</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_classes_.subclassb.html#dosomething" class="tsd-kind-icon">do<wbr>Something</a>
+								<a href="_classes_.SubClassB.html#doSomething" class="tsd-kind-icon">do<wbr>Something</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.subclassb.html#getname" class="tsd-kind-icon">get<wbr>Name</a>
+								<a href="_classes_.SubClassB.html#getName" class="tsd-kind-icon">get<wbr>Name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-								<a href="_classes_.subclassb.html#setname" class="tsd-kind-icon">set<wbr>Name</a>
+								<a href="_classes_.SubClassB.html#setName" class="tsd-kind-icon">set<wbr>Name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassb.html#catest" class="tsd-kind-icon">ca<wbr>Test</a>
+								<a href="_classes_.SubClassB.html#caTest" class="tsd-kind-icon">ca<wbr>Test</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassb.html#getinstance" class="tsd-kind-icon">get<wbr>Instance</a>
+								<a href="_classes_.SubClassB.html#getInstance" class="tsd-kind-icon">get<wbr>Instance</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static">
-								<a href="_classes_.subclassb.html#getname-1" class="tsd-kind-icon">get<wbr>Name</a>
+								<a href="_classes_.SubClassB.html#getName-1" class="tsd-kind-icon">get<wbr>Name</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="../interfaces/_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
+++ b/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_default_export_.html">&quot;default-export&quot;</a>
 				</li>
 				<li>
-					<a href="_default_export_.defaultexportedclass.html">DefaultExportedClass</a>
+					<a href="_default_export_.DefaultExportedClass.html">DefaultExportedClass</a>
 				</li>
 			</ul>
 			<h1>Class DefaultExportedClass</h1>
@@ -93,19 +93,19 @@
 						<section class="tsd-index-section ">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_default_export_.defaultexportedclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_default_export_.DefaultExportedClass.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_default_export_.defaultexportedclass.html#exportedproperty" class="tsd-kind-icon">exported<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_default_export_.DefaultExportedClass.html#exportedProperty" class="tsd-kind-icon">exported<wbr>Property</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_default_export_.defaultexportedclass.html#getexportedproperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_default_export_.DefaultExportedClass.html#getExportedProperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a></li>
 							</ul>
 						</section>
 					</div>
@@ -117,7 +117,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Default<wbr>Exported<wbr>Class<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_default_export_.defaultexportedclass.html" class="tsd-signature-type">DefaultExportedClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Default<wbr>Exported<wbr>Class<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_default_export_.DefaultExportedClass.html" class="tsd-signature-type">DefaultExportedClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -131,7 +131,7 @@
 									<p>This is the constructor of the default exported class.</p>
 								</div>
 							</div>
-							<h4 class="tsd-returns-title">Returns <a href="_default_export_.defaultexportedclass.html" class="tsd-signature-type">DefaultExportedClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_default_export_.DefaultExportedClass.html" class="tsd-signature-type">DefaultExportedClass</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -139,7 +139,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
-					<a name="exportedproperty" class="tsd-anchor"></a>
+					<a name="exportedProperty" class="tsd-anchor"></a>
 					<h3>exported<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">exported<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -157,7 +157,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="getexportedproperty" class="tsd-anchor"></a>
+					<a name="getExportedProperty" class="tsd-anchor"></a>
 					<h3>get<wbr>Exported<wbr>Property</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Exported<wbr>Property<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -232,23 +232,23 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_default_export_.defaultexportedclass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a>
+						<a href="_default_export_.DefaultExportedClass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class">
-								<a href="_default_export_.defaultexportedclass.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_default_export_.DefaultExportedClass.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class">
-								<a href="_default_export_.defaultexportedclass.html#exportedproperty" class="tsd-kind-icon">exported<wbr>Property</a>
+								<a href="_default_export_.DefaultExportedClass.html#exportedProperty" class="tsd-kind-icon">exported<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_default_export_.defaultexportedclass.html#getexportedproperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a>
+								<a href="_default_export_.DefaultExportedClass.html#getExportedProperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_default_export_.notexportedclassname.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class<wbr>Name</a>
+						<a href="_default_export_.NotExportedClassName.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class<wbr>Name</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_default_export_.notexportedclassname.html
+++ b/src/test/renderer/specs/classes/_default_export_.notexportedclassname.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_default_export_.html">&quot;default-export&quot;</a>
 				</li>
 				<li>
-					<a href="_default_export_.notexportedclassname.html">NotExportedClassName</a>
+					<a href="_default_export_.NotExportedClassName.html">NotExportedClassName</a>
 				</li>
 			</ul>
 			<h1>Class NotExportedClassName</h1>
@@ -94,19 +94,19 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported"><a href="_default_export_.notexportedclassname.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported"><a href="_default_export_.NotExportedClassName.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_default_export_.notexportedclassname.html#notexportedproperty" class="tsd-kind-icon">not<wbr>Exported<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_default_export_.NotExportedClassName.html#notExportedProperty" class="tsd-kind-icon">not<wbr>Exported<wbr>Property</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-not-exported"><a href="_default_export_.notexportedclassname.html#getnotexportedproperty" class="tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-not-exported"><a href="_default_export_.NotExportedClassName.html#getNotExportedProperty" class="tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property</a></li>
 							</ul>
 						</section>
 					</div>
@@ -118,7 +118,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Not<wbr>Exported<wbr>Class<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_default_export_.notexportedclassname.html" class="tsd-signature-type">NotExportedClassName</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Not<wbr>Exported<wbr>Class<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_default_export_.NotExportedClassName.html" class="tsd-signature-type">NotExportedClassName</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -132,7 +132,7 @@
 									<p>This is the constructor of the NotExportedClassName class.</p>
 								</div>
 							</div>
-							<h4 class="tsd-returns-title">Returns <a href="_default_export_.notexportedclassname.html" class="tsd-signature-type">NotExportedClassName</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_default_export_.NotExportedClassName.html" class="tsd-signature-type">NotExportedClassName</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -140,7 +140,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-					<a name="notexportedproperty" class="tsd-anchor"></a>
+					<a name="notExportedProperty" class="tsd-anchor"></a>
 					<h3>not<wbr>Exported<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">not<wbr>Exported<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -158,7 +158,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
-					<a name="getnotexportedproperty" class="tsd-anchor"></a>
+					<a name="getNotExportedProperty" class="tsd-anchor"></a>
 					<h3>get<wbr>Not<wbr>Exported<wbr>Property</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -231,21 +231,21 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_default_export_.defaultexportedclass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a>
+						<a href="_default_export_.DefaultExportedClass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_default_export_.notexportedclassname.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class<wbr>Name</a>
+						<a href="_default_export_.NotExportedClassName.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class<wbr>Name</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_default_export_.notexportedclassname.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_default_export_.NotExportedClassName.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_default_export_.notexportedclassname.html#notexportedproperty" class="tsd-kind-icon">not<wbr>Exported<wbr>Property</a>
+								<a href="_default_export_.NotExportedClassName.html#notExportedProperty" class="tsd-kind-icon">not<wbr>Exported<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_default_export_.notexportedclassname.html#getnotexportedproperty" class="tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property</a>
+								<a href="_default_export_.NotExportedClassName.html#getNotExportedProperty" class="tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property</a>
 							</li>
 						</ul>
 					</li>

--- a/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
+++ b/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_flattened_.html">&quot;flattened&quot;</a>
 				</li>
 				<li>
-					<a href="_flattened_.flattenedclass.html">flattenedClass</a>
+					<a href="_flattened_.flattenedClass.html">flattenedClass</a>
 				</li>
 			</ul>
 			<h1>Class flattenedClass</h1>
@@ -91,16 +91,16 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedClass.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#callback" class="tsd-kind-icon">callback</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#indexed" class="tsd-kind-icon">indexed</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#multiplecallsignatures" class="tsd-kind-icon">multiple<wbr>Call<wbr>Signatures</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#options" class="tsd-kind-icon">options</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedClass.html#callback" class="tsd-kind-icon">callback</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedClass.html#indexed" class="tsd-kind-icon">indexed</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedClass.html#multipleCallSignatures" class="tsd-kind-icon">multiple<wbr>Call<wbr>Signatures</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedClass.html#options" class="tsd-kind-icon">options</a></li>
 							</ul>
 						</section>
 					</div>
@@ -112,7 +112,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">new flattened<wbr>Class<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_flattened_.flattenedclass.html" class="tsd-signature-type">flattenedClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new flattened<wbr>Class<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_flattened_.flattenedClass.html" class="tsd-signature-type">flattenedClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -165,7 +165,7 @@
 									</ul>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_flattened_.flattenedclass.html" class="tsd-signature-type">flattenedClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_flattened_.flattenedClass.html" class="tsd-signature-type">flattenedClass</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -255,7 +255,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-					<a name="multiplecallsignatures" class="tsd-anchor"></a>
+					<a name="multipleCallSignatures" class="tsd-anchor"></a>
 					<h3>multiple<wbr>Call<wbr>Signatures</h3>
 					<div class="tsd-signature tsd-kind-icon">multiple<wbr>Call<wbr>Signatures<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
@@ -279,7 +279,7 @@
 							<li class="tsd-parameter-siganture">
 								<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-property tsd-is-not-exported">
 									<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
-									<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_flattened_.flattenedclass.html" class="tsd-signature-type">flattenedClass</a></li>
+									<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_flattened_.flattenedClass.html" class="tsd-signature-type">flattenedClass</a></li>
 								</ul>
 								<ul class="tsd-descriptions">
 									<li class="tsd-description">
@@ -306,7 +306,7 @@
 												</div>
 											</li>
 										</ul>
-										<h4 class="tsd-returns-title">Returns <a href="_flattened_.flattenedclass.html" class="tsd-signature-type">flattenedClass</a></h4>
+										<h4 class="tsd-returns-title">Returns <a href="_flattened_.flattenedClass.html" class="tsd-signature-type">flattenedClass</a></h4>
 										<p>The calling Foo.</p>
 									</li>
 								</ul>
@@ -414,35 +414,35 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_flattened_.flattenedclass.html" class="tsd-kind-icon">flattened<wbr>Class</a>
+						<a href="_flattened_.flattenedClass.html" class="tsd-kind-icon">flattened<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_flattened_.flattenedclass.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_flattened_.flattenedClass.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_flattened_.flattenedclass.html#callback" class="tsd-kind-icon">callback</a>
+								<a href="_flattened_.flattenedClass.html#callback" class="tsd-kind-icon">callback</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_flattened_.flattenedclass.html#indexed" class="tsd-kind-icon">indexed</a>
+								<a href="_flattened_.flattenedClass.html#indexed" class="tsd-kind-icon">indexed</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_flattened_.flattenedclass.html#multiplecallsignatures" class="tsd-kind-icon">multiple<wbr>Call<wbr>Signatures</a>
+								<a href="_flattened_.flattenedClass.html#multipleCallSignatures" class="tsd-kind-icon">multiple<wbr>Call<wbr>Signatures</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_flattened_.flattenedclass.html#options" class="tsd-kind-icon">options</a>
+								<a href="_flattened_.flattenedClass.html#options" class="tsd-kind-icon">options</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_flattened_.html#flattenedcallback" class="tsd-kind-icon">flattened<wbr>Callback</a>
+						<a href="../modules/_flattened_.html#flattenedCallback" class="tsd-kind-icon">flattened<wbr>Callback</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_flattened_.html#flattenedindexsignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a>
+						<a href="../modules/_flattened_.html#flattenedIndexSignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_flattened_.html#flattenedparameter" class="tsd-kind-icon">flattened<wbr>Parameter</a>
+						<a href="../modules/_flattened_.html#flattenedParameter" class="tsd-kind-icon">flattened<wbr>Parameter</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_single_export_.notexportedclass.html
+++ b/src/test/renderer/specs/classes/_single_export_.notexportedclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_single_export_.html">&quot;single-export&quot;</a>
 				</li>
 				<li>
-					<a href="_single_export_.notexportedclass.html">NotExportedClass</a>
+					<a href="_single_export_.NotExportedClass.html">NotExportedClass</a>
 				</li>
 			</ul>
 			<h1>Class NotExportedClass</h1>
@@ -91,19 +91,19 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported"><a href="_single_export_.notexportedclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported"><a href="_single_export_.NotExportedClass.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_single_export_.notexportedclass.html#notexportedproperty" class="tsd-kind-icon">not<wbr>Exported<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_single_export_.NotExportedClass.html#notExportedProperty" class="tsd-kind-icon">not<wbr>Exported<wbr>Property</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-not-exported"><a href="_single_export_.notexportedclass.html#getnotexportedproperty" class="tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-not-exported"><a href="_single_export_.NotExportedClass.html#getNotExportedProperty" class="tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property</a></li>
 							</ul>
 						</section>
 					</div>
@@ -115,7 +115,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Not<wbr>Exported<wbr>Class<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_single_export_.notexportedclass.html" class="tsd-signature-type">NotExportedClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Not<wbr>Exported<wbr>Class<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_single_export_.NotExportedClass.html" class="tsd-signature-type">NotExportedClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -129,7 +129,7 @@
 									<p>This is the constructor of the not exported class.</p>
 								</div>
 							</div>
-							<h4 class="tsd-returns-title">Returns <a href="_single_export_.notexportedclass.html" class="tsd-signature-type">NotExportedClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_single_export_.NotExportedClass.html" class="tsd-signature-type">NotExportedClass</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -137,7 +137,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-					<a name="notexportedproperty" class="tsd-anchor"></a>
+					<a name="notExportedProperty" class="tsd-anchor"></a>
 					<h3>not<wbr>Exported<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">not<wbr>Exported<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -155,7 +155,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
-					<a name="getnotexportedproperty" class="tsd-anchor"></a>
+					<a name="getNotExportedProperty" class="tsd-anchor"></a>
 					<h3>get<wbr>Not<wbr>Exported<wbr>Property</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -230,23 +230,23 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_single_export_.notexportedclass.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class</a>
+						<a href="_single_export_.NotExportedClass.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_single_export_.notexportedclass.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_single_export_.NotExportedClass.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_single_export_.notexportedclass.html#notexportedproperty" class="tsd-kind-icon">not<wbr>Exported<wbr>Property</a>
+								<a href="_single_export_.NotExportedClass.html#notExportedProperty" class="tsd-kind-icon">not<wbr>Exported<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_single_export_.notexportedclass.html#getnotexportedproperty" class="tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property</a>
+								<a href="_single_export_.NotExportedClass.html#getNotExportedProperty" class="tsd-kind-icon">get<wbr>Not<wbr>Exported<wbr>Property</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_single_export_.singleexportedclass.html" class="tsd-kind-icon">Single<wbr>Exported<wbr>Class</a>
+						<a href="_single_export_.SingleExportedClass.html" class="tsd-kind-icon">Single<wbr>Exported<wbr>Class</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_single_export_.singleexportedclass.html
+++ b/src/test/renderer/specs/classes/_single_export_.singleexportedclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_single_export_.html">&quot;single-export&quot;</a>
 				</li>
 				<li>
-					<a href="_single_export_.singleexportedclass.html">SingleExportedClass</a>
+					<a href="_single_export_.SingleExportedClass.html">SingleExportedClass</a>
 				</li>
 			</ul>
 			<h1>Class SingleExportedClass</h1>
@@ -93,19 +93,19 @@
 						<section class="tsd-index-section ">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_single_export_.singleexportedclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_single_export_.SingleExportedClass.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_single_export_.singleexportedclass.html#exportedproperty" class="tsd-kind-icon">exported<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_single_export_.SingleExportedClass.html#exportedProperty" class="tsd-kind-icon">exported<wbr>Property</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_single_export_.singleexportedclass.html#getexportedproperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_single_export_.SingleExportedClass.html#getExportedProperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a></li>
 							</ul>
 						</section>
 					</div>
@@ -117,7 +117,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Single<wbr>Exported<wbr>Class<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_single_export_.singleexportedclass.html" class="tsd-signature-type">SingleExportedClass</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Single<wbr>Exported<wbr>Class<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_single_export_.SingleExportedClass.html" class="tsd-signature-type">SingleExportedClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -131,7 +131,7 @@
 									<p>This is the constructor of the exported class.</p>
 								</div>
 							</div>
-							<h4 class="tsd-returns-title">Returns <a href="_single_export_.singleexportedclass.html" class="tsd-signature-type">SingleExportedClass</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_single_export_.SingleExportedClass.html" class="tsd-signature-type">SingleExportedClass</a></h4>
 						</li>
 					</ul>
 				</section>
@@ -139,7 +139,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
-					<a name="exportedproperty" class="tsd-anchor"></a>
+					<a name="exportedProperty" class="tsd-anchor"></a>
 					<h3>exported<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">exported<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -157,7 +157,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
-					<a name="getexportedproperty" class="tsd-anchor"></a>
+					<a name="getExportedProperty" class="tsd-anchor"></a>
 					<h3>get<wbr>Exported<wbr>Property</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Exported<wbr>Property<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -230,21 +230,21 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_single_export_.notexportedclass.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class</a>
+						<a href="_single_export_.NotExportedClass.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module">
-						<a href="_single_export_.singleexportedclass.html" class="tsd-kind-icon">Single<wbr>Exported<wbr>Class</a>
+						<a href="_single_export_.SingleExportedClass.html" class="tsd-kind-icon">Single<wbr>Exported<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-constructor tsd-parent-kind-class">
-								<a href="_single_export_.singleexportedclass.html#constructor" class="tsd-kind-icon">constructor</a>
+								<a href="_single_export_.SingleExportedClass.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class">
-								<a href="_single_export_.singleexportedclass.html#exportedproperty" class="tsd-kind-icon">exported<wbr>Property</a>
+								<a href="_single_export_.SingleExportedClass.html#exportedProperty" class="tsd-kind-icon">exported<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
-								<a href="_single_export_.singleexportedclass.html#getexportedproperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a>
+								<a href="_single_export_.SingleExportedClass.html#getExportedProperty" class="tsd-kind-icon">get<wbr>Exported<wbr>Property</a>
 							</li>
 						</ul>
 					</li>

--- a/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_typescript_1_3_.html">&quot;typescript-1.3&quot;</a>
 				</li>
 				<li>
-					<a href="_typescript_1_3_.classwithprotectedmembers.html">ClassWithProtectedMembers</a>
+					<a href="_typescript_1_3_.ClassWithProtectedMembers.html">ClassWithProtectedMembers</a>
 				</li>
 			</ul>
 			<h1>Class ClassWithProtectedMembers</h1>
@@ -83,7 +83,7 @@
 						<span class="target">ClassWithProtectedMembers</span>
 						<ul class="tsd-hierarchy">
 							<li>
-								<a href="_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-signature-type">SubclassWithProtectedMembers</a>
+								<a href="_typescript_1_3_.SubclassWithProtectedMembers.html" class="tsd-signature-type">SubclassWithProtectedMembers</a>
 							</li>
 						</ul>
 					</li>
@@ -96,17 +96,17 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#privateproperty" class="tsd-kind-icon">private<wbr>Property</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-not-exported"><a href="_typescript_1_3_.ClassWithProtectedMembers.html#privateProperty" class="tsd-kind-icon">private<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.ClassWithProtectedMembers.html#protectedProperty" class="tsd-kind-icon">protected<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_typescript_1_3_.ClassWithProtectedMembers.html#publicProperty" class="tsd-kind-icon">public<wbr>Property</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#privatemethod" class="tsd-kind-icon">private<wbr>Method</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-not-exported"><a href="_typescript_1_3_.ClassWithProtectedMembers.html#privateMethod" class="tsd-kind-icon">private<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.ClassWithProtectedMembers.html#protectedMethod" class="tsd-kind-icon">protected<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-not-exported"><a href="_typescript_1_3_.ClassWithProtectedMembers.html#publicMethod" class="tsd-kind-icon">public<wbr>Method</a></li>
 							</ul>
 						</section>
 					</div>
@@ -115,7 +115,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
-					<a name="privateproperty" class="tsd-anchor"></a>
+					<a name="privateProperty" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> private<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">private<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
@@ -130,7 +130,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
-					<a name="protectedproperty" class="tsd-anchor"></a>
+					<a name="protectedProperty" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> protected<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">protected<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -145,7 +145,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-					<a name="publicproperty" class="tsd-anchor"></a>
+					<a name="publicProperty" class="tsd-anchor"></a>
 					<h3>public<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -163,7 +163,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
-					<a name="privatemethod" class="tsd-anchor"></a>
+					<a name="privateMethod" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> private<wbr>Method</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">private<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -185,7 +185,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
-					<a name="protectedmethod" class="tsd-anchor"></a>
+					<a name="protectedMethod" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> protected<wbr>Method</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">protected<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -207,7 +207,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
-					<a name="publicmethod" class="tsd-anchor"></a>
+					<a name="publicMethod" class="tsd-anchor"></a>
 					<h3>public<wbr>Method</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">public<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -282,35 +282,35 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_3_.classwithprotectedmembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a>
+						<a href="_typescript_1_3_.ClassWithProtectedMembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a>
 						<ul>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
-								<a href="_typescript_1_3_.classwithprotectedmembers.html#privateproperty" class="tsd-kind-icon">private<wbr>Property</a>
+								<a href="_typescript_1_3_.ClassWithProtectedMembers.html#privateProperty" class="tsd-kind-icon">private<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
-								<a href="_typescript_1_3_.classwithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a>
+								<a href="_typescript_1_3_.ClassWithProtectedMembers.html#protectedProperty" class="tsd-kind-icon">protected<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_typescript_1_3_.classwithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a>
+								<a href="_typescript_1_3_.ClassWithProtectedMembers.html#publicProperty" class="tsd-kind-icon">public<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
-								<a href="_typescript_1_3_.classwithprotectedmembers.html#privatemethod" class="tsd-kind-icon">private<wbr>Method</a>
+								<a href="_typescript_1_3_.ClassWithProtectedMembers.html#privateMethod" class="tsd-kind-icon">private<wbr>Method</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
-								<a href="_typescript_1_3_.classwithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a>
+								<a href="_typescript_1_3_.ClassWithProtectedMembers.html#protectedMethod" class="tsd-kind-icon">protected<wbr>Method</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
-								<a href="_typescript_1_3_.classwithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a>
+								<a href="_typescript_1_3_.ClassWithProtectedMembers.html#publicMethod" class="tsd-kind-icon">public<wbr>Method</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a>
+						<a href="_typescript_1_3_.SubclassWithProtectedMembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_3_.html#tupletype" class="tsd-kind-icon">tuple<wbr>Type</a>
+						<a href="../modules/_typescript_1_3_.html#tupleType" class="tsd-kind-icon">tuple<wbr>Type</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_typescript_1_3_.html">&quot;typescript-1.3&quot;</a>
 				</li>
 				<li>
-					<a href="_typescript_1_3_.subclasswithprotectedmembers.html">SubclassWithProtectedMembers</a>
+					<a href="_typescript_1_3_.SubclassWithProtectedMembers.html">SubclassWithProtectedMembers</a>
 				</li>
 			</ul>
 			<h1>Class SubclassWithProtectedMembers</h1>
@@ -80,7 +80,7 @@
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<a href="_typescript_1_3_.classwithprotectedmembers.html" class="tsd-signature-type">ClassWithProtectedMembers</a>
+						<a href="_typescript_1_3_.ClassWithProtectedMembers.html" class="tsd-signature-type">ClassWithProtectedMembers</a>
 						<ul class="tsd-hierarchy">
 							<li>
 								<span class="target">SubclassWithProtectedMembers</span>
@@ -96,15 +96,15 @@
 						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.SubclassWithProtectedMembers.html#protectedProperty" class="tsd-kind-icon">protected<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported"><a href="_typescript_1_3_.SubclassWithProtectedMembers.html#publicProperty" class="tsd-kind-icon">public<wbr>Property</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.SubclassWithProtectedMembers.html#protectedMethod" class="tsd-kind-icon">protected<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported"><a href="_typescript_1_3_.SubclassWithProtectedMembers.html#publicMethod" class="tsd-kind-icon">public<wbr>Method</a></li>
 							</ul>
 						</section>
 					</div>
@@ -113,11 +113,11 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
 				<h2>Properties</h2>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
-					<a name="protectedproperty" class="tsd-anchor"></a>
+					<a name="protectedProperty" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> protected<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">protected<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_typescript_1_3_.classwithprotectedmembers.html">ClassWithProtectedMembers</a>.<a href="_typescript_1_3_.classwithprotectedmembers.html#protectedproperty">protectedProperty</a></p>
+						<p>Inherited from <a href="_typescript_1_3_.ClassWithProtectedMembers.html">ClassWithProtectedMembers</a>.<a href="_typescript_1_3_.ClassWithProtectedMembers.html#protectedProperty">protectedProperty</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.3.ts#L14">typescript-1.3.ts:14</a></li>
 						</ul>
@@ -129,11 +129,11 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
-					<a name="publicproperty" class="tsd-anchor"></a>
+					<a name="publicProperty" class="tsd-anchor"></a>
 					<h3>public<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_typescript_1_3_.classwithprotectedmembers.html">ClassWithProtectedMembers</a>.<a href="_typescript_1_3_.classwithprotectedmembers.html#publicproperty">publicProperty</a></p>
+						<p>Inherited from <a href="_typescript_1_3_.ClassWithProtectedMembers.html">ClassWithProtectedMembers</a>.<a href="_typescript_1_3_.ClassWithProtectedMembers.html#publicProperty">publicProperty</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.3.ts#L9">typescript-1.3.ts:9</a></li>
 						</ul>
@@ -148,7 +148,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
-					<a name="protectedmethod" class="tsd-anchor"></a>
+					<a name="protectedMethod" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> protected<wbr>Method</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">protected<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -156,7 +156,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_typescript_1_3_.classwithprotectedmembers.html">ClassWithProtectedMembers</a>.<a href="_typescript_1_3_.classwithprotectedmembers.html#protectedmethod">protectedMethod</a></p>
+								<p>Inherited from <a href="_typescript_1_3_.ClassWithProtectedMembers.html">ClassWithProtectedMembers</a>.<a href="_typescript_1_3_.ClassWithProtectedMembers.html#protectedMethod">protectedMethod</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.3.ts#L29">typescript-1.3.ts:29</a></li>
 								</ul>
@@ -171,7 +171,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
-					<a name="publicmethod" class="tsd-anchor"></a>
+					<a name="publicMethod" class="tsd-anchor"></a>
 					<h3>public<wbr>Method</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">public<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -179,7 +179,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_typescript_1_3_.classwithprotectedmembers.html">ClassWithProtectedMembers</a>.<a href="_typescript_1_3_.classwithprotectedmembers.html#publicmethod">publicMethod</a></p>
+								<p>Inherited from <a href="_typescript_1_3_.ClassWithProtectedMembers.html">ClassWithProtectedMembers</a>.<a href="_typescript_1_3_.ClassWithProtectedMembers.html#publicMethod">publicMethod</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.3.ts#L24">typescript-1.3.ts:24</a></li>
 								</ul>
@@ -245,31 +245,31 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_3_.classwithprotectedmembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a>
+						<a href="_typescript_1_3_.ClassWithProtectedMembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a>
+						<a href="_typescript_1_3_.SubclassWithProtectedMembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a>
 						<ul>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
-								<a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a>
+								<a href="_typescript_1_3_.SubclassWithProtectedMembers.html#protectedProperty" class="tsd-kind-icon">protected<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
-								<a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a>
+								<a href="_typescript_1_3_.SubclassWithProtectedMembers.html#publicProperty" class="tsd-kind-icon">public<wbr>Property</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
-								<a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a>
+								<a href="_typescript_1_3_.SubclassWithProtectedMembers.html#protectedMethod" class="tsd-kind-icon">protected<wbr>Method</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
-								<a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a>
+								<a href="_typescript_1_3_.SubclassWithProtectedMembers.html#publicMethod" class="tsd-kind-icon">public<wbr>Method</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_3_.html#tupletype" class="tsd-kind-icon">tuple<wbr>Type</a>
+						<a href="../modules/_typescript_1_3_.html#tupleType" class="tsd-kind-icon">tuple<wbr>Type</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/classes/_typescript_1_4_.simpleclass.html
+++ b/src/test/renderer/specs/classes/_typescript_1_4_.simpleclass.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_typescript_1_4_.html">&quot;typescript-1.4&quot;</a>
 				</li>
 				<li>
-					<a href="_typescript_1_4_.simpleclass.html">SimpleClass</a>
+					<a href="_typescript_1_4_.SimpleClass.html">SimpleClass</a>
 				</li>
 			</ul>
 			<h1>Class SimpleClass</h1>
@@ -91,7 +91,7 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter tsd-is-not-exported"><a href="_typescript_1_4_.simpleclass.html#somefunction" class="tsd-kind-icon">some<wbr>Function</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter tsd-is-not-exported"><a href="_typescript_1_4_.SimpleClass.html#someFunction" class="tsd-kind-icon">some<wbr>Function</a></li>
 							</ul>
 						</section>
 					</div>
@@ -100,10 +100,10 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter tsd-is-not-exported">
-					<a name="somefunction" class="tsd-anchor"></a>
+					<a name="someFunction" class="tsd-anchor"></a>
 					<h3>some<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">some<wbr>Function&lt;T&gt;<span class="tsd-signature-symbol">(</span>arr<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span>, callback<span class="tsd-signature-symbol">: </span><a href="../modules/_typescript_1_4_.html#genericcallback" class="tsd-signature-type">GenericCallback</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span></li>
+						<li class="tsd-signature tsd-kind-icon">some<wbr>Function&lt;T&gt;<span class="tsd-signature-symbol">(</span>arr<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span>, callback<span class="tsd-signature-symbol">: </span><a href="../modules/_typescript_1_4_.html#GenericCallback" class="tsd-signature-type">GenericCallback</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -116,7 +116,7 @@
 								<div class="lead">
 									<p>A generic function using a generic type alias.</p>
 								</div>
-								<p>Uses <a href="../modules/_typescript_1_4_.html#genericcallback">GenericCallback</a> instead of <a href="../modules/_typescript_1_4_.html#callback">Callback</a>.</p>
+								<p>Uses <a href="../modules/_typescript_1_4_.html#GenericCallback">GenericCallback</a> instead of <a href="../modules/_typescript_1_4_.html#Callback">Callback</a>.</p>
 							</div>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
 							<ul class="tsd-type-parameters">
@@ -136,7 +136,7 @@
 									</div>
 								</li>
 								<li>
-									<h5>callback: <a href="../modules/_typescript_1_4_.html#genericcallback" class="tsd-signature-type">GenericCallback</a></h5>
+									<h5>callback: <a href="../modules/_typescript_1_4_.html#GenericCallback" class="tsd-signature-type">GenericCallback</a></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>Some generic type alias callback.</p>
 									</div>
@@ -201,44 +201,44 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_4_.simpleclass.html" class="tsd-kind-icon">Simple<wbr>Class</a>
+						<a href="_typescript_1_4_.SimpleClass.html" class="tsd-kind-icon">Simple<wbr>Class</a>
 						<ul>
 							<li class=" tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter tsd-is-not-exported">
-								<a href="_typescript_1_4_.simpleclass.html#somefunction" class="tsd-kind-icon">some<wbr>Function</a>
+								<a href="_typescript_1_4_.SimpleClass.html#someFunction" class="tsd-kind-icon">some<wbr>Function</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../interfaces/_typescript_1_4_.runoptions.html" class="tsd-kind-icon">Run<wbr>Options</a>
+						<a href="../interfaces/_typescript_1_4_.RunOptions.html" class="tsd-kind-icon">Run<wbr>Options</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#callback" class="tsd-kind-icon">Callback</a>
+						<a href="../modules/_typescript_1_4_.html#Callback" class="tsd-kind-icon">Callback</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module">
-						<a href="../modules/_typescript_1_4_.html#genericcallback" class="tsd-kind-icon">Generic<wbr>Callback</a>
+						<a href="../modules/_typescript_1_4_.html#GenericCallback" class="tsd-kind-icon">Generic<wbr>Callback</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#mynumber" class="tsd-kind-icon">My<wbr>Number</a>
+						<a href="../modules/_typescript_1_4_.html#MyNumber" class="tsd-kind-icon">My<wbr>Number</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#myrunoptions" class="tsd-kind-icon">My<wbr>Run<wbr>Options</a>
+						<a href="../modules/_typescript_1_4_.html#MyRunOptions" class="tsd-kind-icon">My<wbr>Run<wbr>Options</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#primitivearray" class="tsd-kind-icon">Primitive<wbr>Array</a>
+						<a href="../modules/_typescript_1_4_.html#PrimitiveArray" class="tsd-kind-icon">Primitive<wbr>Array</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#callback-1" class="tsd-kind-icon">callback</a>
+						<a href="../modules/_typescript_1_4_.html#callback" class="tsd-kind-icon">callback</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#interfaceorstring" class="tsd-kind-icon">interface<wbr>OrString</a>
+						<a href="../modules/_typescript_1_4_.html#interfaceOrString" class="tsd-kind-icon">interface<wbr>OrString</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#functionusingtypes" class="tsd-kind-icon">function<wbr>Using<wbr>Types</a>
+						<a href="../modules/_typescript_1_4_.html#functionUsingTypes" class="tsd-kind-icon">function<wbr>Using<wbr>Types</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#functionwithgenericcallback" class="tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback</a>
+						<a href="../modules/_typescript_1_4_.html#functionWithGenericCallback" class="tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/enums/_enumerations_.directions.html
+++ b/src/test/renderer/specs/enums/_enumerations_.directions.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_enumerations_.html">&quot;enumerations&quot;</a>
 				</li>
 				<li>
-					<a href="_enumerations_.directions.html">Directions</a>
+					<a href="_enumerations_.Directions.html">Directions</a>
 				</li>
 			</ul>
 			<h1>Enumeration Directions</h1>
@@ -83,12 +83,12 @@
 						<section class="tsd-index-section ">
 							<h3>Enumeration members</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.directions.html#bottom" class="tsd-kind-icon">Bottom</a></li>
-								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.directions.html#left" class="tsd-kind-icon">Left</a></li>
-								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.directions.html#right" class="tsd-kind-icon">Right</a></li>
-								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.directions.html#top" class="tsd-kind-icon">Top</a></li>
-								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.directions.html#topleft" class="tsd-kind-icon">Top<wbr>Left</a></li>
-								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.directions.html#topright" class="tsd-kind-icon">Top<wbr>Right</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.Directions.html#Bottom" class="tsd-kind-icon">Bottom</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.Directions.html#Left" class="tsd-kind-icon">Left</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.Directions.html#Right" class="tsd-kind-icon">Right</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.Directions.html#Top" class="tsd-kind-icon">Top</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.Directions.html#TopLeft" class="tsd-kind-icon">Top<wbr>Left</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.Directions.html#TopRight" class="tsd-kind-icon">Top<wbr>Right</a></li>
 							</ul>
 						</section>
 					</div>
@@ -97,7 +97,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Enumeration members</h2>
 				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
-					<a name="bottom" class="tsd-anchor"></a>
+					<a name="Bottom" class="tsd-anchor"></a>
 					<h3>Bottom</h3>
 					<div class="tsd-signature tsd-kind-icon">Bottom<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
@@ -112,7 +112,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
-					<a name="left" class="tsd-anchor"></a>
+					<a name="Left" class="tsd-anchor"></a>
 					<h3>Left</h3>
 					<div class="tsd-signature tsd-kind-icon">Left<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
@@ -127,7 +127,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
-					<a name="right" class="tsd-anchor"></a>
+					<a name="Right" class="tsd-anchor"></a>
 					<h3>Right</h3>
 					<div class="tsd-signature tsd-kind-icon">Right<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
@@ -142,7 +142,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
-					<a name="top" class="tsd-anchor"></a>
+					<a name="Top" class="tsd-anchor"></a>
 					<h3>Top</h3>
 					<div class="tsd-signature tsd-kind-icon">Top<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
@@ -157,7 +157,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
-					<a name="topleft" class="tsd-anchor"></a>
+					<a name="TopLeft" class="tsd-anchor"></a>
 					<h3>Top<wbr>Left</h3>
 					<div class="tsd-signature tsd-kind-icon">Top<wbr>Left<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;Top | Left</span></div>
 					<aside class="tsd-sources">
@@ -172,7 +172,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
-					<a name="topright" class="tsd-anchor"></a>
+					<a name="TopRight" class="tsd-anchor"></a>
 					<h3>Top<wbr>Right</h3>
 					<div class="tsd-signature tsd-kind-icon">Top<wbr>Right<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;Top | Right</span></div>
 					<aside class="tsd-sources">
@@ -240,32 +240,32 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-enum tsd-parent-kind-external-module">
-						<a href="_enumerations_.directions.html" class="tsd-kind-icon">Directions</a>
+						<a href="_enumerations_.Directions.html" class="tsd-kind-icon">Directions</a>
 						<ul>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
-								<a href="_enumerations_.directions.html#bottom" class="tsd-kind-icon">Bottom</a>
+								<a href="_enumerations_.Directions.html#Bottom" class="tsd-kind-icon">Bottom</a>
 							</li>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
-								<a href="_enumerations_.directions.html#left" class="tsd-kind-icon">Left</a>
+								<a href="_enumerations_.Directions.html#Left" class="tsd-kind-icon">Left</a>
 							</li>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
-								<a href="_enumerations_.directions.html#right" class="tsd-kind-icon">Right</a>
+								<a href="_enumerations_.Directions.html#Right" class="tsd-kind-icon">Right</a>
 							</li>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
-								<a href="_enumerations_.directions.html#top" class="tsd-kind-icon">Top</a>
+								<a href="_enumerations_.Directions.html#Top" class="tsd-kind-icon">Top</a>
 							</li>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
-								<a href="_enumerations_.directions.html#topleft" class="tsd-kind-icon">Top<wbr>Left</a>
+								<a href="_enumerations_.Directions.html#TopLeft" class="tsd-kind-icon">Top<wbr>Left</a>
 							</li>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
-								<a href="_enumerations_.directions.html#topright" class="tsd-kind-icon">Top<wbr>Right</a>
+								<a href="_enumerations_.Directions.html#TopRight" class="tsd-kind-icon">Top<wbr>Right</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-enum tsd-parent-kind-external-module">
-						<a href="_enumerations_.size.html" class="tsd-kind-icon">Size</a>
+						<a href="_enumerations_.Size.html" class="tsd-kind-icon">Size</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/enums/_enumerations_.size.html
+++ b/src/test/renderer/specs/enums/_enumerations_.size.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_enumerations_.html">&quot;enumerations&quot;</a>
 				</li>
 				<li>
-					<a href="_enumerations_.size.html">Size</a>
+					<a href="_enumerations_.Size.html">Size</a>
 				</li>
 			</ul>
 			<h1>Enumeration Size</h1>
@@ -85,21 +85,21 @@
 						<section class="tsd-index-section ">
 							<h3>Enumeration members</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.size.html#large" class="tsd-kind-icon">Large</a></li>
-								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.size.html#medium" class="tsd-kind-icon">Medium</a></li>
-								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.size.html#small" class="tsd-kind-icon">Small</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.Size.html#Large" class="tsd-kind-icon">Large</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.Size.html#Medium" class="tsd-kind-icon">Medium</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="_enumerations_.Size.html#Small" class="tsd-kind-icon">Small</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-enum"><a href="_enumerations_.size.html#defaultsize" class="tsd-kind-icon">default<wbr>Size</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-enum"><a href="_enumerations_.Size.html#defaultSize" class="tsd-kind-icon">default<wbr>Size</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-enum"><a href="_enumerations_.size.html#issmall" class="tsd-kind-icon">is<wbr>Small</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-enum"><a href="_enumerations_.Size.html#isSmall" class="tsd-kind-icon">is<wbr>Small</a></li>
 							</ul>
 						</section>
 					</div>
@@ -108,7 +108,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Enumeration members</h2>
 				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
-					<a name="large" class="tsd-anchor"></a>
+					<a name="Large" class="tsd-anchor"></a>
 					<h3>Large</h3>
 					<div class="tsd-signature tsd-kind-icon">Large<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
@@ -123,7 +123,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
-					<a name="medium" class="tsd-anchor"></a>
+					<a name="Medium" class="tsd-anchor"></a>
 					<h3>Medium</h3>
 					<div class="tsd-signature tsd-kind-icon">Medium<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
@@ -138,7 +138,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
-					<a name="small" class="tsd-anchor"></a>
+					<a name="Small" class="tsd-anchor"></a>
 					<h3>Small</h3>
 					<div class="tsd-signature tsd-kind-icon">Small<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
@@ -156,9 +156,9 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-enum">
-					<a name="defaultsize" class="tsd-anchor"></a>
+					<a name="defaultSize" class="tsd-anchor"></a>
 					<h3>default<wbr>Size</h3>
-					<div class="tsd-signature tsd-kind-icon">default<wbr>Size<span class="tsd-signature-symbol">:</span> <a href="_enumerations_.size.html" class="tsd-signature-type">Size</a><span class="tsd-signature-symbol"> =&nbsp;Size.Medium</span></div>
+					<div class="tsd-signature tsd-kind-icon">default<wbr>Size<span class="tsd-signature-symbol">:</span> <a href="_enumerations_.Size.html" class="tsd-signature-type">Size</a><span class="tsd-signature-symbol"> =&nbsp;Size.Medium</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/enumerations.ts#L70">enumerations.ts:70</a></li>
@@ -174,10 +174,10 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Functions</h2>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-enum">
-					<a name="issmall" class="tsd-anchor"></a>
+					<a name="isSmall" class="tsd-anchor"></a>
 					<h3>is<wbr>Small</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-enum">
-						<li class="tsd-signature tsd-kind-icon">is<wbr>Small<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><a href="_enumerations_.size.html" class="tsd-signature-type">Size</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
+						<li class="tsd-signature tsd-kind-icon">is<wbr>Small<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><a href="_enumerations_.Size.html" class="tsd-signature-type">Size</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -194,7 +194,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>value: <a href="_enumerations_.size.html" class="tsd-signature-type">Size</a></h5>
+									<h5>value: <a href="_enumerations_.Size.html" class="tsd-signature-type">Size</a></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>The value that should be tested.</p>
 									</div>
@@ -257,27 +257,27 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-enum tsd-parent-kind-external-module">
-						<a href="_enumerations_.directions.html" class="tsd-kind-icon">Directions</a>
+						<a href="_enumerations_.Directions.html" class="tsd-kind-icon">Directions</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-enum tsd-parent-kind-external-module">
-						<a href="_enumerations_.size.html" class="tsd-kind-icon">Size</a>
+						<a href="_enumerations_.Size.html" class="tsd-kind-icon">Size</a>
 						<ul>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
-								<a href="_enumerations_.size.html#large" class="tsd-kind-icon">Large</a>
+								<a href="_enumerations_.Size.html#Large" class="tsd-kind-icon">Large</a>
 							</li>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
-								<a href="_enumerations_.size.html#medium" class="tsd-kind-icon">Medium</a>
+								<a href="_enumerations_.Size.html#Medium" class="tsd-kind-icon">Medium</a>
 							</li>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
-								<a href="_enumerations_.size.html#small" class="tsd-kind-icon">Small</a>
+								<a href="_enumerations_.Size.html#Small" class="tsd-kind-icon">Small</a>
 							</li>
 							<li class=" tsd-kind-variable tsd-parent-kind-enum">
-								<a href="_enumerations_.size.html#defaultsize" class="tsd-kind-icon">default<wbr>Size</a>
+								<a href="_enumerations_.Size.html#defaultSize" class="tsd-kind-icon">default<wbr>Size</a>
 							</li>
 							<li class=" tsd-kind-function tsd-parent-kind-enum">
-								<a href="_enumerations_.size.html#issmall" class="tsd-kind-icon">is<wbr>Small</a>
+								<a href="_enumerations_.Size.html#isSmall" class="tsd-kind-icon">is<wbr>Small</a>
 							</li>
 						</ul>
 					</li>

--- a/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_classes_.html">&quot;classes&quot;</a>
 				</li>
 				<li>
-					<a href="_classes_.inameinterface.html">INameInterface</a>
+					<a href="_classes_.INameInterface.html">INameInterface</a>
 				</li>
 			</ul>
 			<h1>Interface INameInterface</h1>
@@ -83,7 +83,7 @@
 						<span class="target">INameInterface</span>
 						<ul class="tsd-hierarchy">
 							<li>
-								<a href="_classes_.iprintnameinterface.html" class="tsd-signature-type">IPrintNameInterface</a>
+								<a href="_classes_.IPrintNameInterface.html" class="tsd-signature-type">IPrintNameInterface</a>
 							</li>
 						</ul>
 					</li>
@@ -92,9 +92,9 @@
 			<section class="tsd-panel">
 				<h3>Implemented by</h3>
 				<ul class="tsd-hierarchy">
-					<li><a href="../classes/_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></li>
-					<li><a href="../classes/_classes_.subclassa.html" class="tsd-signature-type">SubClassA</a></li>
-					<li><a href="../classes/_classes_.subclassb.html" class="tsd-signature-type">SubClassB</a></li>
+					<li><a href="../classes/_classes_.BaseClass.html" class="tsd-signature-type">BaseClass</a></li>
+					<li><a href="../classes/_classes_.SubClassA.html" class="tsd-signature-type">SubClassA</a></li>
+					<li><a href="../classes/_classes_.SubClassB.html" class="tsd-signature-type">SubClassB</a></li>
 				</ul>
 			</section>
 			<section class="tsd-panel-group tsd-index-group">
@@ -104,13 +104,13 @@
 						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-interface"><a href="_classes_.inameinterface.html#name" class="tsd-kind-icon">name</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface"><a href="_classes_.INameInterface.html#name" class="tsd-kind-icon">name</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface"><a href="_classes_.inameinterface.html#getname" class="tsd-kind-icon">get<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface"><a href="_classes_.INameInterface.html#getName" class="tsd-kind-icon">get<wbr>Name</a></li>
 							</ul>
 						</section>
 					</div>
@@ -138,7 +138,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface">
-					<a name="getname" class="tsd-anchor"></a>
+					<a name="getName" class="tsd-anchor"></a>
 					<h3>get<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -212,43 +212,43 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="../classes/_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="../classes/_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="../classes/_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="../classes/_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="../classes/_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="../classes/_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 						<ul>
 							<li class=" tsd-kind-property tsd-parent-kind-interface">
-								<a href="_classes_.inameinterface.html#name" class="tsd-kind-icon">name</a>
+								<a href="_classes_.INameInterface.html#name" class="tsd-kind-icon">name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface">
-								<a href="_classes_.inameinterface.html#getname" class="tsd-kind-icon">get<wbr>Name</a>
+								<a href="_classes_.INameInterface.html#getName" class="tsd-kind-icon">get<wbr>Name</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_classes_.html">&quot;classes&quot;</a>
 				</li>
 				<li>
-					<a href="_classes_.iprintinterface.html">IPrintInterface</a>
+					<a href="_classes_.IPrintInterface.html">IPrintInterface</a>
 				</li>
 			</ul>
 			<h1>Interface IPrintInterface</h1>
@@ -83,7 +83,7 @@
 						<span class="target">IPrintInterface</span>
 						<ul class="tsd-hierarchy">
 							<li>
-								<a href="_classes_.iprintnameinterface.html" class="tsd-signature-type">IPrintNameInterface</a>
+								<a href="_classes_.IPrintNameInterface.html" class="tsd-signature-type">IPrintNameInterface</a>
 							</li>
 						</ul>
 					</li>
@@ -96,7 +96,7 @@
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface"><a href="_classes_.iprintinterface.html#print" class="tsd-kind-icon">print</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface"><a href="_classes_.IPrintInterface.html#print" class="tsd-kind-icon">print</a></li>
 							</ul>
 						</section>
 					</div>
@@ -185,40 +185,40 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="../classes/_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="../classes/_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="../classes/_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="../classes/_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="../classes/_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="../classes/_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 						<ul>
 							<li class=" tsd-kind-method tsd-parent-kind-interface">
-								<a href="_classes_.iprintinterface.html#print" class="tsd-kind-icon">print</a>
+								<a href="_classes_.IPrintInterface.html#print" class="tsd-kind-icon">print</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_classes_.html">&quot;classes&quot;</a>
 				</li>
 				<li>
-					<a href="_classes_.iprintnameinterface.html">IPrintNameInterface</a>
+					<a href="_classes_.IPrintNameInterface.html">IPrintNameInterface</a>
 				</li>
 			</ul>
 			<h1>Interface IPrintNameInterface</h1>
@@ -80,10 +80,10 @@
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<a href="_classes_.inameinterface.html" class="tsd-signature-type">INameInterface</a>
+						<a href="_classes_.INameInterface.html" class="tsd-signature-type">INameInterface</a>
 					</li>
 					<li>
-						<a href="_classes_.iprintinterface.html" class="tsd-signature-type">IPrintInterface</a>
+						<a href="_classes_.IPrintInterface.html" class="tsd-signature-type">IPrintInterface</a>
 						<ul class="tsd-hierarchy">
 							<li>
 								<span class="target">IPrintNameInterface</span>
@@ -95,7 +95,7 @@
 			<section class="tsd-panel">
 				<h3>Implemented by</h3>
 				<ul class="tsd-hierarchy">
-					<li><a href="../classes/_classes_.subclassa.html" class="tsd-signature-type">SubClassA</a></li>
+					<li><a href="../classes/_classes_.SubClassA.html" class="tsd-signature-type">SubClassA</a></li>
 				</ul>
 			</section>
 			<section class="tsd-panel-group tsd-index-group">
@@ -105,15 +105,15 @@
 						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a href="_classes_.iprintnameinterface.html#name" class="tsd-kind-icon">name</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a href="_classes_.IPrintNameInterface.html#name" class="tsd-kind-icon">name</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_classes_.iprintnameinterface.html#getname" class="tsd-kind-icon">get<wbr>Name</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_classes_.iprintnameinterface.html#print" class="tsd-kind-icon">print</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface"><a href="_classes_.iprintnameinterface.html#printname" class="tsd-kind-icon">print<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_classes_.IPrintNameInterface.html#getName" class="tsd-kind-icon">get<wbr>Name</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_classes_.IPrintNameInterface.html#print" class="tsd-kind-icon">print</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface"><a href="_classes_.IPrintNameInterface.html#printName" class="tsd-kind-icon">print<wbr>Name</a></li>
 							</ul>
 						</section>
 					</div>
@@ -126,7 +126,7 @@
 					<h3>name</h3>
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
-						<p>Inherited from <a href="_classes_.inameinterface.html">INameInterface</a>.<a href="_classes_.inameinterface.html#name">name</a></p>
+						<p>Inherited from <a href="_classes_.INameInterface.html">INameInterface</a>.<a href="_classes_.INameInterface.html#name">name</a></p>
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L11">classes.ts:11</a></li>
 						</ul>
@@ -142,7 +142,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-					<a name="getname" class="tsd-anchor"></a>
+					<a name="getName" class="tsd-anchor"></a>
 					<h3>get<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -150,7 +150,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.inameinterface.html">INameInterface</a>.<a href="_classes_.inameinterface.html#getname">getName</a></p>
+								<p>Inherited from <a href="_classes_.INameInterface.html">INameInterface</a>.<a href="_classes_.INameInterface.html#getName">getName</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L18">classes.ts:18</a></li>
 								</ul>
@@ -174,7 +174,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_classes_.iprintinterface.html">IPrintInterface</a>.<a href="_classes_.iprintinterface.html#print">print</a></p>
+								<p>Inherited from <a href="_classes_.IPrintInterface.html">IPrintInterface</a>.<a href="_classes_.IPrintInterface.html#print">print</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L32">classes.ts:32</a></li>
 								</ul>
@@ -196,7 +196,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface">
-					<a name="printname" class="tsd-anchor"></a>
+					<a name="printName" class="tsd-anchor"></a>
 					<h3>print<wbr>Name</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
 						<li class="tsd-signature tsd-kind-icon">print<wbr>Name<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -269,45 +269,45 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="../classes/_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="../classes/_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="../classes/_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="../classes/_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="../classes/_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="../classes/_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 						<ul>
 							<li class=" tsd-kind-property tsd-parent-kind-interface tsd-is-inherited">
-								<a href="_classes_.iprintnameinterface.html#name" class="tsd-kind-icon">name</a>
+								<a href="_classes_.IPrintNameInterface.html#name" class="tsd-kind-icon">name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-								<a href="_classes_.iprintnameinterface.html#getname" class="tsd-kind-icon">get<wbr>Name</a>
+								<a href="_classes_.IPrintNameInterface.html#getName" class="tsd-kind-icon">get<wbr>Name</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-								<a href="_classes_.iprintnameinterface.html#print" class="tsd-kind-icon">print</a>
+								<a href="_classes_.IPrintNameInterface.html#print" class="tsd-kind-icon">print</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface">
-								<a href="_classes_.iprintnameinterface.html#printname" class="tsd-kind-icon">print<wbr>Name</a>
+								<a href="_classes_.IPrintNameInterface.html#printName" class="tsd-kind-icon">print<wbr>Name</a>
 							</li>
 						</ul>
 					</li>

--- a/src/test/renderer/specs/interfaces/_generics_.a.html
+++ b/src/test/renderer/specs/interfaces/_generics_.a.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 				</li>
 				<li>
-					<a href="_generics_.a.html">A</a>
+					<a href="_generics_.A.html">A</a>
 				</li>
 			</ul>
 			<h1>Interface A&lt;T&gt;</h1>
@@ -96,7 +96,7 @@
 						<span class="target">A</span>
 						<ul class="tsd-hierarchy">
 							<li>
-								<a href="_generics_.ab.html" class="tsd-signature-type">AB</a>
+								<a href="_generics_.AB.html" class="tsd-signature-type">AB</a>
 							</li>
 						</ul>
 					</li>
@@ -109,7 +109,7 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported"><a href="_generics_.a.html#gett" class="tsd-kind-icon">getT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported"><a href="_generics_.A.html#getT" class="tsd-kind-icon">getT</a></li>
 							</ul>
 						</section>
 					</div>
@@ -118,7 +118,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
-					<a name="gett" class="tsd-anchor"></a>
+					<a name="getT" class="tsd-anchor"></a>
 					<h3>getT</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">getT<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span></li>
@@ -194,32 +194,32 @@
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
+						<a href="_generics_.A.html" class="tsd-kind-icon">A</a>
 						<ul>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
-								<a href="_generics_.a.html#gett" class="tsd-kind-icon">getT</a>
+								<a href="_generics_.A.html#getT" class="tsd-kind-icon">getT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
+						<a href="_generics_.AB.html" class="tsd-kind-icon">AB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
+						<a href="_generics_.ABNumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
+						<a href="_generics_.ABString.html" class="tsd-kind-icon">ABString</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
+						<a href="_generics_.B.html" class="tsd-kind-icon">B</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
+						<a href="../modules/_generics_.html#getGenericArray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
+						<a href="../modules/_generics_.html#testFunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/interfaces/_generics_.ab.html
+++ b/src/test/renderer/specs/interfaces/_generics_.ab.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 				</li>
 				<li>
-					<a href="_generics_.ab.html">AB</a>
+					<a href="_generics_.AB.html">AB</a>
 				</li>
 			</ul>
 			<h1>Interface AB&lt;T&gt;</h1>
@@ -94,19 +94,19 @@
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<a href="_generics_.a.html" class="tsd-signature-type">A</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span>
+						<a href="_generics_.A.html" class="tsd-signature-type">A</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span>
 					</li>
 					<li>
-						<a href="_generics_.b.html" class="tsd-signature-type">B</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span>
+						<a href="_generics_.B.html" class="tsd-signature-type">B</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span>
 						<ul class="tsd-hierarchy">
 							<li>
 								<span class="target">AB</span>
 								<ul class="tsd-hierarchy">
 									<li>
-										<a href="_generics_.abstring.html" class="tsd-signature-type">ABString</a>
+										<a href="_generics_.ABString.html" class="tsd-signature-type">ABString</a>
 									</li>
 									<li>
-										<a href="_generics_.abnumber.html" class="tsd-signature-type">ABNumber</a>
+										<a href="_generics_.ABNumber.html" class="tsd-signature-type">ABNumber</a>
 									</li>
 								</ul>
 							</li>
@@ -121,9 +121,9 @@
 						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ab.html#getc" class="tsd-kind-icon">getC</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ab.html#gett" class="tsd-kind-icon">getT</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ab.html#sett" class="tsd-kind-icon">setT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.AB.html#getC" class="tsd-kind-icon">getC</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.AB.html#getT" class="tsd-kind-icon">getT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.AB.html#setT" class="tsd-kind-icon">setT</a></li>
 							</ul>
 						</section>
 					</div>
@@ -132,7 +132,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-					<a name="getc" class="tsd-anchor"></a>
+					<a name="getC" class="tsd-anchor"></a>
 					<h3>getC</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">getC<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
@@ -140,7 +140,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_generics_.b.html">B</a>.<a href="_generics_.b.html#getc">getC</a></p>
+								<p>Inherited from <a href="_generics_.B.html">B</a>.<a href="_generics_.B.html#getC">getC</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/generics.ts#L48">generics.ts:48</a></li>
 								</ul>
@@ -156,7 +156,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-					<a name="gett" class="tsd-anchor"></a>
+					<a name="getT" class="tsd-anchor"></a>
 					<h3>getT</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">getT<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span></li>
@@ -164,7 +164,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_generics_.a.html">A</a>.<a href="_generics_.a.html#gett">getT</a></p>
+								<p>Inherited from <a href="_generics_.A.html">A</a>.<a href="_generics_.A.html#getT">getT</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/generics.ts#L24">generics.ts:24</a></li>
 								</ul>
@@ -180,7 +180,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-					<a name="sett" class="tsd-anchor"></a>
+					<a name="setT" class="tsd-anchor"></a>
 					<h3>setT</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">setT<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -188,7 +188,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_generics_.b.html">B</a>.<a href="_generics_.b.html#sett">setT</a></p>
+								<p>Inherited from <a href="_generics_.B.html">B</a>.<a href="_generics_.B.html#setT">setT</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/generics.ts#L41">generics.ts:41</a></li>
 								</ul>
@@ -263,40 +263,40 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
+						<a href="_generics_.A.html" class="tsd-kind-icon">A</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
+						<a href="_generics_.AB.html" class="tsd-kind-icon">AB</a>
 						<ul>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-								<a href="_generics_.ab.html#getc" class="tsd-kind-icon">getC</a>
+								<a href="_generics_.AB.html#getC" class="tsd-kind-icon">getC</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-								<a href="_generics_.ab.html#gett" class="tsd-kind-icon">getT</a>
+								<a href="_generics_.AB.html#getT" class="tsd-kind-icon">getT</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-								<a href="_generics_.ab.html#sett" class="tsd-kind-icon">setT</a>
+								<a href="_generics_.AB.html#setT" class="tsd-kind-icon">setT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
+						<a href="_generics_.ABNumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
+						<a href="_generics_.ABString.html" class="tsd-kind-icon">ABString</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
+						<a href="_generics_.B.html" class="tsd-kind-icon">B</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
+						<a href="../modules/_generics_.html#getGenericArray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
+						<a href="../modules/_generics_.html#testFunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/interfaces/_generics_.abnumber.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abnumber.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 				</li>
 				<li>
-					<a href="_generics_.abnumber.html">ABNumber</a>
+					<a href="_generics_.ABNumber.html">ABNumber</a>
 				</li>
 			</ul>
 			<h1>Interface ABNumber</h1>
@@ -80,7 +80,7 @@
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<a href="_generics_.ab.html" class="tsd-signature-type">AB</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span>
+						<a href="_generics_.AB.html" class="tsd-signature-type">AB</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span>
 						<ul class="tsd-hierarchy">
 							<li>
 								<span class="target">ABNumber</span>
@@ -96,9 +96,9 @@
 						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abnumber.html#getc" class="tsd-kind-icon">getC</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abnumber.html#gett" class="tsd-kind-icon">getT</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abnumber.html#sett" class="tsd-kind-icon">setT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ABNumber.html#getC" class="tsd-kind-icon">getC</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ABNumber.html#getT" class="tsd-kind-icon">getT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ABNumber.html#setT" class="tsd-kind-icon">setT</a></li>
 							</ul>
 						</section>
 					</div>
@@ -107,7 +107,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-					<a name="getc" class="tsd-anchor"></a>
+					<a name="getC" class="tsd-anchor"></a>
 					<h3>getC</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">getC<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
@@ -115,7 +115,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_generics_.b.html">B</a>.<a href="_generics_.b.html#getc">getC</a></p>
+								<p>Inherited from <a href="_generics_.B.html">B</a>.<a href="_generics_.B.html#getC">getC</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/generics.ts#L48">generics.ts:48</a></li>
 								</ul>
@@ -131,7 +131,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-					<a name="gett" class="tsd-anchor"></a>
+					<a name="getT" class="tsd-anchor"></a>
 					<h3>getT</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">getT<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
@@ -139,7 +139,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_generics_.a.html">A</a>.<a href="_generics_.a.html#gett">getT</a></p>
+								<p>Inherited from <a href="_generics_.A.html">A</a>.<a href="_generics_.A.html#getT">getT</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/generics.ts#L24">generics.ts:24</a></li>
 								</ul>
@@ -155,7 +155,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-					<a name="sett" class="tsd-anchor"></a>
+					<a name="setT" class="tsd-anchor"></a>
 					<h3>setT</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">setT<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -163,7 +163,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_generics_.b.html">B</a>.<a href="_generics_.b.html#sett">setT</a></p>
+								<p>Inherited from <a href="_generics_.B.html">B</a>.<a href="_generics_.B.html#setT">setT</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/generics.ts#L41">generics.ts:41</a></li>
 								</ul>
@@ -238,40 +238,40 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
+						<a href="_generics_.A.html" class="tsd-kind-icon">A</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
+						<a href="_generics_.AB.html" class="tsd-kind-icon">AB</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
+						<a href="_generics_.ABNumber.html" class="tsd-kind-icon">ABNumber</a>
 						<ul>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-								<a href="_generics_.abnumber.html#getc" class="tsd-kind-icon">getC</a>
+								<a href="_generics_.ABNumber.html#getC" class="tsd-kind-icon">getC</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-								<a href="_generics_.abnumber.html#gett" class="tsd-kind-icon">getT</a>
+								<a href="_generics_.ABNumber.html#getT" class="tsd-kind-icon">getT</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-								<a href="_generics_.abnumber.html#sett" class="tsd-kind-icon">setT</a>
+								<a href="_generics_.ABNumber.html#setT" class="tsd-kind-icon">setT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
+						<a href="_generics_.ABString.html" class="tsd-kind-icon">ABString</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
+						<a href="_generics_.B.html" class="tsd-kind-icon">B</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
+						<a href="../modules/_generics_.html#getGenericArray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
+						<a href="../modules/_generics_.html#testFunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/interfaces/_generics_.abstring.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abstring.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 				</li>
 				<li>
-					<a href="_generics_.abstring.html">ABString</a>
+					<a href="_generics_.ABString.html">ABString</a>
 				</li>
 			</ul>
 			<h1>Interface ABString</h1>
@@ -80,7 +80,7 @@
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
 					<li>
-						<a href="_generics_.ab.html" class="tsd-signature-type">AB</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span>
+						<a href="_generics_.AB.html" class="tsd-signature-type">AB</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span>
 						<ul class="tsd-hierarchy">
 							<li>
 								<span class="target">ABString</span>
@@ -96,9 +96,9 @@
 						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abstring.html#getc" class="tsd-kind-icon">getC</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abstring.html#gett" class="tsd-kind-icon">getT</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abstring.html#sett" class="tsd-kind-icon">setT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ABString.html#getC" class="tsd-kind-icon">getC</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ABString.html#getT" class="tsd-kind-icon">getT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ABString.html#setT" class="tsd-kind-icon">setT</a></li>
 							</ul>
 						</section>
 					</div>
@@ -107,7 +107,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-					<a name="getc" class="tsd-anchor"></a>
+					<a name="getC" class="tsd-anchor"></a>
 					<h3>getC</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">getC<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
@@ -115,7 +115,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_generics_.b.html">B</a>.<a href="_generics_.b.html#getc">getC</a></p>
+								<p>Inherited from <a href="_generics_.B.html">B</a>.<a href="_generics_.B.html#getC">getC</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/generics.ts#L48">generics.ts:48</a></li>
 								</ul>
@@ -131,7 +131,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-					<a name="gett" class="tsd-anchor"></a>
+					<a name="getT" class="tsd-anchor"></a>
 					<h3>getT</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">getT<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -139,7 +139,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_generics_.a.html">A</a>.<a href="_generics_.a.html#gett">getT</a></p>
+								<p>Inherited from <a href="_generics_.A.html">A</a>.<a href="_generics_.A.html#getT">getT</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/generics.ts#L24">generics.ts:24</a></li>
 								</ul>
@@ -155,7 +155,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-					<a name="sett" class="tsd-anchor"></a>
+					<a name="setT" class="tsd-anchor"></a>
 					<h3>setT</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">setT<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -163,7 +163,7 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Inherited from <a href="_generics_.b.html">B</a>.<a href="_generics_.b.html#sett">setT</a></p>
+								<p>Inherited from <a href="_generics_.B.html">B</a>.<a href="_generics_.B.html#setT">setT</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/generics.ts#L41">generics.ts:41</a></li>
 								</ul>
@@ -238,40 +238,40 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
+						<a href="_generics_.A.html" class="tsd-kind-icon">A</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
+						<a href="_generics_.AB.html" class="tsd-kind-icon">AB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
+						<a href="_generics_.ABNumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
+						<a href="_generics_.ABString.html" class="tsd-kind-icon">ABString</a>
 						<ul>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-								<a href="_generics_.abstring.html#getc" class="tsd-kind-icon">getC</a>
+								<a href="_generics_.ABString.html#getC" class="tsd-kind-icon">getC</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-								<a href="_generics_.abstring.html#gett" class="tsd-kind-icon">getT</a>
+								<a href="_generics_.ABString.html#getT" class="tsd-kind-icon">getT</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
-								<a href="_generics_.abstring.html#sett" class="tsd-kind-icon">setT</a>
+								<a href="_generics_.ABString.html#setT" class="tsd-kind-icon">setT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
+						<a href="_generics_.B.html" class="tsd-kind-icon">B</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
+						<a href="../modules/_generics_.html#getGenericArray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
+						<a href="../modules/_generics_.html#testFunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/interfaces/_generics_.b.html
+++ b/src/test/renderer/specs/interfaces/_generics_.b.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 				</li>
 				<li>
-					<a href="_generics_.b.html">B</a>
+					<a href="_generics_.B.html">B</a>
 				</li>
 			</ul>
 			<h1>Interface B&lt;T, C&gt;</h1>
@@ -104,7 +104,7 @@
 						<span class="target">B</span>
 						<ul class="tsd-hierarchy">
 							<li>
-								<a href="_generics_.ab.html" class="tsd-signature-type">AB</a>
+								<a href="_generics_.AB.html" class="tsd-signature-type">AB</a>
 							</li>
 						</ul>
 					</li>
@@ -117,8 +117,8 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported"><a href="_generics_.b.html#getc" class="tsd-kind-icon">getC</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported"><a href="_generics_.b.html#sett" class="tsd-kind-icon">setT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported"><a href="_generics_.B.html#getC" class="tsd-kind-icon">getC</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported"><a href="_generics_.B.html#setT" class="tsd-kind-icon">setT</a></li>
 							</ul>
 						</section>
 					</div>
@@ -127,7 +127,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Methods</h2>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
-					<a name="getc" class="tsd-anchor"></a>
+					<a name="getC" class="tsd-anchor"></a>
 					<h3>getC</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">getC<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">C</span></li>
@@ -150,7 +150,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
-					<a name="sett" class="tsd-anchor"></a>
+					<a name="setT" class="tsd-anchor"></a>
 					<h3>setT</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">setT<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -232,37 +232,37 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
+						<a href="_generics_.A.html" class="tsd-kind-icon">A</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
+						<a href="_generics_.AB.html" class="tsd-kind-icon">AB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
+						<a href="_generics_.ABNumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
+						<a href="_generics_.ABString.html" class="tsd-kind-icon">ABString</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
+						<a href="_generics_.B.html" class="tsd-kind-icon">B</a>
 						<ul>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
-								<a href="_generics_.b.html#getc" class="tsd-kind-icon">getC</a>
+								<a href="_generics_.B.html#getC" class="tsd-kind-icon">getC</a>
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
-								<a href="_generics_.b.html#sett" class="tsd-kind-icon">setT</a>
+								<a href="_generics_.B.html#setT" class="tsd-kind-icon">setT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
+						<a href="../modules/_generics_.html#getGenericArray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
+						<a href="../modules/_generics_.html#testFunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/interfaces/_typescript_1_4_.runoptions.html
+++ b/src/test/renderer/specs/interfaces/_typescript_1_4_.runoptions.html
@@ -59,7 +59,7 @@
 					<a href="../modules/_typescript_1_4_.html">&quot;typescript-1.4&quot;</a>
 				</li>
 				<li>
-					<a href="_typescript_1_4_.runoptions.html">RunOptions</a>
+					<a href="_typescript_1_4_.RunOptions.html">RunOptions</a>
 				</li>
 			</ul>
 			<h1>Interface RunOptions</h1>
@@ -91,8 +91,8 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-not-exported"><a href="_typescript_1_4_.runoptions.html#commandline" class="tsd-kind-icon">commandline</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-not-exported"><a href="_typescript_1_4_.runoptions.html#program" class="tsd-kind-icon">program</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-not-exported"><a href="_typescript_1_4_.RunOptions.html#commandline" class="tsd-kind-icon">commandline</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-not-exported"><a href="_typescript_1_4_.RunOptions.html#program" class="tsd-kind-icon">program</a></li>
 							</ul>
 						</section>
 					</div>
@@ -172,49 +172,49 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../classes/_typescript_1_4_.simpleclass.html" class="tsd-kind-icon">Simple<wbr>Class</a>
+						<a href="../classes/_typescript_1_4_.SimpleClass.html" class="tsd-kind-icon">Simple<wbr>Class</a>
 					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_4_.runoptions.html" class="tsd-kind-icon">Run<wbr>Options</a>
+						<a href="_typescript_1_4_.RunOptions.html" class="tsd-kind-icon">Run<wbr>Options</a>
 						<ul>
 							<li class=" tsd-kind-property tsd-parent-kind-interface tsd-is-not-exported">
-								<a href="_typescript_1_4_.runoptions.html#commandline" class="tsd-kind-icon">commandline</a>
+								<a href="_typescript_1_4_.RunOptions.html#commandline" class="tsd-kind-icon">commandline</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-interface tsd-is-not-exported">
-								<a href="_typescript_1_4_.runoptions.html#program" class="tsd-kind-icon">program</a>
+								<a href="_typescript_1_4_.RunOptions.html#program" class="tsd-kind-icon">program</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#callback" class="tsd-kind-icon">Callback</a>
+						<a href="../modules/_typescript_1_4_.html#Callback" class="tsd-kind-icon">Callback</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module">
-						<a href="../modules/_typescript_1_4_.html#genericcallback" class="tsd-kind-icon">Generic<wbr>Callback</a>
+						<a href="../modules/_typescript_1_4_.html#GenericCallback" class="tsd-kind-icon">Generic<wbr>Callback</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#mynumber" class="tsd-kind-icon">My<wbr>Number</a>
+						<a href="../modules/_typescript_1_4_.html#MyNumber" class="tsd-kind-icon">My<wbr>Number</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#myrunoptions" class="tsd-kind-icon">My<wbr>Run<wbr>Options</a>
+						<a href="../modules/_typescript_1_4_.html#MyRunOptions" class="tsd-kind-icon">My<wbr>Run<wbr>Options</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#primitivearray" class="tsd-kind-icon">Primitive<wbr>Array</a>
+						<a href="../modules/_typescript_1_4_.html#PrimitiveArray" class="tsd-kind-icon">Primitive<wbr>Array</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#callback-1" class="tsd-kind-icon">callback</a>
+						<a href="../modules/_typescript_1_4_.html#callback" class="tsd-kind-icon">callback</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#interfaceorstring" class="tsd-kind-icon">interface<wbr>OrString</a>
+						<a href="../modules/_typescript_1_4_.html#interfaceOrString" class="tsd-kind-icon">interface<wbr>OrString</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#functionusingtypes" class="tsd-kind-icon">function<wbr>Using<wbr>Types</a>
+						<a href="../modules/_typescript_1_4_.html#functionUsingTypes" class="tsd-kind-icon">function<wbr>Using<wbr>Types</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../modules/_typescript_1_4_.html#functionwithgenericcallback" class="tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback</a>
+						<a href="../modules/_typescript_1_4_.html#functionWithGenericCallback" class="tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_access_.html
+++ b/src/test/renderer/specs/modules/_access_.html
@@ -73,27 +73,27 @@
 						<section class="tsd-index-section tsd-is-private tsd-is-private-protected">
 							<h3>Modules</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-module tsd-parent-kind-external-module tsd-is-private"><a href="_access_.privatemodule.html" class="tsd-kind-icon">Private<wbr>Module</a></li>
+								<li class="tsd-kind-module tsd-parent-kind-external-module tsd-is-private"><a href="_access_.PrivateModule.html" class="tsd-kind-icon">Private<wbr>Module</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-private tsd-is-private-protected">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-private"><a href="../classes/_access_.privateclass.html" class="tsd-kind-icon">Private<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-private"><a href="../classes/_access_.PrivateClass.html" class="tsd-kind-icon">Private<wbr>Class</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-private-protected">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-private"><a href="_access_.html#fakeprivatevariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-protected"><a href="_access_.html#fakeprotectedvariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-private"><a href="_access_.html#fakePrivateVariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-protected"><a href="_access_.html#fakeProtectedVariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-private-protected">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-private"><a href="_access_.html#fakeprivatefunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-protected"><a href="_access_.html#fakeprotectedfunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-private"><a href="_access_.html#fakePrivateFunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-protected"><a href="_access_.html#fakeProtectedFunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a></li>
 							</ul>
 						</section>
 					</div>
@@ -102,7 +102,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-private-protected">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-private">
-					<a name="fakeprivatevariable" class="tsd-anchor"></a>
+					<a name="fakePrivateVariable" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> fake<wbr>Private<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">fake<wbr>Private<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;test&quot;</span></div>
 					<aside class="tsd-sources">
@@ -117,7 +117,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-protected">
-					<a name="fakeprotectedvariable" class="tsd-anchor"></a>
+					<a name="fakeProtectedVariable" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> fake<wbr>Protected<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">fake<wbr>Protected<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;test&quot;</span></div>
 					<aside class="tsd-sources">
@@ -135,7 +135,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-private-protected">
 				<h2>Functions</h2>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-private">
-					<a name="fakeprivatefunction" class="tsd-anchor"></a>
+					<a name="fakePrivateFunction" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> fake<wbr>Private<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-private">
 						<li class="tsd-signature tsd-kind-icon">fake<wbr>Private<wbr>Function<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -157,7 +157,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-protected">
-					<a name="fakeprotectedfunction" class="tsd-anchor"></a>
+					<a name="fakeProtectedFunction" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> fake<wbr>Protected<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-protected">
 						<li class="tsd-signature tsd-kind-icon">fake<wbr>Protected<wbr>Function<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -190,7 +190,7 @@
 						<a href="_access_.html">"access"</a>
 						<ul>
 							<li class=" tsd-kind-module tsd-parent-kind-external-module tsd-is-private">
-								<a href="_access_.privatemodule.html">Private<wbr>Module</a>
+								<a href="_access_.PrivateModule.html">Private<wbr>Module</a>
 							</li>
 						</ul>
 					</li>
@@ -235,19 +235,19 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-private">
-						<a href="../classes/_access_.privateclass.html" class="tsd-kind-icon">Private<wbr>Class</a>
+						<a href="../classes/_access_.PrivateClass.html" class="tsd-kind-icon">Private<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-private">
-						<a href="_access_.html#fakeprivatevariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a>
+						<a href="_access_.html#fakePrivateVariable" class="tsd-kind-icon">fake<wbr>Private<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-protected">
-						<a href="_access_.html#fakeprotectedvariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a>
+						<a href="_access_.html#fakeProtectedVariable" class="tsd-kind-icon">fake<wbr>Protected<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-private">
-						<a href="_access_.html#fakeprivatefunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a>
+						<a href="_access_.html#fakePrivateFunction" class="tsd-kind-icon">fake<wbr>Private<wbr>Function</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-protected">
-						<a href="_access_.html#fakeprotectedfunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a>
+						<a href="_access_.html#fakeProtectedFunction" class="tsd-kind-icon">fake<wbr>Protected<wbr>Function</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_access_.privatemodule.html
+++ b/src/test/renderer/specs/modules/_access_.privatemodule.html
@@ -59,7 +59,7 @@
 					<a href="_access_.html">&quot;access&quot;</a>
 				</li>
 				<li>
-					<a href="_access_.privatemodule.html">PrivateModule</a>
+					<a href="_access_.PrivateModule.html">PrivateModule</a>
 				</li>
 			</ul>
 			<h1>Module PrivateModule</h1>
@@ -83,7 +83,7 @@
 						<section class="tsd-index-section ">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-module"><a href="_access_.privatemodule.html#functioninsideprivatemodule" class="tsd-kind-icon">function<wbr>Inside<wbr>Private<wbr>Module</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-module"><a href="_access_.PrivateModule.html#functionInsidePrivateModule" class="tsd-kind-icon">function<wbr>Inside<wbr>Private<wbr>Module</a></li>
 							</ul>
 						</section>
 					</div>
@@ -92,7 +92,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Functions</h2>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-module">
-					<a name="functioninsideprivatemodule" class="tsd-anchor"></a>
+					<a name="functionInsidePrivateModule" class="tsd-anchor"></a>
 					<h3>function<wbr>Inside<wbr>Private<wbr>Module</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-module">
 						<li class="tsd-signature tsd-kind-icon">function<wbr>Inside<wbr>Private<wbr>Module<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -120,7 +120,7 @@
 						<a href="_access_.html">"access"</a>
 						<ul>
 							<li class="current tsd-kind-module tsd-parent-kind-external-module tsd-is-private">
-								<a href="_access_.privatemodule.html">Private<wbr>Module</a>
+								<a href="_access_.PrivateModule.html">Private<wbr>Module</a>
 							</li>
 						</ul>
 					</li>
@@ -165,7 +165,7 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-function tsd-parent-kind-module">
-						<a href="_access_.privatemodule.html#functioninsideprivatemodule" class="tsd-kind-icon">function<wbr>Inside<wbr>Private<wbr>Module</a>
+						<a href="_access_.PrivateModule.html#functionInsidePrivateModule" class="tsd-kind-icon">function<wbr>Inside<wbr>Private<wbr>Module</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_classes_.html
+++ b/src/test/renderer/specs/modules/_classes_.html
@@ -73,20 +73,20 @@
 						<section class="tsd-index-section ">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter"><a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter"><a href="../classes/_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../classes/_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Interfaces</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-interface tsd-parent-kind-external-module"><a href="../interfaces/_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module"><a href="../interfaces/_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module"><a href="../interfaces/_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module"><a href="../interfaces/_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module"><a href="../interfaces/_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module"><a href="../interfaces/_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a></li>
 							</ul>
 						</section>
 					</div>
@@ -143,31 +143,31 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.baseclass.html" class="tsd-kind-icon">Base<wbr>Class</a>
+						<a href="../classes/_classes_.BaseClass.html" class="tsd-kind-icon">Base<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="../classes/_classes_.genericclass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
+						<a href="../classes/_classes_.GenericClass.html" class="tsd-kind-icon">Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../classes/_classes_.internalclass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
+						<a href="../classes/_classes_.InternalClass.html" class="tsd-kind-icon">Internal<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.nongenericclass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
+						<a href="../classes/_classes_.NonGenericClass.html" class="tsd-kind-icon">Non<wbr>Generic<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.subclassa.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
+						<a href="../classes/_classes_.SubClassA.html" class="tsd-kind-icon">Sub<wbr>ClassA</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_classes_.subclassb.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
+						<a href="../classes/_classes_.SubClassB.html" class="tsd-kind-icon">Sub<wbr>ClassB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.inameinterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
+						<a href="../interfaces/_classes_.INameInterface.html" class="tsd-kind-icon">IName<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintinterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintInterface.html" class="tsd-kind-icon">IPrint<wbr>Interface</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
-						<a href="../interfaces/_classes_.iprintnameinterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
+						<a href="../interfaces/_classes_.IPrintNameInterface.html" class="tsd-kind-icon">IPrint<wbr>Name<wbr>Interface</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_default_export_.html
+++ b/src/test/renderer/specs/modules/_default_export_.html
@@ -73,8 +73,8 @@
 						<section class="tsd-index-section ">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_default_export_.defaultexportedclass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_default_export_.notexportedclassname.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class<wbr>Name</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_default_export_.DefaultExportedClass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_default_export_.NotExportedClassName.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class<wbr>Name</a></li>
 							</ul>
 						</section>
 					</div>
@@ -131,10 +131,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_default_export_.defaultexportedclass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a>
+						<a href="../classes/_default_export_.DefaultExportedClass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../classes/_default_export_.notexportedclassname.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class<wbr>Name</a>
+						<a href="../classes/_default_export_.NotExportedClassName.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class<wbr>Name</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_enumerations_.html
+++ b/src/test/renderer/specs/modules/_enumerations_.html
@@ -73,8 +73,8 @@
 						<section class="tsd-index-section ">
 							<h3>Enumerations</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-enum tsd-parent-kind-external-module"><a href="../enums/_enumerations_.directions.html" class="tsd-kind-icon">Directions</a></li>
-								<li class="tsd-kind-enum tsd-parent-kind-external-module"><a href="../enums/_enumerations_.size.html" class="tsd-kind-icon">Size</a></li>
+								<li class="tsd-kind-enum tsd-parent-kind-external-module"><a href="../enums/_enumerations_.Directions.html" class="tsd-kind-icon">Directions</a></li>
+								<li class="tsd-kind-enum tsd-parent-kind-external-module"><a href="../enums/_enumerations_.Size.html" class="tsd-kind-icon">Size</a></li>
 							</ul>
 						</section>
 					</div>
@@ -131,10 +131,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-enum tsd-parent-kind-external-module">
-						<a href="../enums/_enumerations_.directions.html" class="tsd-kind-icon">Directions</a>
+						<a href="../enums/_enumerations_.Directions.html" class="tsd-kind-icon">Directions</a>
 					</li>
 					<li class=" tsd-kind-enum tsd-parent-kind-external-module">
-						<a href="../enums/_enumerations_.size.html" class="tsd-kind-icon">Size</a>
+						<a href="../enums/_enumerations_.Size.html" class="tsd-kind-icon">Size</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_flattened_.html
+++ b/src/test/renderer/specs/modules/_flattened_.html
@@ -73,15 +73,15 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_flattened_.flattenedclass.html" class="tsd-kind-icon">flattened<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_flattened_.flattenedClass.html" class="tsd-kind-icon">flattened<wbr>Class</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_flattened_.html#flattenedcallback" class="tsd-kind-icon">flattened<wbr>Callback</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_flattened_.html#flattenedindexsignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_flattened_.html#flattenedparameter" class="tsd-kind-icon">flattened<wbr>Parameter</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_flattened_.html#flattenedCallback" class="tsd-kind-icon">flattened<wbr>Callback</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_flattened_.html#flattenedIndexSignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_flattened_.html#flattenedParameter" class="tsd-kind-icon">flattened<wbr>Parameter</a></li>
 							</ul>
 						</section>
 					</div>
@@ -90,7 +90,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Functions</h2>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="flattenedcallback" class="tsd-anchor"></a>
+					<a name="flattenedCallback" class="tsd-anchor"></a>
 					<h3>flattened<wbr>Callback</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">flattened<wbr>Callback<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -148,7 +148,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="flattenedindexsignature" class="tsd-anchor"></a>
+					<a name="flattenedIndexSignature" class="tsd-anchor"></a>
 					<h3>flattened<wbr>Index<wbr>Signature</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">flattened<wbr>Index<wbr>Signature<span class="tsd-signature-symbol">(</span>indexed<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -198,7 +198,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="flattenedparameter" class="tsd-anchor"></a>
+					<a name="flattenedParameter" class="tsd-anchor"></a>
 					<h3>flattened<wbr>Parameter</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">flattened<wbr>Parameter<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -311,16 +311,16 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../classes/_flattened_.flattenedclass.html" class="tsd-kind-icon">flattened<wbr>Class</a>
+						<a href="../classes/_flattened_.flattenedClass.html" class="tsd-kind-icon">flattened<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_flattened_.html#flattenedcallback" class="tsd-kind-icon">flattened<wbr>Callback</a>
+						<a href="_flattened_.html#flattenedCallback" class="tsd-kind-icon">flattened<wbr>Callback</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_flattened_.html#flattenedindexsignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a>
+						<a href="_flattened_.html#flattenedIndexSignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_flattened_.html#flattenedparameter" class="tsd-kind-icon">flattened<wbr>Parameter</a>
+						<a href="_flattened_.html#flattenedParameter" class="tsd-kind-icon">flattened<wbr>Parameter</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_functions_.html
+++ b/src/test/renderer/specs/modules/_functions_.html
@@ -73,23 +73,23 @@
 						<section class="tsd-index-section ">
 							<h3>Modules</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-module tsd-parent-kind-external-module"><a href="_functions_.modulefunction.html" class="tsd-kind-icon">module<wbr>Function</a></li>
+								<li class="tsd-kind-module tsd-parent-kind-external-module"><a href="_functions_.moduleFunction.html" class="tsd-kind-icon">module<wbr>Function</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#createsomething" class="tsd-kind-icon">create<wbr>Something</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#exportedfunction" class="tsd-kind-icon">exported<wbr>Function</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#functionwitharguments" class="tsd-kind-icon">function<wbr>With<wbr>Arguments</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#functionwithdefaults" class="tsd-kind-icon">function<wbr>With<wbr>Defaults</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#functionwithdoclink" class="tsd-kind-icon">function<wbr>With<wbr>Doc<wbr>Link</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#functionwithoptionalvalue" class="tsd-kind-icon">function<wbr>With<wbr>Optional<wbr>Value</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_functions_.html#functionwithrest" class="tsd-kind-icon">function<wbr>With<wbr>Rest</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter"><a href="_functions_.html#genericfunction" class="tsd-kind-icon">generic<wbr>Function</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_functions_.html#internalfunction" class="tsd-kind-icon">internal<wbr>Function</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#multiplesignatures" class="tsd-kind-icon">multiple<wbr>Signatures</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_functions_.html#variablefunction" class="tsd-kind-icon">variable<wbr>Function</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#createSomething" class="tsd-kind-icon">create<wbr>Something</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#exportedFunction" class="tsd-kind-icon">exported<wbr>Function</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#functionWithArguments" class="tsd-kind-icon">function<wbr>With<wbr>Arguments</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#functionWithDefaults" class="tsd-kind-icon">function<wbr>With<wbr>Defaults</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#functionWithDocLink" class="tsd-kind-icon">function<wbr>With<wbr>Doc<wbr>Link</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#functionWithOptionalValue" class="tsd-kind-icon">function<wbr>With<wbr>Optional<wbr>Value</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_functions_.html#functionWithRest" class="tsd-kind-icon">function<wbr>With<wbr>Rest</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter"><a href="_functions_.html#genericFunction" class="tsd-kind-icon">generic<wbr>Function</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_functions_.html#internalFunction" class="tsd-kind-icon">internal<wbr>Function</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_functions_.html#multipleSignatures" class="tsd-kind-icon">multiple<wbr>Signatures</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_functions_.html#variableFunction" class="tsd-kind-icon">variable<wbr>Function</a></li>
 							</ul>
 						</section>
 					</div>
@@ -98,7 +98,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Functions</h2>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
-					<a name="createsomething" class="tsd-anchor"></a>
+					<a name="createSomething" class="tsd-anchor"></a>
 					<h3>create<wbr>Something</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">create<wbr>Something<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span></li>
@@ -162,7 +162,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
-					<a name="exportedfunction" class="tsd-anchor"></a>
+					<a name="exportedFunction" class="tsd-anchor"></a>
 					<h3>exported<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">exported<wbr>Function<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -184,10 +184,10 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
-					<a name="functionwitharguments" class="tsd-anchor"></a>
+					<a name="functionWithArguments" class="tsd-anchor"></a>
 					<h3>function<wbr>With<wbr>Arguments</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
-						<li class="tsd-signature tsd-kind-icon">function<wbr>With<wbr>Arguments<span class="tsd-signature-symbol">(</span>paramZ<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, paramG<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, paramA<span class="tsd-signature-symbol">: </span><a href="../interfaces/_classes_.inameinterface.html" class="tsd-signature-type">INameInterface</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
+						<li class="tsd-signature tsd-kind-icon">function<wbr>With<wbr>Arguments<span class="tsd-signature-symbol">(</span>paramZ<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, paramG<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, paramA<span class="tsd-signature-symbol">: </span><a href="../interfaces/_classes_.INameInterface.html" class="tsd-signature-type">INameInterface</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -217,7 +217,7 @@
 									</div>
 								</li>
 								<li>
-									<h5>paramA: <a href="../interfaces/_classes_.inameinterface.html" class="tsd-signature-type">INameInterface</a></h5>
+									<h5>paramA: <a href="../interfaces/_classes_.INameInterface.html" class="tsd-signature-type">INameInterface</a></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>This is a <strong>parameter</strong> pointing to an interface.</p>
 										<pre><code><span class="hljs-keyword">var</span> <span class="hljs-keyword">value</span>:BaseClass = <span class="hljs-keyword">new</span> BaseClass(<span class="hljs-string">'test'</span>);
@@ -231,7 +231,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
-					<a name="functionwithdefaults" class="tsd-anchor"></a>
+					<a name="functionWithDefaults" class="tsd-anchor"></a>
 					<h3>function<wbr>With<wbr>Defaults</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">function<wbr>With<wbr>Defaults<span class="tsd-signature-symbol">(</span>valueA<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, valueB<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span>, valueC<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span>, valueD<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span>, valueE<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -272,7 +272,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
-					<a name="functionwithdoclink" class="tsd-anchor"></a>
+					<a name="functionWithDocLink" class="tsd-anchor"></a>
 					<h3>function<wbr>With<wbr>Doc<wbr>Link</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">function<wbr>With<wbr>Doc<wbr>Link<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -286,7 +286,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>See <a href="../interfaces/_classes_.inameinterface.html"><code>INameInterface</code></a> and <a href="../interfaces/_classes_.inameinterface.html#name">INameInterface&#39;s name property</a>.
+									<p>See <a href="../interfaces/_classes_.INameInterface.html"><code>INameInterface</code></a> and <a href="../interfaces/_classes_.INameInterface.html#name">INameInterface&#39;s name property</a>.
 										Also, check out <a href="http://www.google.com" class="external">Google</a> and
 									<a href="https://github.com" class="external">GitHub</a>.</p>
 								</div>
@@ -297,7 +297,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
-					<a name="functionwithoptionalvalue" class="tsd-anchor"></a>
+					<a name="functionWithOptionalValue" class="tsd-anchor"></a>
 					<h3>function<wbr>With<wbr>Optional<wbr>Value</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">function<wbr>With<wbr>Optional<wbr>Value<span class="tsd-signature-symbol">(</span>requiredParam<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, optionalParam<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -334,7 +334,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="functionwithrest" class="tsd-anchor"></a>
+					<a name="functionWithRest" class="tsd-anchor"></a>
 					<h3>function<wbr>With<wbr>Rest</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">function<wbr>With<wbr>Rest<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>rest<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -366,7 +366,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
-					<a name="genericfunction" class="tsd-anchor"></a>
+					<a name="genericFunction" class="tsd-anchor"></a>
 					<h3>generic<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
 						<li class="tsd-signature tsd-kind-icon">generic<wbr>Function&lt;T&gt;<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span></li>
@@ -407,7 +407,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="internalfunction" class="tsd-anchor"></a>
+					<a name="internalFunction" class="tsd-anchor"></a>
 					<h3>internal<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">internal<wbr>Function<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -429,7 +429,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
-					<a name="multiplesignatures" class="tsd-anchor"></a>
+					<a name="multipleSignatures" class="tsd-anchor"></a>
 					<h3>multiple<wbr>Signatures</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">multiple<wbr>Signatures<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -491,10 +491,10 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="variablefunction" class="tsd-anchor"></a>
+					<a name="variableFunction" class="tsd-anchor"></a>
 					<h3>variable<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">variable<wbr>Function<span class="tsd-signature-symbol">(</span>paramZ<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, paramG<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, paramA<span class="tsd-signature-symbol">: </span><a href="../interfaces/_classes_.inameinterface.html" class="tsd-signature-type">INameInterface</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
+						<li class="tsd-signature tsd-kind-icon">variable<wbr>Function<span class="tsd-signature-symbol">(</span>paramZ<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, paramG<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, paramA<span class="tsd-signature-symbol">: </span><a href="../interfaces/_classes_.INameInterface.html" class="tsd-signature-type">INameInterface</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -528,7 +528,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 									</div>
 								</li>
 								<li>
-									<h5>paramA: <a href="../interfaces/_classes_.inameinterface.html" class="tsd-signature-type">INameInterface</a></h5>
+									<h5>paramA: <a href="../interfaces/_classes_.INameInterface.html" class="tsd-signature-type">INameInterface</a></h5>
 									<div class="tsd-comment tsd-typography">
 										<div class="lead">
 											<p>This is a <strong>parameter</strong> pointing to an interface.</p>
@@ -570,7 +570,7 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 						<a href="_functions_.html">"functions"</a>
 						<ul>
 							<li class=" tsd-kind-module tsd-parent-kind-external-module">
-								<a href="_functions_.modulefunction.html">module<wbr>Function</a>
+								<a href="_functions_.moduleFunction.html">module<wbr>Function</a>
 							</li>
 						</ul>
 					</li>
@@ -600,37 +600,37 @@ functionWithArguments(<span class="hljs-string">'arg'</span>, <span class="hljs-
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-function tsd-parent-kind-external-module">
-						<a href="_functions_.html#createsomething" class="tsd-kind-icon">create<wbr>Something</a>
+						<a href="_functions_.html#createSomething" class="tsd-kind-icon">create<wbr>Something</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module">
-						<a href="_functions_.html#exportedfunction" class="tsd-kind-icon">exported<wbr>Function</a>
+						<a href="_functions_.html#exportedFunction" class="tsd-kind-icon">exported<wbr>Function</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module">
-						<a href="_functions_.html#functionwitharguments" class="tsd-kind-icon">function<wbr>With<wbr>Arguments</a>
+						<a href="_functions_.html#functionWithArguments" class="tsd-kind-icon">function<wbr>With<wbr>Arguments</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module">
-						<a href="_functions_.html#functionwithdefaults" class="tsd-kind-icon">function<wbr>With<wbr>Defaults</a>
+						<a href="_functions_.html#functionWithDefaults" class="tsd-kind-icon">function<wbr>With<wbr>Defaults</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module">
-						<a href="_functions_.html#functionwithdoclink" class="tsd-kind-icon">function<wbr>With<wbr>Doc<wbr>Link</a>
+						<a href="_functions_.html#functionWithDocLink" class="tsd-kind-icon">function<wbr>With<wbr>Doc<wbr>Link</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module">
-						<a href="_functions_.html#functionwithoptionalvalue" class="tsd-kind-icon">function<wbr>With<wbr>Optional<wbr>Value</a>
+						<a href="_functions_.html#functionWithOptionalValue" class="tsd-kind-icon">function<wbr>With<wbr>Optional<wbr>Value</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_functions_.html#functionwithrest" class="tsd-kind-icon">function<wbr>With<wbr>Rest</a>
+						<a href="_functions_.html#functionWithRest" class="tsd-kind-icon">function<wbr>With<wbr>Rest</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
-						<a href="_functions_.html#genericfunction" class="tsd-kind-icon">generic<wbr>Function</a>
+						<a href="_functions_.html#genericFunction" class="tsd-kind-icon">generic<wbr>Function</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_functions_.html#internalfunction" class="tsd-kind-icon">internal<wbr>Function</a>
+						<a href="_functions_.html#internalFunction" class="tsd-kind-icon">internal<wbr>Function</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module">
-						<a href="_functions_.html#multiplesignatures" class="tsd-kind-icon">multiple<wbr>Signatures</a>
+						<a href="_functions_.html#multipleSignatures" class="tsd-kind-icon">multiple<wbr>Signatures</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_functions_.html#variablefunction" class="tsd-kind-icon">variable<wbr>Function</a>
+						<a href="_functions_.html#variableFunction" class="tsd-kind-icon">variable<wbr>Function</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_functions_.modulefunction.html
+++ b/src/test/renderer/specs/modules/_functions_.modulefunction.html
@@ -59,7 +59,7 @@
 					<a href="_functions_.html">&quot;functions&quot;</a>
 				</li>
 				<li>
-					<a href="_functions_.modulefunction.html">moduleFunction</a>
+					<a href="_functions_.moduleFunction.html">moduleFunction</a>
 				</li>
 			</ul>
 			<h1>Module moduleFunction</h1>
@@ -113,14 +113,14 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.modulefunction.html#functionvariable" class="tsd-kind-icon">function<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.moduleFunction.html#functionVariable" class="tsd-kind-icon">function<wbr>Variable</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.modulefunction.html#append" class="tsd-kind-icon">append</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.modulefunction.html#prepend" class="tsd-kind-icon">prepend</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.moduleFunction.html#append" class="tsd-kind-icon">append</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.moduleFunction.html#prepend" class="tsd-kind-icon">prepend</a></li>
 							</ul>
 						</section>
 					</div>
@@ -129,7 +129,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-					<a name="functionvariable" class="tsd-anchor"></a>
+					<a name="functionVariable" class="tsd-anchor"></a>
 					<h3>function<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">function<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -217,7 +217,7 @@
 						<a href="_functions_.html">"functions"</a>
 						<ul>
 							<li class="current tsd-kind-module tsd-parent-kind-external-module">
-								<a href="_functions_.modulefunction.html">module<wbr>Function</a>
+								<a href="_functions_.moduleFunction.html">module<wbr>Function</a>
 							</li>
 						</ul>
 					</li>
@@ -247,13 +247,13 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_functions_.modulefunction.html#functionvariable" class="tsd-kind-icon">function<wbr>Variable</a>
+						<a href="_functions_.moduleFunction.html#functionVariable" class="tsd-kind-icon">function<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_functions_.modulefunction.html#append" class="tsd-kind-icon">append</a>
+						<a href="_functions_.moduleFunction.html#append" class="tsd-kind-icon">append</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_functions_.modulefunction.html#prepend" class="tsd-kind-icon">prepend</a>
+						<a href="_functions_.moduleFunction.html#prepend" class="tsd-kind-icon">prepend</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_generics_.html
+++ b/src/test/renderer/specs/modules/_generics_.html
@@ -73,18 +73,18 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Interfaces</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../interfaces/_generics_.a.html" class="tsd-kind-icon">A</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../interfaces/_generics_.ab.html" class="tsd-kind-icon">AB</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported"><a href="../interfaces/_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported"><a href="../interfaces/_generics_.abstring.html" class="tsd-kind-icon">ABString</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../interfaces/_generics_.b.html" class="tsd-kind-icon">B</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../interfaces/_generics_.A.html" class="tsd-kind-icon">A</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../interfaces/_generics_.AB.html" class="tsd-kind-icon">AB</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported"><a href="../interfaces/_generics_.ABNumber.html" class="tsd-kind-icon">ABNumber</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported"><a href="../interfaces/_generics_.ABString.html" class="tsd-kind-icon">ABString</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../interfaces/_generics_.B.html" class="tsd-kind-icon">B</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_generics_.html#getGenericArray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="_generics_.html#testFunction" class="tsd-kind-icon">test<wbr>Function</a></li>
 							</ul>
 						</section>
 					</div>
@@ -93,7 +93,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Functions</h2>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="getgenericarray" class="tsd-anchor"></a>
+					<a name="getGenericArray" class="tsd-anchor"></a>
 					<h3>get<wbr>Generic<wbr>Array</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Generic<wbr>Array<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></li>
@@ -116,7 +116,7 @@
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-					<a name="testfunction" class="tsd-anchor"></a>
+					<a name="testFunction" class="tsd-anchor"></a>
 					<h3>test<wbr>Function</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">test<wbr>Function&lt;T&gt;<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span></li>
@@ -208,25 +208,25 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../interfaces/_generics_.a.html" class="tsd-kind-icon">A</a>
+						<a href="../interfaces/_generics_.A.html" class="tsd-kind-icon">A</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../interfaces/_generics_.ab.html" class="tsd-kind-icon">AB</a>
+						<a href="../interfaces/_generics_.AB.html" class="tsd-kind-icon">AB</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../interfaces/_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
+						<a href="../interfaces/_generics_.ABNumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../interfaces/_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
+						<a href="../interfaces/_generics_.ABString.html" class="tsd-kind-icon">ABString</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="../interfaces/_generics_.b.html" class="tsd-kind-icon">B</a>
+						<a href="../interfaces/_generics_.B.html" class="tsd-kind-icon">B</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
+						<a href="_generics_.html#getGenericArray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
+						<a href="_generics_.html#testFunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_modules_.html
+++ b/src/test/renderer/specs/modules/_modules_.html
@@ -80,21 +80,21 @@
 						<section class="tsd-index-section ">
 							<h3>Modules</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-module tsd-parent-kind-external-module"><a href="_modules_.mymodule.html" class="tsd-kind-icon">My<wbr>Module</a></li>
+								<li class="tsd-kind-module tsd-parent-kind-external-module"><a href="_modules_.MyModule.html" class="tsd-kind-icon">My<wbr>Module</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_modules_.html#exportedglobalvariable" class="tsd-kind-icon">exported<wbr>Global<wbr>Variable</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_modules_.html#globalvariable" class="tsd-kind-icon">global<wbr>Variable</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_modules_.html#typeliteral" class="tsd-kind-icon">type<wbr>Literal</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_modules_.html#exportedGlobalVariable" class="tsd-kind-icon">exported<wbr>Global<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_modules_.html#globalVariable" class="tsd-kind-icon">global<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_modules_.html#typeLiteral" class="tsd-kind-icon">type<wbr>Literal</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Object literals</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-object-literal tsd-parent-kind-external-module tsd-is-not-exported"><a href="_modules_.html#objectliteral" class="tsd-kind-icon">object<wbr>Literal</a></li>
+								<li class="tsd-kind-object-literal tsd-parent-kind-external-module tsd-is-not-exported"><a href="_modules_.html#objectLiteral" class="tsd-kind-icon">object<wbr>Literal</a></li>
 							</ul>
 						</section>
 					</div>
@@ -103,7 +103,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
-					<a name="exportedglobalvariable" class="tsd-anchor"></a>
+					<a name="exportedGlobalVariable" class="tsd-anchor"></a>
 					<h3>exported<wbr>Global<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">exported<wbr>Global<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;foo&quot;</span></div>
 					<aside class="tsd-sources">
@@ -118,7 +118,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="globalvariable" class="tsd-anchor"></a>
+					<a name="globalVariable" class="tsd-anchor"></a>
 					<h3>global<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">global<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;foo&quot;</span></div>
 					<aside class="tsd-sources">
@@ -133,7 +133,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="typeliteral" class="tsd-anchor"></a>
+					<a name="typeLiteral" class="tsd-anchor"></a>
 					<h3>type<wbr>Literal</h3>
 					<div class="tsd-signature tsd-kind-icon">type<wbr>Literal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
@@ -225,7 +225,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Object literals</h2>
 				<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="objectliteral" class="tsd-anchor"></a>
+					<a name="objectLiteral" class="tsd-anchor"></a>
 					<h3>object<wbr>Literal</h3>
 					<div class="tsd-signature tsd-kind-icon">object<wbr>Literal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
@@ -239,7 +239,7 @@
 						</div>
 					</div>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal tsd-is-not-exported">
-						<a name="objectliteral.valuea-2" class="tsd-anchor"></a>
+						<a name="objectLiteral.valueA-2" class="tsd-anchor"></a>
 						<h3>valueA</h3>
 						<div class="tsd-signature tsd-kind-icon">valueA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;100</span></div>
 						<aside class="tsd-sources">
@@ -249,7 +249,7 @@
 						</aside>
 					</section>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal tsd-is-not-exported">
-						<a name="objectliteral.valueb-1" class="tsd-anchor"></a>
+						<a name="objectLiteral.valueB-1" class="tsd-anchor"></a>
 						<h3>valueB</h3>
 						<div class="tsd-signature tsd-kind-icon">valueB<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> =&nbsp;true</span></div>
 						<aside class="tsd-sources">
@@ -259,7 +259,7 @@
 						</aside>
 					</section>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal tsd-is-not-exported">
-						<a name="objectliteral.valuez-2" class="tsd-anchor"></a>
+						<a name="objectLiteral.valueZ-2" class="tsd-anchor"></a>
 						<h3>valueZ</h3>
 						<div class="tsd-signature tsd-kind-icon">valueZ<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;foo&quot;</span></div>
 						<aside class="tsd-sources">
@@ -269,7 +269,7 @@
 						</aside>
 					</section>
 					<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-object-literal tsd-is-not-exported">
-						<a name="objectliteral.valuey-2" class="tsd-anchor"></a>
+						<a name="objectLiteral.valueY-2" class="tsd-anchor"></a>
 						<h3>valueY</h3>
 						<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-object-literal tsd-is-not-exported">
 							<li class="tsd-signature tsd-kind-icon">valueY<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
@@ -286,7 +286,7 @@
 						</ul>
 					</section>
 					<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-object-literal tsd-is-not-exported">
-						<a name="objectliteral.valuex-1" class="tsd-anchor"></a>
+						<a name="objectLiteral.valueX-1" class="tsd-anchor"></a>
 						<h3>valueX</h3>
 						<div class="tsd-signature tsd-kind-icon">valueX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
@@ -295,7 +295,7 @@
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal tsd-is-not-exported">
-							<a name="objectliteral.valuex-1.valuea-3" class="tsd-anchor"></a>
+							<a name="objectLiteral.valueX-1.valueA-3" class="tsd-anchor"></a>
 							<h3>valueA</h3>
 							<div class="tsd-signature tsd-kind-icon">valueA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[100, 200, 300]</span></div>
 							<aside class="tsd-sources">
@@ -305,7 +305,7 @@
 							</aside>
 						</section>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal tsd-is-not-exported">
-							<a name="objectliteral.valuex-1.valuez-3" class="tsd-anchor"></a>
+							<a name="objectLiteral.valueX-1.valueZ-3" class="tsd-anchor"></a>
 							<h3>valueZ</h3>
 							<div class="tsd-signature tsd-kind-icon">valueZ<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;foo&quot;</span></div>
 							<aside class="tsd-sources">
@@ -315,7 +315,7 @@
 							</aside>
 						</section>
 						<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-object-literal tsd-is-not-exported">
-							<a name="objectliteral.valuex-1.valuey-3" class="tsd-anchor"></a>
+							<a name="objectLiteral.valueX-1.valueY-3" class="tsd-anchor"></a>
 							<h3>valueY</h3>
 							<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-object-literal tsd-is-not-exported">
 								<li class="tsd-signature tsd-kind-icon">valueY<span class="tsd-signature-symbol">(</span>z<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span></li>
@@ -380,7 +380,7 @@
 						<a href="_modules_.html">"modules"</a>
 						<ul>
 							<li class=" tsd-kind-module tsd-parent-kind-external-module">
-								<a href="_modules_.mymodule.html">My<wbr>Module</a>
+								<a href="_modules_.MyModule.html">My<wbr>Module</a>
 							</li>
 						</ul>
 					</li>
@@ -404,16 +404,16 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
-						<a href="_modules_.html#exportedglobalvariable" class="tsd-kind-icon">exported<wbr>Global<wbr>Variable</a>
+						<a href="_modules_.html#exportedGlobalVariable" class="tsd-kind-icon">exported<wbr>Global<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_modules_.html#globalvariable" class="tsd-kind-icon">global<wbr>Variable</a>
+						<a href="_modules_.html#globalVariable" class="tsd-kind-icon">global<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_modules_.html#typeliteral" class="tsd-kind-icon">type<wbr>Literal</a>
+						<a href="_modules_.html#typeLiteral" class="tsd-kind-icon">type<wbr>Literal</a>
 					</li>
 					<li class=" tsd-kind-object-literal tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_modules_.html#objectliteral" class="tsd-kind-icon">object<wbr>Literal</a>
+						<a href="_modules_.html#objectLiteral" class="tsd-kind-icon">object<wbr>Literal</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_modules_.mymodule.html
+++ b/src/test/renderer/specs/modules/_modules_.mymodule.html
@@ -59,7 +59,7 @@
 					<a href="_modules_.html">&quot;modules&quot;</a>
 				</li>
 				<li>
-					<a href="_modules_.mymodule.html">MyModule</a>
+					<a href="_modules_.MyModule.html">MyModule</a>
 				</li>
 			</ul>
 			<h1>Module MyModule</h1>
@@ -83,21 +83,21 @@
 						<section class="tsd-index-section ">
 							<h3>Modules</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-module tsd-parent-kind-module"><a href="_modules_.mymodule.mysubmodule.html" class="tsd-kind-icon">My<wbr>Submodule</a></li>
+								<li class="tsd-kind-module tsd-parent-kind-module"><a href="_modules_.MyModule.MySubmodule.html" class="tsd-kind-icon">My<wbr>Submodule</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-module"><a href="_modules_.mymodule.html#exportedmodulevariable" class="tsd-kind-icon">exported<wbr>Module<wbr>Variable</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_modules_.mymodule.html#modulevariable" class="tsd-kind-icon">module<wbr>Variable</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_modules_.mymodule.html#modulevariable2" class="tsd-kind-icon">module<wbr>Variable2</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-module"><a href="_modules_.MyModule.html#exportedModuleVariable" class="tsd-kind-icon">exported<wbr>Module<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_modules_.MyModule.html#moduleVariable" class="tsd-kind-icon">module<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_modules_.MyModule.html#moduleVariable2" class="tsd-kind-icon">module<wbr>Variable2</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Object literals</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-object-literal tsd-parent-kind-module"><a href="_modules_.mymodule.html#object" class="tsd-kind-icon">object</a></li>
+								<li class="tsd-kind-object-literal tsd-parent-kind-module"><a href="_modules_.MyModule.html#object" class="tsd-kind-icon">object</a></li>
 							</ul>
 						</section>
 					</div>
@@ -106,7 +106,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module">
-					<a name="exportedmodulevariable" class="tsd-anchor"></a>
+					<a name="exportedModuleVariable" class="tsd-anchor"></a>
 					<h3>exported<wbr>Module<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">exported<wbr>Module<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;foo&quot;</span></div>
 					<aside class="tsd-sources">
@@ -116,7 +116,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-					<a name="modulevariable" class="tsd-anchor"></a>
+					<a name="moduleVariable" class="tsd-anchor"></a>
 					<h3>module<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">module<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[100, 200]</span></div>
 					<aside class="tsd-sources">
@@ -126,7 +126,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-					<a name="modulevariable2" class="tsd-anchor"></a>
+					<a name="moduleVariable2" class="tsd-anchor"></a>
 					<h3>module<wbr>Variable2</h3>
 					<div class="tsd-signature tsd-kind-icon">module<wbr>Variable2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
@@ -229,10 +229,10 @@
 						<a href="_modules_.html">"modules"</a>
 						<ul>
 							<li class="current tsd-kind-module tsd-parent-kind-external-module">
-								<a href="_modules_.mymodule.html">My<wbr>Module</a>
+								<a href="_modules_.MyModule.html">My<wbr>Module</a>
 								<ul>
 									<li class=" tsd-kind-module tsd-parent-kind-module">
-										<a href="_modules_.mymodule.mysubmodule.html">My<wbr>Submodule</a>
+										<a href="_modules_.MyModule.MySubmodule.html">My<wbr>Submodule</a>
 									</li>
 								</ul>
 							</li>
@@ -258,16 +258,16 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-variable tsd-parent-kind-module">
-						<a href="_modules_.mymodule.html#exportedmodulevariable" class="tsd-kind-icon">exported<wbr>Module<wbr>Variable</a>
+						<a href="_modules_.MyModule.html#exportedModuleVariable" class="tsd-kind-icon">exported<wbr>Module<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_modules_.mymodule.html#modulevariable" class="tsd-kind-icon">module<wbr>Variable</a>
+						<a href="_modules_.MyModule.html#moduleVariable" class="tsd-kind-icon">module<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_modules_.mymodule.html#modulevariable2" class="tsd-kind-icon">module<wbr>Variable2</a>
+						<a href="_modules_.MyModule.html#moduleVariable2" class="tsd-kind-icon">module<wbr>Variable2</a>
 					</li>
 					<li class=" tsd-kind-object-literal tsd-parent-kind-module">
-						<a href="_modules_.mymodule.html#object" class="tsd-kind-icon">object</a>
+						<a href="_modules_.MyModule.html#object" class="tsd-kind-icon">object</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_modules_.mymodule.mysubmodule.html
+++ b/src/test/renderer/specs/modules/_modules_.mymodule.mysubmodule.html
@@ -59,10 +59,10 @@
 					<a href="_modules_.html">&quot;modules&quot;</a>
 				</li>
 				<li>
-					<a href="_modules_.mymodule.html">MyModule</a>
+					<a href="_modules_.MyModule.html">MyModule</a>
 				</li>
 				<li>
-					<a href="_modules_.mymodule.mysubmodule.html">MySubmodule</a>
+					<a href="_modules_.MyModule.MySubmodule.html">MySubmodule</a>
 				</li>
 			</ul>
 			<h1>Module MySubmodule</h1>
@@ -86,8 +86,8 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_modules_.mymodule.mysubmodule.html#a" class="tsd-kind-icon">a</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_modules_.mymodule.mysubmodule.html#b" class="tsd-kind-icon">b</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_modules_.MyModule.MySubmodule.html#a" class="tsd-kind-icon">a</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_modules_.MyModule.MySubmodule.html#b" class="tsd-kind-icon">b</a></li>
 							</ul>
 						</section>
 					</div>
@@ -148,10 +148,10 @@
 						<a href="_modules_.html">"modules"</a>
 						<ul>
 							<li class="current tsd-kind-module tsd-parent-kind-external-module">
-								<a href="_modules_.mymodule.html">My<wbr>Module</a>
+								<a href="_modules_.MyModule.html">My<wbr>Module</a>
 								<ul>
 									<li class="current tsd-kind-module tsd-parent-kind-module">
-										<a href="_modules_.mymodule.mysubmodule.html">My<wbr>Submodule</a>
+										<a href="_modules_.MyModule.MySubmodule.html">My<wbr>Submodule</a>
 									</li>
 								</ul>
 							</li>
@@ -177,10 +177,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_modules_.mymodule.mysubmodule.html#a" class="tsd-kind-icon">a</a>
+						<a href="_modules_.MyModule.MySubmodule.html#a" class="tsd-kind-icon">a</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_modules_.mymodule.mysubmodule.html#b" class="tsd-kind-icon">b</a>
+						<a href="_modules_.MyModule.MySubmodule.html#b" class="tsd-kind-icon">b</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_single_export_.html
+++ b/src/test/renderer/specs/modules/_single_export_.html
@@ -73,8 +73,8 @@
 						<section class="tsd-index-section ">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_single_export_.notexportedclass.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_single_export_.singleexportedclass.html" class="tsd-kind-icon">Single<wbr>Exported<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_single_export_.NotExportedClass.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_single_export_.SingleExportedClass.html" class="tsd-kind-icon">Single<wbr>Exported<wbr>Class</a></li>
 							</ul>
 						</section>
 					</div>
@@ -131,10 +131,10 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../classes/_single_export_.notexportedclass.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class</a>
+						<a href="../classes/_single_export_.NotExportedClass.html" class="tsd-kind-icon">Not<wbr>Exported<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
-						<a href="../classes/_single_export_.singleexportedclass.html" class="tsd-kind-icon">Single<wbr>Exported<wbr>Class</a>
+						<a href="../classes/_single_export_.SingleExportedClass.html" class="tsd-kind-icon">Single<wbr>Exported<wbr>Class</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_typescript_1_3_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_3_.html
@@ -73,14 +73,14 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_typescript_1_3_.classwithprotectedmembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_typescript_1_3_.ClassWithProtectedMembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_typescript_1_3_.SubclassWithProtectedMembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_3_.html#tupletype" class="tsd-kind-icon">tuple<wbr>Type</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_3_.html#tupleType" class="tsd-kind-icon">tuple<wbr>Type</a></li>
 							</ul>
 						</section>
 					</div>
@@ -89,9 +89,9 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="tupletype" class="tsd-anchor"></a>
+					<a name="tupleType" class="tsd-anchor"></a>
 					<h3>tuple<wbr>Type</h3>
-					<div class="tsd-signature tsd-kind-icon">tuple<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><a href="../classes/_typescript_1_3_.classwithprotectedmembers.html" class="tsd-signature-type">ClassWithProtectedMembers</a><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> =&nbsp;[&#x27;test&#x27;, new ClassWithProtectedMembers()]</span></div>
+					<div class="tsd-signature tsd-kind-icon">tuple<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><a href="../classes/_typescript_1_3_.ClassWithProtectedMembers.html" class="tsd-signature-type">ClassWithProtectedMembers</a><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> =&nbsp;[&#x27;test&#x27;, new ClassWithProtectedMembers()]</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.3.ts#L49">typescript-1.3.ts:49</a></li>
@@ -155,13 +155,13 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../classes/_typescript_1_3_.classwithprotectedmembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a>
+						<a href="../classes/_typescript_1_3_.ClassWithProtectedMembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a>
 					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../classes/_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a>
+						<a href="../classes/_typescript_1_3_.SubclassWithProtectedMembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_3_.html#tupletype" class="tsd-kind-icon">tuple<wbr>Type</a>
+						<a href="_typescript_1_3_.html#tupleType" class="tsd-kind-icon">tuple<wbr>Type</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_typescript_1_4_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_4_.html
@@ -85,37 +85,37 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_typescript_1_4_.simpleclass.html" class="tsd-kind-icon">Simple<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_typescript_1_4_.SimpleClass.html" class="tsd-kind-icon">Simple<wbr>Class</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Interfaces</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported"><a href="../interfaces/_typescript_1_4_.runoptions.html" class="tsd-kind-icon">Run<wbr>Options</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported"><a href="../interfaces/_typescript_1_4_.RunOptions.html" class="tsd-kind-icon">Run<wbr>Options</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
 							<h3>Type aliases</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#callback" class="tsd-kind-icon">Callback</a></li>
-								<li class="tsd-kind-type-alias tsd-parent-kind-external-module"><a href="_typescript_1_4_.html#genericcallback" class="tsd-kind-icon">Generic<wbr>Callback</a></li>
-								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#mynumber" class="tsd-kind-icon">My<wbr>Number</a></li>
-								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#myrunoptions" class="tsd-kind-icon">My<wbr>Run<wbr>Options</a></li>
-								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#primitivearray" class="tsd-kind-icon">Primitive<wbr>Array</a></li>
+								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#Callback" class="tsd-kind-icon">Callback</a></li>
+								<li class="tsd-kind-type-alias tsd-parent-kind-external-module"><a href="_typescript_1_4_.html#GenericCallback" class="tsd-kind-icon">Generic<wbr>Callback</a></li>
+								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#MyNumber" class="tsd-kind-icon">My<wbr>Number</a></li>
+								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#MyRunOptions" class="tsd-kind-icon">My<wbr>Run<wbr>Options</a></li>
+								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#PrimitiveArray" class="tsd-kind-icon">Primitive<wbr>Array</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#callback-1" class="tsd-kind-icon">callback</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#interfaceorstring" class="tsd-kind-icon">interface<wbr>OrString</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#callback" class="tsd-kind-icon">callback</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#interfaceOrString" class="tsd-kind-icon">interface<wbr>OrString</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#functionusingtypes" class="tsd-kind-icon">function<wbr>Using<wbr>Types</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="_typescript_1_4_.html#functionwithgenericcallback" class="tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_4_.html#functionUsingTypes" class="tsd-kind-icon">function<wbr>Using<wbr>Types</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="_typescript_1_4_.html#functionWithGenericCallback" class="tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback</a></li>
 							</ul>
 						</section>
 					</div>
@@ -124,7 +124,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Type aliases</h2>
 				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="callback" class="tsd-anchor"></a>
+					<a name="Callback" class="tsd-anchor"></a>
 					<h3>Callback</h3>
 					<div class="tsd-signature tsd-kind-icon">Callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
@@ -163,7 +163,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-external-module">
-					<a name="genericcallback" class="tsd-anchor"></a>
+					<a name="GenericCallback" class="tsd-anchor"></a>
 					<h3>Generic<wbr>Callback</h3>
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
@@ -228,7 +228,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="mynumber" class="tsd-anchor"></a>
+					<a name="MyNumber" class="tsd-anchor"></a>
 					<h3>My<wbr>Number</h3>
 					<div class="tsd-signature tsd-kind-icon">My<wbr>Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
@@ -243,9 +243,9 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="myrunoptions" class="tsd-anchor"></a>
+					<a name="MyRunOptions" class="tsd-anchor"></a>
 					<h3>My<wbr>Run<wbr>Options</h3>
-					<div class="tsd-signature tsd-kind-icon">My<wbr>Run<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_typescript_1_4_.runoptions.html" class="tsd-signature-type">RunOptions</a></div>
+					<div class="tsd-signature tsd-kind-icon">My<wbr>Run<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_typescript_1_4_.RunOptions.html" class="tsd-signature-type">RunOptions</a></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.4.ts#L31">typescript-1.4.ts:31</a></li>
@@ -258,7 +258,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="primitivearray" class="tsd-anchor"></a>
+					<a name="PrimitiveArray" class="tsd-anchor"></a>
 					<h3>Primitive<wbr>Array</h3>
 					<div class="tsd-signature tsd-kind-icon">Primitive<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
@@ -276,9 +276,9 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="callback-1" class="tsd-anchor"></a>
+					<a name="callback" class="tsd-anchor"></a>
 					<h3>callback</h3>
-					<div class="tsd-signature tsd-kind-icon">callback<span class="tsd-signature-symbol">:</span> <a href="_typescript_1_4_.html#callback" class="tsd-signature-type">Callback</a></div>
+					<div class="tsd-signature tsd-kind-icon">callback<span class="tsd-signature-symbol">:</span> <a href="_typescript_1_4_.html#Callback" class="tsd-signature-type">Callback</a></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.4.ts#L63">typescript-1.4.ts:63</a></li>
@@ -291,9 +291,9 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="interfaceorstring" class="tsd-anchor"></a>
+					<a name="interfaceOrString" class="tsd-anchor"></a>
 					<h3>interface<wbr>OrString</h3>
-					<div class="tsd-signature tsd-kind-icon">interface<wbr>OrString<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_typescript_1_4_.runoptions.html" class="tsd-signature-type">RunOptions</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
+					<div class="tsd-signature tsd-kind-icon">interface<wbr>OrString<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_typescript_1_4_.RunOptions.html" class="tsd-signature-type">RunOptions</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.4.ts#L57">typescript-1.4.ts:57</a></li>
@@ -309,10 +309,10 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Functions</h2>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="functionusingtypes" class="tsd-anchor"></a>
+					<a name="functionUsingTypes" class="tsd-anchor"></a>
 					<h3>function<wbr>Using<wbr>Types</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">function<wbr>Using<wbr>Types<span class="tsd-signature-symbol">(</span>aliasData<span class="tsd-signature-symbol">: </span><a href="_typescript_1_4_.html#primitivearray" class="tsd-signature-type">PrimitiveArray</a>, callback<span class="tsd-signature-symbol">: </span><a href="_typescript_1_4_.html#callback" class="tsd-signature-type">Callback</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_typescript_1_4_.html#mynumber" class="tsd-signature-type">MyNumber</a></li>
+						<li class="tsd-signature tsd-kind-icon">function<wbr>Using<wbr>Types<span class="tsd-signature-symbol">(</span>aliasData<span class="tsd-signature-symbol">: </span><a href="_typescript_1_4_.html#PrimitiveArray" class="tsd-signature-type">PrimitiveArray</a>, callback<span class="tsd-signature-symbol">: </span><a href="_typescript_1_4_.html#Callback" class="tsd-signature-type">Callback</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_typescript_1_4_.html#MyNumber" class="tsd-signature-type">MyNumber</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -329,21 +329,21 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>aliasData: <a href="_typescript_1_4_.html#primitivearray" class="tsd-signature-type">PrimitiveArray</a></h5>
+									<h5>aliasData: <a href="_typescript_1_4_.html#PrimitiveArray" class="tsd-signature-type">PrimitiveArray</a></h5>
 								</li>
 								<li>
-									<h5>callback: <a href="_typescript_1_4_.html#callback" class="tsd-signature-type">Callback</a></h5>
+									<h5>callback: <a href="_typescript_1_4_.html#Callback" class="tsd-signature-type">Callback</a></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <a href="_typescript_1_4_.html#mynumber" class="tsd-signature-type">MyNumber</a></h4>
+							<h4 class="tsd-returns-title">Returns <a href="_typescript_1_4_.html#MyNumber" class="tsd-signature-type">MyNumber</a></h4>
 						</li>
 					</ul>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-					<a name="functionwithgenericcallback" class="tsd-anchor"></a>
+					<a name="functionWithGenericCallback" class="tsd-anchor"></a>
 					<h3>function<wbr>With<wbr>Generic<wbr>Callback</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback&lt;T&gt;<span class="tsd-signature-symbol">(</span>arr<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span>, callback<span class="tsd-signature-symbol">: </span><a href="_typescript_1_4_.html#genericcallback" class="tsd-signature-type">GenericCallback</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span></li>
+						<li class="tsd-signature tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback&lt;T&gt;<span class="tsd-signature-symbol">(</span>arr<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span>, callback<span class="tsd-signature-symbol">: </span><a href="_typescript_1_4_.html#GenericCallback" class="tsd-signature-type">GenericCallback</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -375,7 +375,7 @@
 									</div>
 								</li>
 								<li>
-									<h5>callback: <a href="_typescript_1_4_.html#genericcallback" class="tsd-signature-type">GenericCallback</a></h5>
+									<h5>callback: <a href="_typescript_1_4_.html#GenericCallback" class="tsd-signature-type">GenericCallback</a></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>Some generic type alias callback.</p>
 									</div>
@@ -438,37 +438,37 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../classes/_typescript_1_4_.simpleclass.html" class="tsd-kind-icon">Simple<wbr>Class</a>
+						<a href="../classes/_typescript_1_4_.SimpleClass.html" class="tsd-kind-icon">Simple<wbr>Class</a>
 					</li>
 					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="../interfaces/_typescript_1_4_.runoptions.html" class="tsd-kind-icon">Run<wbr>Options</a>
+						<a href="../interfaces/_typescript_1_4_.RunOptions.html" class="tsd-kind-icon">Run<wbr>Options</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_4_.html#callback" class="tsd-kind-icon">Callback</a>
+						<a href="_typescript_1_4_.html#Callback" class="tsd-kind-icon">Callback</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module">
-						<a href="_typescript_1_4_.html#genericcallback" class="tsd-kind-icon">Generic<wbr>Callback</a>
+						<a href="_typescript_1_4_.html#GenericCallback" class="tsd-kind-icon">Generic<wbr>Callback</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_4_.html#mynumber" class="tsd-kind-icon">My<wbr>Number</a>
+						<a href="_typescript_1_4_.html#MyNumber" class="tsd-kind-icon">My<wbr>Number</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_4_.html#myrunoptions" class="tsd-kind-icon">My<wbr>Run<wbr>Options</a>
+						<a href="_typescript_1_4_.html#MyRunOptions" class="tsd-kind-icon">My<wbr>Run<wbr>Options</a>
 					</li>
 					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_4_.html#primitivearray" class="tsd-kind-icon">Primitive<wbr>Array</a>
+						<a href="_typescript_1_4_.html#PrimitiveArray" class="tsd-kind-icon">Primitive<wbr>Array</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_4_.html#callback-1" class="tsd-kind-icon">callback</a>
+						<a href="_typescript_1_4_.html#callback" class="tsd-kind-icon">callback</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_4_.html#interfaceorstring" class="tsd-kind-icon">interface<wbr>OrString</a>
+						<a href="_typescript_1_4_.html#interfaceOrString" class="tsd-kind-icon">interface<wbr>OrString</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_4_.html#functionusingtypes" class="tsd-kind-icon">function<wbr>Using<wbr>Types</a>
+						<a href="_typescript_1_4_.html#functionUsingTypes" class="tsd-kind-icon">function<wbr>Using<wbr>Types</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
-						<a href="_typescript_1_4_.html#functionwithgenericcallback" class="tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback</a>
+						<a href="_typescript_1_4_.html#functionWithGenericCallback" class="tsd-kind-icon">function<wbr>With<wbr>Generic<wbr>Callback</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_typescript_1_5_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_5_.html
@@ -73,23 +73,23 @@
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraya" class="tsd-kind-icon">destruct<wbr>ArrayA</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarrayb" class="tsd-kind-icon">destruct<wbr>ArrayB</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarrayc" class="tsd-kind-icon">destruct<wbr>ArrayC</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithignoresa" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>IgnoresA</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithignoresrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithresta" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestA</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithrestb" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestB</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructobjecta" class="tsd-kind-icon">destruct<wbr>ObjectA</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructobjectb" class="tsd-kind-icon">destruct<wbr>ObjectB</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructobjectc" class="tsd-kind-icon">destruct<wbr>ObjectC</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructArrayA" class="tsd-kind-icon">destruct<wbr>ArrayA</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructArrayB" class="tsd-kind-icon">destruct<wbr>ArrayB</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructArrayC" class="tsd-kind-icon">destruct<wbr>ArrayC</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructArrayWithIgnoresA" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>IgnoresA</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructArrayWithIgnoresRest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructArrayWithRest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructArrayWithRestA" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestA</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructArrayWithRestB" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestB</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructObjectA" class="tsd-kind-icon">destruct<wbr>ObjectA</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructObjectB" class="tsd-kind-icon">destruct<wbr>ObjectB</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructObjectC" class="tsd-kind-icon">destruct<wbr>ObjectC</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#drawtext" class="tsd-kind-icon">draw<wbr>Text</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#drawText" class="tsd-kind-icon">draw<wbr>Text</a></li>
 							</ul>
 						</section>
 					</div>
@@ -98,7 +98,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructarraya" class="tsd-anchor"></a>
+					<a name="destructArrayA" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ArrayA</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ArrayA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
@@ -108,7 +108,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructarrayb" class="tsd-anchor"></a>
+					<a name="destructArrayB" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ArrayB</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ArrayB<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -118,7 +118,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructarrayc" class="tsd-anchor"></a>
+					<a name="destructArrayC" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ArrayC</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ArrayC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;10</span></div>
 					<aside class="tsd-sources">
@@ -128,7 +128,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructarraywithignoresa" class="tsd-anchor"></a>
+					<a name="destructArrayWithIgnoresA" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>IgnoresA</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>IgnoresA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
@@ -138,7 +138,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructarraywithignoresrest" class="tsd-anchor"></a>
+					<a name="destructArrayWithIgnoresRest" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
@@ -148,7 +148,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructarraywithrest" class="tsd-anchor"></a>
+					<a name="destructArrayWithRest" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>Rest</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
@@ -158,7 +158,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructarraywithresta" class="tsd-anchor"></a>
+					<a name="destructArrayWithRestA" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>RestA</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
@@ -168,7 +168,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructarraywithrestb" class="tsd-anchor"></a>
+					<a name="destructArrayWithRestB" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>RestB</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestB<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
@@ -178,7 +178,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructobjecta" class="tsd-anchor"></a>
+					<a name="destructObjectA" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ObjectA</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ObjectA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
@@ -188,7 +188,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructobjectb" class="tsd-anchor"></a>
+					<a name="destructObjectB" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ObjectB</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ObjectB<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
@@ -198,7 +198,7 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="destructobjectc" class="tsd-anchor"></a>
+					<a name="destructObjectC" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ObjectC</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ObjectC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
@@ -211,7 +211,7 @@
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Functions</h2>
 				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-					<a name="drawtext" class="tsd-anchor"></a>
+					<a name="drawText" class="tsd-anchor"></a>
 					<h3>draw<wbr>Text</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
 						<li class="tsd-signature tsd-kind-icon">draw<wbr>Text<span class="tsd-signature-symbol">(</span>__namedParameters<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
@@ -310,40 +310,40 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructarraya" class="tsd-kind-icon">destruct<wbr>ArrayA</a>
+						<a href="_typescript_1_5_.html#destructArrayA" class="tsd-kind-icon">destruct<wbr>ArrayA</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructarrayb" class="tsd-kind-icon">destruct<wbr>ArrayB</a>
+						<a href="_typescript_1_5_.html#destructArrayB" class="tsd-kind-icon">destruct<wbr>ArrayB</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructarrayc" class="tsd-kind-icon">destruct<wbr>ArrayC</a>
+						<a href="_typescript_1_5_.html#destructArrayC" class="tsd-kind-icon">destruct<wbr>ArrayC</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructarraywithignoresa" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>IgnoresA</a>
+						<a href="_typescript_1_5_.html#destructArrayWithIgnoresA" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>IgnoresA</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructarraywithignoresrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</a>
+						<a href="_typescript_1_5_.html#destructArrayWithIgnoresRest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructarraywithrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest</a>
+						<a href="_typescript_1_5_.html#destructArrayWithRest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructarraywithresta" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestA</a>
+						<a href="_typescript_1_5_.html#destructArrayWithRestA" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestA</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructarraywithrestb" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestB</a>
+						<a href="_typescript_1_5_.html#destructArrayWithRestB" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestB</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructobjecta" class="tsd-kind-icon">destruct<wbr>ObjectA</a>
+						<a href="_typescript_1_5_.html#destructObjectA" class="tsd-kind-icon">destruct<wbr>ObjectA</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructobjectb" class="tsd-kind-icon">destruct<wbr>ObjectB</a>
+						<a href="_typescript_1_5_.html#destructObjectB" class="tsd-kind-icon">destruct<wbr>ObjectB</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#destructobjectc" class="tsd-kind-icon">destruct<wbr>ObjectC</a>
+						<a href="_typescript_1_5_.html#destructObjectC" class="tsd-kind-icon">destruct<wbr>ObjectC</a>
 					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
-						<a href="_typescript_1_5_.html#drawtext" class="tsd-kind-icon">draw<wbr>Text</a>
+						<a href="_typescript_1_5_.html#drawText" class="tsd-kind-icon">draw<wbr>Text</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_variables_.html
+++ b/src/test/renderer/specs/modules/_variables_.html
@@ -73,9 +73,9 @@
 						<section class="tsd-index-section ">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_variables_.html#constvariable" class="tsd-kind-icon">const<wbr>Variable</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_variables_.html#letvariable" class="tsd-kind-icon">let<wbr>Variable</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_variables_.html#varvariable" class="tsd-kind-icon">var<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_variables_.html#constVariable" class="tsd-kind-icon">const<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_variables_.html#letVariable" class="tsd-kind-icon">let<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_variables_.html#varVariable" class="tsd-kind-icon">var<wbr>Variable</a></li>
 							</ul>
 						</section>
 					</div>
@@ -84,7 +84,7 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
-					<a name="constvariable" class="tsd-anchor"></a>
+					<a name="constVariable" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagConst">Const</span> const<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">const<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"const"</span><span class="tsd-signature-symbol"> =&nbsp;&quot;const&quot;</span></div>
 					<aside class="tsd-sources">
@@ -99,7 +99,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
-					<a name="letvariable" class="tsd-anchor"></a>
+					<a name="letVariable" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagLet">Let</span> let<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">let<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;let&quot;</span></div>
 					<aside class="tsd-sources">
@@ -114,7 +114,7 @@
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
-					<a name="varvariable" class="tsd-anchor"></a>
+					<a name="varVariable" class="tsd-anchor"></a>
 					<h3>var<wbr>Variable</h3>
 					<div class="tsd-signature tsd-kind-icon">var<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;var&quot;</span></div>
 					<aside class="tsd-sources">
@@ -180,13 +180,13 @@
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
-						<a href="_variables_.html#constvariable" class="tsd-kind-icon">const<wbr>Variable</a>
+						<a href="_variables_.html#constVariable" class="tsd-kind-icon">const<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
-						<a href="_variables_.html#letvariable" class="tsd-kind-icon">let<wbr>Variable</a>
+						<a href="_variables_.html#letVariable" class="tsd-kind-icon">let<wbr>Variable</a>
 					</li>
 					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
-						<a href="_variables_.html#varvariable" class="tsd-kind-icon">var<wbr>Variable</a>
+						<a href="_variables_.html#varVariable" class="tsd-kind-icon">var<wbr>Variable</a>
 					</li>
 				</ul>
 			</nav>


### PR DESCRIPTION
Addresses: https://github.com/TypeStrong/typedoc/issues/722

Don't cast files to lower case.  This enables me to dynamically use the file names to describe what the files contain when I list them in an index on my documentation page.

This change also fixes three lint errors.