### PR TITLE
Mock the plugins.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,12 @@
       "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
       "dev": true
     },
+    "@types/mockery": {
+      "version": "1.4.29",
+      "resolved": "https://registry.npmjs.org/@types/mockery/-/mockery-1.4.29.tgz",
+      "integrity": "sha1-m6It838H43gP/4Ux0aOOYz+UV6U=",
+      "dev": true
+    },
     "@types/node": {
       "version": "9.4.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
@@ -1604,6 +1610,12 @@
           }
         }
       }
+    },
+    "mockery": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+      "dev": true
     },
     "ms": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@types/mocha": "2.2.48",
+    "@types/mockery": "^1.4.29",
     "grunt": "^1.0.2",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
@@ -61,6 +62,7 @@
     "grunt-tslint": "^5.0.1",
     "istanbul": "^0.4.1",
     "mocha": "^5.0.4",
+    "mockery": "^2.1.0",
     "tslint": "^5.9.1"
   },
   "files": [

--- a/src/test/plugin-host.ts
+++ b/src/test/plugin-host.ts
@@ -1,7 +1,21 @@
 import { Application } from '..';
 import Assert = require('assert');
+import * as mockery from 'mockery';
 
 describe('PluginHost', function () {
+  before (function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false
+    });
+    mockery.registerMock('typedoc-plugin-1', () => {});
+    mockery.registerMock('typedoc-plugin-2', () => {});
+  });
+
+  after(function ()  {
+    mockery.disable();
+  });
+
   it('parses plugins correctly', function () {
     let app = new Application({
       plugin: 'typedoc-plugin-1,typedoc-plugin-2'


### PR DESCRIPTION
Doing this prevents the plugin-host tests from dumping a stack trace to the console and looking like a serious failure occurred.
