### PR TITLE
Add realpath method to compiler host

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -254,28 +254,22 @@ export class Application extends ChildableComponent<Application, AbstractCompone
             return exclude.some(mm => mm.match(fileName));
         }
 
-        function add(dirname: string) {
-            FS.readdirSync(dirname).forEach((file) => {
-                const realpath = Path.join(dirname, file);
-                if (FS.statSync(realpath).isDirectory()) {
-                    add(realpath);
-                } else if (/\.tsx?$/.test(realpath)) {
-                    if (isExcluded(realpath.replace(/\\/g, '/'))) {
-                        return;
-                    }
+        function add(file: string) {
+            if (isExcluded(file.replace(/\\/g, '/'))) {
+                return;
+            }
 
-                    files.push(realpath);
-                }
-            });
+            if (FS.statSync(file).isDirectory()) {
+                FS.readdirSync(file).forEach((child) => {
+                    add(Path.join(file, child));
+                });
+            } else if (/\.tsx?$/.test(file)) {
+                files.push(file);
+            }
         }
 
         inputFiles.forEach((file) => {
-            file = Path.resolve(file);
-            if (FS.statSync(file).isDirectory()) {
-                add(file);
-            } else if (!isExcluded(file)) {
-                files.push(file);
-            }
+            add(Path.resolve(file));
         });
 
         return files;

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -261,7 +261,10 @@ export class Application extends ChildableComponent<Application, AbstractCompone
 
             if (FS.statSync(file).isDirectory()) {
                 FS.readdirSync(file).forEach((child) => {
-                    add(Path.join(file, child));
+                    const childRealPath = Path.join(file, child);
+                    if (!FS.statSync(childRealPath).isSymbolicLink()) {
+                        add(childRealPath);
+                    }
                 });
             } else if (/\.tsx?$/.test(file)) {
                 files.push(file);

--- a/src/lib/converter/utils/compiler-host.ts
+++ b/src/lib/converter/utils/compiler-host.ts
@@ -152,4 +152,16 @@ export class CompilerHost extends ConverterComponent implements ts.CompilerHost 
      * @param onError  A callback that will be invoked if an error occurs.
      */
     writeFile(fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void) { }
+
+    /**
+     * Return the real path of the given file path by resolving symbolic links.
+     * @param fileName
+     */
+    realpath(fileName: string): string {
+        if (ts.sys.realpath) {
+            return ts.sys.realpath(fileName);
+        }
+
+        return fileName;
+    }
 }

--- a/src/test/typedoc.ts
+++ b/src/test/typedoc.ts
@@ -55,5 +55,15 @@ describe('TypeDoc', function() {
             Assert.equal(expanded.indexOf(Path.join(inputFiles, 'access', 'access.ts')), -1);
             Assert.equal(expanded.indexOf(inputFiles), -1);
         });
+
+        it('supports directory excludes', function() {
+            const inputFiles = Path.join(__dirname, 'converter');
+            application.options.setValue('exclude', [ '**/access' ]);
+            const expanded = application.expandInputFiles([inputFiles]);
+
+            Assert.ok(expanded.indexOf(Path.join(inputFiles, 'class', 'class.ts')) > -1);
+            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'access', 'access.ts')), -1);
+            Assert.equal(expanded.indexOf(inputFiles), -1);
+        });
     });
 });


### PR DESCRIPTION
I got a large number of errors after run `typedoc [myoptions]`, those errors are just like:
```
...
Error: /project/node_modules/@types/node/index.d.ts(6945)
 Cannot redeclare block-scoped variable 'HTTP_STATUS_UPGRADE_REQUIRED'.
Error: /project/node_modules/@types/node/index.d.ts(6946)
 Cannot redeclare block-scoped variable 'HTTP_STATUS_PRECONDITION_REQUIRED'.
...
```

But I can compile my project using `tsc` with no errors.

Even though I can add `--ignoreCompilerErrors` arg to the command, those errors always make me uncomfortably.

After debugging, I have found the reason: the `realpath()` method of `CompilerHost` class is missing.
And there is some  symbolic links in my `node_modules`. (also see #730)

This PR is to fix it by adding the `realpath` method.
