### PR TITLE
Support for scoped npm plugins

### DIFF
--- a/src/lib/utils/plugins.ts
+++ b/src/lib/utils/plugins.ts
@@ -6,7 +6,7 @@ import { Application } from '../application';
 import { AbstractComponent, Component, Option } from './component';
 import { ParameterType } from './options/declaration';
 
-@Component({name: 'plugin-host', internal: true})
+@Component({ name: 'plugin-host', internal: true })
 export class PluginHost extends AbstractComponent<Application> {
     @Option({
         name: 'plugin',
@@ -42,9 +42,9 @@ export class PluginHost extends AbstractComponent<Application> {
             try {
                 const instance = require(plugin);
                 const initFunction = typeof instance.load === 'function'
-                  ? instance.load
-                  : instance                // support legacy plugins
-                ;
+                    ? instance.load
+                    : instance                // support legacy plugins
+                    ;
                 if (typeof initFunction === 'function') {
                     instance(this);
                     logger.write('Loaded plugin %s', plugin);
@@ -89,16 +89,25 @@ export class PluginHost extends AbstractComponent<Application> {
          * Scan the given `node_modules` directory for TypeDoc plugins.
          */
         function discoverModules(basePath: string) {
+            const candidates: string[] = [];
             FS.readdirSync(basePath).forEach((name) => {
                 const dir = Path.join(basePath, name);
-                const infoFile = Path.join(dir, 'package.json');
+                if (name.startsWith('@')) {
+                    FS.readdirSync(dir).forEach((n) => {
+                        candidates.push(Path.join(name, n));
+                    });
+                }
+                candidates.push(name);
+            });
+            candidates.forEach((name) => {
+                const infoFile = Path.join(basePath, name, 'package.json');
                 if (!FS.existsSync(infoFile)) {
                     return;
                 }
 
                 const info = loadPackageInfo(infoFile);
                 if (isPlugin(info)) {
-                    result.push(name);
+                    result.push(Path.join(basePath, name));
                 }
             });
         }
@@ -108,7 +117,7 @@ export class PluginHost extends AbstractComponent<Application> {
          */
         function loadPackageInfo(fileName: string): any {
             try {
-                return JSON.parse(FS.readFileSync(fileName, {encoding: 'utf-8'}));
+                return JSON.parse(FS.readFileSync(fileName, { encoding: 'utf-8' }));
             } catch (error) {
                 logger.error('Could not parse %s', fileName);
                 return {};


### PR DESCRIPTION
The plugin discovery function needs to check directories in
`node_modules`, and also any directorys in `node_modules/@scope`.