### PR TITLE
fix(plugins): traverse symlinked node_modules when scanning for plugins

### DIFF
--- a/src/lib/utils/plugins.ts
+++ b/src/lib/utils/plugins.ts
@@ -76,7 +76,7 @@ export class PluginHost extends AbstractComponent<Application> {
             let path = process.cwd(), previous: string;
             do {
                 const modules = Path.join(path, 'node_modules');
-                if (FS.existsSync(modules) && FS.lstatSync(modules).isDirectory()) {
+                if (FS.existsSync(modules) && FS.statSync(modules).isDirectory()) {
                     discoverModules(modules);
                 }
 


### PR DESCRIPTION
When Typedoc is scanning `node_modules` for plugins, it checks if `node_modules` exists, and is a directory.  It does this using `lstatSync(..).isDirectory()`.  However, this doesn't return `true` when `node_modules` is a symlink.  

I'm staging docs generation in a temporary directory and want to symlink the project's node_modules in there.  To support this, I propose changing `lstatSync()` to `statSync()`.  Tested locally and seems to work.