### PR TITLE
Renderer.getInstalledTheme(themeName)

### DIFF
--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -196,8 +196,11 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
             if (!FS.existsSync(path)) {
                 path = Path.join(Renderer.getThemeDirectory(), themeName);
                 if (!FS.existsSync(path)) {
-                    this.application.logger.error('The theme %s could not be found.', themeName);
-                    return false;
+                    path = Renderer.getInstalledTheme(themeName);
+                    if (path === null || !FS.existsSync(path)) {
+                        this.application.logger.error('The theme %s could not be found.', themeName);
+                        return false;
+                    }
                 }
             }
 
@@ -280,6 +283,21 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
      */
     static getThemeDirectory(): string {
         return Path.dirname(require.resolve('typedoc-default-themes'));
+    }
+
+    /**
+     * Return the path to the target installed theme.
+     *
+     * @returns The path to the default theme.
+     */
+    static getInstalledTheme(themeName: string): string {
+        if (/[\/\\]/.test(themeName)) {
+            return null;
+        }
+        try {
+            return Path.join(Path.dirname(require.resolve(`typedoc-themes-${themeName}`)), 'theme');
+        } catch (e) {}
+        return null;
     }
 
     /**


### PR DESCRIPTION
```bash
typedoc --out docs --theme color
```

will looking `typedoc-themes-color` module and if exists use `theme` folder

make us without install out theme every time every project

and can install as global module for reuse