### PR TITLE
Add realpath method to CompilerHost

### DIFF
--- a/src/lib/converter/utils/compiler-host.ts
+++ b/src/lib/converter/utils/compiler-host.ts
@@ -152,4 +152,16 @@ export class CompilerHost extends ConverterComponent implements ts.CompilerHost 
      * @param onError  A callback that will be invoked if an error occurs.
      */
     writeFile(fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void) { }
+
+    /**
+     * Return the real path of the given file path by resolving symbolic links.
+     * @param fileName
+     */
+    realpath(fileName: string): string {
+        if (ts.sys.realpath) {
+            return ts.sys.realpath(fileName);
+        }
+
+        return fileName;
+    }
 }


### PR DESCRIPTION
I got a large number of errors after run `typedoc [myoptions]`, those errors are just like:
```
...
Error: /project/node_modules/@types/node/index.d.ts(6945)
 Cannot redeclare block-scoped variable 'HTTP_STATUS_UPGRADE_REQUIRED'.
Error: /project/node_modules/@types/node/index.d.ts(6946)
 Cannot redeclare block-scoped variable 'HTTP_STATUS_PRECONDITION_REQUIRED'.
...
```

But I can compile my project using `tsc` with no errors.

Even though I can add `--ignoreCompilerErrors` arg to the command, those errors always make me uncomfortably.

After debugging, I have found the reason: the `realpath()` method of `CompilerHost` class is missing.
And there is some  symbolic links in my `node_modules`. (also see #730)

This PR is to fix it by adding the `realpath` method.
