### PR TITLE
CommonMark code block class names

### DIFF
--- a/src/lib/output/plugins/MarkedPlugin.ts
+++ b/src/lib/output/plugins/MarkedPlugin.ts
@@ -87,7 +87,8 @@ export class MarkedPlugin extends ContextAwareRendererComponent {
         Handlebars.registerHelper('relativeURL', (url: string) => url ? this.getRelativeUrl(url) : url);
 
         Marked.setOptions({
-            highlight: (text: any, lang: any) => this.getHighlighted(text, lang)
+            highlight: (text: any, lang: any) => this.getHighlighted(text, lang),
+            langPrefix: 'language-'
         });
     }
 


### PR DESCRIPTION
This is a very simple fix that changes TypeDoc to follow the [CommonMark](http://commonmark.org) spec for code blocks:
<https://spec.commonmark.org/0.27/> Example: <https://spec.commonmark.org/0.27/#example-109>

Right now TypeDoc prints out code block prefixes with `lang-` as the prefix, which is far I understand it, is legacy from Highlight.js. Since TypeDoc uses Highlight.js, `lang-`, `language-` and even un-prefixed values are supported... But by enforcing the CommonMark standard developers will be able to leverage other CommonMark tools with TypeDoc.