### PR TITLE
Fix to catch error in expandInputFiles

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -257,25 +257,28 @@ export class Application extends ChildableComponent<Application, AbstractCompone
         function add(dirname: string) {
             FS.readdirSync(dirname).forEach((file) => {
                 const realpath = Path.join(dirname, file);
-                if (FS.statSync(realpath).isDirectory()) {
-                    add(realpath);
-                } else if (/\.tsx?$/.test(realpath)) {
-                    if (isExcluded(realpath.replace(/\\/g, '/'))) {
-                        return;
+                try {
+                    if (FS.statSync(realpath).isDirectory()) {
+                        add(realpath);
+                    } else if (/\.tsx?$/.test(realpath)) {
+                        if (isExcluded(realpath.replace(/\\/g, '/'))) {
+                            return;
+                        }
+                        files.push(realpath);
                     }
-
-                    files.push(realpath);
-                }
+                } catch (e) {}
             });
         }
 
         inputFiles.forEach((file) => {
             file = Path.resolve(file);
-            if (FS.statSync(file).isDirectory()) {
-                add(file);
-            } else if (!isExcluded(file)) {
-                files.push(file);
-            }
+            try {
+                if (FS.statSync(file).isDirectory()) {
+                    add(file);
+                } else if (!isExcluded(file)) {
+                    files.push(file);
+                }
+            } catch (e) {}
         });
 
         return files;


### PR DESCRIPTION
If there exists a symlinked file in the directories that typedoc is running over, the expandInputFiles function fails due to fs.statSync() throwing the error "file does not exist."

This PR wraps fs.statSync in a try/catch block to catch this error. 

See this post for more explanation:
https://stackoverflow.com/a/33401005