### PR TITLE
Readme, config file, missing config, config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ typedoc --out path/to/documentation/ path/to/typescript/project/
 
 Starting with version 0.2, TypeDoc no longer can predict whether files should be treated as modules
 or whether the project should be compiled into one big namespace. You must specify the `mode` argument
-in order to change the behaviour of TypeDoc.
+in order to change the behavior of TypeDoc.
 
 
 ### Arguments
@@ -48,17 +48,17 @@ in order to change the behaviour of TypeDoc.
 * `--out <path/to/documentation/>`<br>
   Specifies the location the documentation should be written to.
 * `--mode <file|modules>`<br>
-  Specifies the output mode the project is used to be compiled with.
+  Specifies the output mode the project is used to be compiled with. Use `file` to treat files as modules and `modules` to compile the project into one big namespace. 
 * `--options`<br>
-  Specify a js option file that should be loaded. If not specified TypeDoc will look for 'typedoc.js' in the current directory.
+  Specify a `.js` or `.ts` TypeDoc configuration file that should be loaded. If not specified TypeDoc will look for `typedoc.js` in the current directory. See [Configuration file](#user-content-configuration-file)
 * `--json <path/to/output.json>`<br>
   Specifies the location and file name a json file describing the project is written to. When specified no documentation will be generated.
-* `--ignoreCompilerErrors`<br>
-  Should TypeDoc still generate documentation pages even after the compiler has returned errors?
+* `--listInvalidSymbolLinks`<br>
+  Emits a list of broken symbol `[[navigation]]` links after documentation generation
 
 #### Source file handling
 * `--exclude <pattern>`<br>
-  Exclude files by the given pattern when a path is provided as source. Supports standard minimatch patterns (see [#170](https://github.com/TypeStrong/typedoc/issues/170))
+  Exclude files by the given pattern when a path is provided as source. Supports standard [minimatch patterns](https://github.com/isaacs/minimatch) (see [#170](https://github.com/TypeStrong/typedoc/issues/170))
 * `--includeDeclarations`<br>
   Turn on parsing of .d.ts declaration files.
 * `--externalPattern <pattern>`<br>
@@ -71,15 +71,17 @@ in order to change the behaviour of TypeDoc.
   Prevent protected members from being included in the generated documentation.
 
 #### TypeScript compiler
+* `--ignoreCompilerErrors`<br>
+  Should TypeDoc still generate documentation pages even after the compiler has returned errors?
 * `--module <commonjs, amd, system or umd>`<br>
   Specify module code generation: "commonjs", "amd", "system" or "umd".
 * `--target <ES3, ES5, or ES6>`<br>
   Specify ECMAScript target version: "ES3" (default), "ES5" or "ES6"
 * `--tsconfig <path/to/tsconfig.json>`<br>
-  Specify a typescript config file that should be loaded. If not specified TypeDoc will look for 'tsconfig.json' in the current directory.
+  Specify a typescript config file that should be loaded. If not specified TypeDoc will look for `tsconfig.json` in the current directory.
   
 #### Theming
-* `--theme <default|minimal|path/to/theme>`<br>
+* `--theme <default|minimal|path/to/theme>|theme-module-name`<br>
   Specify the path to the theme that should be used.
 * `--name <Documentation title>`<br>
   Set the name of the project that will be used in the header of the template.
@@ -87,7 +89,7 @@ in order to change the behaviour of TypeDoc.
   Path to the readme file that should be displayed on the index page. Pass `none` to disable the index page
   and start the documentation on the globals page.
 * `--plugin`<br>
-  Specify the npm plugins that should be loaded. Omit to load all installed plugins, set to 'none' to load no plugins.
+  Specify the npm plugins that should be loaded. Omit to load all installed plugins, set to `none` to load no plugins.
 * `--hideGenerator`<br>
   Do not print the TypeDoc link at the end of the page.
 * `--gaID`<br>
@@ -101,18 +103,38 @@ in order to change the behaviour of TypeDoc.
 
 #### Content
 * `--includes <path/to/includes>`<br>
-  Specifies the location to look for included documents. One may use <code>[[include:FILENAME]]</code>
+  Specifies the location to look for included documents. One may use `[[include:FILENAME]]`
   in comments to include documents from this location.
-
 * `--media <path/to/media>`<br>
   Specifies the location with media files that should be copied to the output directory. In order to create
-  a link to media files use the pattern <code>media://FILENAME</code> in comments.
+  a link to media files use the pattern `media://FILENAME` in comments.
+* `--toc`<br>
+  Specifies the top level table of contents.
 
 #### Miscellaneous
 * `--version`<br>
   Display the version number of TypeDoc.
 * `--help`<br>
   Display all TypeDoc options.
+* `--logger`<br>
+  Specify the logger that should be used, `none` or `console`
+  
+
+#### Configuration file
+
+Example of a `typedoc.js` configuration file: 
+
+```js
+module.exports = {
+  src: ['./src/index.ts', './typings/'],
+  mode: 'file',
+  out: './docs',
+  includeDeclarations: true
+};
+```
+
+
+## Build Tools integration
 
 ### Webpack
 
@@ -133,6 +155,7 @@ There is a plugin available to run TypeDoc with Grunt created by Bart van der Sc
 
 ## Plugins
 
+* [Markdown](https://github.com/tgreyjs/typedoc-plugin-markdown) - Generates Markdown output. Exposes a theme and additional arguments for rendering markdown
 * [External Module Name](https://github.com/christopherthielen/typedoc-plugin-external-module-name) - Set the name of TypeDoc external modules
 * [Sourcefile URL](https://github.com/gdelmas/typedoc-plugin-sourcefile-url) - Set custom source file URL links
 * [Internal/External Module](https://github.com/christopherthielen/typedoc-plugin-internal-external) - Explicitly mark modules as `@internal` or `@external`

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ in order to change the behavior of TypeDoc.
   Specify a typescript config file that should be loaded. If not specified TypeDoc will look for `tsconfig.json` in the current directory.
   
 #### Theming
-* `--theme <default|minimal|path/to/theme>|theme-module-name`<br>
+* `--theme <default|minimal|path/to/theme>|theme-module-name>`<br>
   Specify the path to the theme that should be used.
 * `--name <Documentation title>`<br>
   Set the name of the project that will be used in the header of the template.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ in order to change the behavior of TypeDoc.
 * `--json <path/to/output.json>`<br>
   Specifies the location and file name a json file describing the project is written to. When specified no documentation will be generated.
 * `--listInvalidSymbolLinks`<br>
-  Emits a list of broken symbol `[[navigation]]` links after documentation generation
+  Emits a list of broken symbol `[[navigation]]` links after documentation generation.
 
 #### Source file handling
 * `--exclude <pattern>`<br>
@@ -76,7 +76,7 @@ in order to change the behavior of TypeDoc.
 * `--module <commonjs, amd, system or umd>`<br>
   Specify module code generation: "commonjs", "amd", "system" or "umd".
 * `--target <ES3, ES5, or ES6>`<br>
-  Specify ECMAScript target version: "ES3" (default), "ES5" or "ES6"
+  Specify ECMAScript target version: "ES3" (default), "ES5" or "ES6".
 * `--tsconfig <path/to/tsconfig.json>`<br>
   Specify a typescript config file that should be loaded. If not specified TypeDoc will look for `tsconfig.json` in the current directory.
   
@@ -86,7 +86,7 @@ in order to change the behavior of TypeDoc.
 * `--name <Documentation title>`<br>
   Set the name of the project that will be used in the header of the template.
 * `--readme <path/to/readme|none>`<br>
-  Path to the readme file that should be displayed on the index page. Pass `none` to disable the index page
+  Path to the readme file that should be displayed on the index page. Pass `none` to disable the index page.
   and start the documentation on the globals page.
 * `--plugin`<br>
   Specify the npm plugins that should be loaded. Omit to load all installed plugins, set to `none` to load no plugins.
@@ -95,7 +95,7 @@ in order to change the behavior of TypeDoc.
 * `--gaID`<br>
   Set the Google Analytics tracking ID and activate tracking code.
 * `--gaSite <site>`<br>
-  Set the site name for Google Analytics. Defaults to `auto`
+  Set the site name for Google Analytics. Defaults to `auto`.
 * `--entryPoint <fully.qualified.name>`<br>
   Specifies the fully qualified name of the root symbol. Defaults to global namespace.
 * `--gitRevision <revision|branch>`<br>
@@ -117,7 +117,7 @@ in order to change the behavior of TypeDoc.
 * `--help`<br>
   Display all TypeDoc options.
 * `--logger`<br>
-  Specify the logger that should be used, `none` or `console`
+  Specify the logger that should be used, `none` or `console`.
   
 
 #### Configuration file
@@ -153,13 +153,15 @@ There is a plugin available to run TypeDoc with Gulp created by Rogier Schouten.
 There is a plugin available to run TypeDoc with Grunt created by Bart van der Schoor. You can find it on NPM:<br>
 [https://www.npmjs.org/package/grunt-typedoc](https://www.npmjs.org/package/grunt-typedoc)
 
+
 ## Plugins
 
-* [Markdown](https://github.com/tgreyjs/typedoc-plugin-markdown) - Generates Markdown output. Exposes a theme and additional arguments for rendering markdown
-* [External Module Name](https://github.com/christopherthielen/typedoc-plugin-external-module-name) - Set the name of TypeDoc external modules
-* [Sourcefile URL](https://github.com/gdelmas/typedoc-plugin-sourcefile-url) - Set custom source file URL links
-* [Internal/External Module](https://github.com/christopherthielen/typedoc-plugin-internal-external) - Explicitly mark modules as `@internal` or `@external`
-* [Single Line Tags](https://github.com/christopherthielen/typedoc-plugin-single-line-tags) - Process certain `@tags` as single lines
+* [Markdown](https://github.com/tgreyjs/typedoc-plugin-markdown) - Generates Markdown output. Exposes a theme and additional arguments for rendering markdown.
+* [External Module Name](https://github.com/christopherthielen/typedoc-plugin-external-module-name) - Set the name of TypeDoc external modules.
+* [Sourcefile URL](https://github.com/gdelmas/typedoc-plugin-sourcefile-url) - Set custom source file URL links.
+* [Internal/External Module](https://github.com/christopherthielen/typedoc-plugin-internal-external) - Explicitly mark modules as `@internal` or `@external`.
+* [Single Line Tags](https://github.com/christopherthielen/typedoc-plugin-single-line-tags) - Process certain `@tags` as single lines.
+
 
 ## Advanced guides and docs
 

--- a/src/lib/converter/nodes/block.ts
+++ b/src/lib/converter/nodes/block.ts
@@ -7,7 +7,7 @@ import { Component, ConverterNodeComponent } from '../components';
 import { Option } from '../../utils/component';
 import { ParameterType } from '../../utils/options/declaration';
 
-const prefered: ts.SyntaxKind[] = [
+const preferred: ts.SyntaxKind[] = [
     ts.SyntaxKind.ClassDeclaration,
     ts.SyntaxKind.InterfaceDeclaration,
     ts.SyntaxKind.EnumDeclaration
@@ -87,7 +87,7 @@ export class BlockConverter extends ConverterNodeComponent<ts.SourceFile|ts.Bloc
             const statements: ts.Statement[] = [];
 
             node.statements.forEach((statement) => {
-                if (prefered.indexOf(statement.kind) !== -1) {
+                if (preferred.indexOf(statement.kind) !== -1) {
                     this.owner.convertNode(context, statement);
                 } else {
                     statements.push(statement);

--- a/src/test/converter/constructor-properties/specs.json
+++ b/src/test/converter/constructor-properties/specs.json
@@ -125,7 +125,6 @@
               "id": 4,
               "name": "x",
               "kind": 1024,
-              "kindString": "Property",
               "flags": {
                 "isConstructorProperty": true,
                 "isPublic": true
@@ -135,7 +134,7 @@
               },
               "sources": [
                 {
-                  "fileName": "constructor-properties.ts",
+                  "fileName": "%BASE%/constructor-properties/constructor-properties.ts",
                   "line": 11,
                   "character": 24
                 }
@@ -149,7 +148,6 @@
               "id": 5,
               "name": "y",
               "kind": 1024,
-              "kindString": "Property",
               "flags": {
                 "isConstructorProperty": true,
                 "isPublic": true
@@ -159,7 +157,7 @@
               },
               "sources": [
                 {
-                  "fileName": "constructor-properties.ts",
+                  "fileName": "%BASE%/constructor-properties/constructor-properties.ts",
                   "line": 11,
                   "character": 41
                 }
@@ -364,8 +362,7 @@
               },
               "inheritedFrom": {
                 "type": "reference",
-                "name": "Vector2.x",
-                "id": 4
+                "name": "Vector2.x"
               }
             },
             {
@@ -393,8 +390,7 @@
               },
               "overwrites": {
                 "type": "reference",
-                "name": "Vector2.y",
-                "id": 5
+                "name": "Vector2.y"
               }
             },
             {

--- a/src/test/converter/decorators/specs.json
+++ b/src/test/converter/decorators/specs.json
@@ -48,8 +48,7 @@
                   "name": "decoratorAtom",
                   "type": {
                     "type": "reference",
-                    "name": "decoratorAtom",
-                    "id": 5
+                    "name": "decoratorAtom"
                   }
                 },
                 {
@@ -69,7 +68,6 @@
                   "id": 4,
                   "name": "decoratedMethod",
                   "kind": 4096,
-                  "kindString": "Call signature",
                   "flags": {},
                   "comment": {
                     "shortText": "A decorated method."
@@ -110,15 +108,7 @@
           "id": 5,
           "name": "decoratorAtom",
           "kind": 64,
-          "kindString": "Function",
           "flags": {},
-          "decorates": [
-            {
-              "type": "reference",
-              "name": "decoratedMethod",
-              "id": 3
-            }
-          ],
           "signatures": [
             {
               "id": 6,
@@ -187,7 +177,7 @@
           ],
           "sources": [
             {
-              "fileName": "decorators.ts",
+              "fileName": "%BASE%/decorators/decorators.ts",
               "line": 21,
               "character": 22
             }

--- a/src/test/converter/destructuring/specs.json
+++ b/src/test/converter/destructuring/specs.json
@@ -18,11 +18,10 @@
           "id": 5,
           "name": "destructArrayA",
           "kind": 32,
-          "kindString": "Variable",
           "flags": {},
           "sources": [
             {
-              "fileName": "destructuring.ts",
+              "fileName": "%BASE%/destructuring/destructuring.ts",
               "line": 10,
               "character": 21
             }
@@ -214,11 +213,10 @@
           "id": 4,
           "name": "destructObjectC",
           "kind": 32,
-          "kindString": "Variable",
           "flags": {},
           "sources": [
             {
-              "fileName": "destructuring.ts",
+              "fileName": "%BASE%/destructuring/destructuring.ts",
               "line": 4,
               "character": 56
             }

--- a/src/test/converter/enum/specs.json
+++ b/src/test/converter/enum/specs.json
@@ -217,7 +217,6 @@
               "id": 4,
               "name": "EnumValue2",
               "kind": 16,
-              "kindString": "Enumeration member",
               "flags": {
                 "isExported": true
               },
@@ -226,7 +225,7 @@
               },
               "sources": [
                 {
-                  "fileName": "enum.ts",
+                  "fileName": "%BASE%/enum/enum.ts",
                   "line": 14,
                   "character": 14
                 }
@@ -237,7 +236,6 @@
               "id": 5,
               "name": "EnumValue3",
               "kind": 16,
-              "kindString": "Enumeration member",
               "flags": {
                 "isExported": true
               },
@@ -246,7 +244,7 @@
               },
               "sources": [
                 {
-                  "fileName": "enum.ts",
+                  "fileName": "%BASE%/enum/enum.ts",
                   "line": 19,
                   "character": 14
                 }

--- a/src/test/converter/events-overloads/specs.json
+++ b/src/test/converter/events-overloads/specs.json
@@ -41,7 +41,6 @@
                   "id": 4,
                   "name": "on",
                   "kind": 8388608,
-                  "kindString": "Event",
                   "flags": {},
                   "comment": {
                     "shortText": "Subscribe for a general event by name."
@@ -51,7 +50,6 @@
                       "id": 5,
                       "name": "event",
                       "kind": 32768,
-                      "kindString": "Parameter",
                       "flags": {},
                       "comment": {
                         "text": "The name of the event to subscribe for."

--- a/src/test/converter/export-assignment/specs.json
+++ b/src/test/converter/export-assignment/specs.json
@@ -35,7 +35,6 @@
                   "id": 4,
                   "name": "x",
                   "kind": 32768,
-                  "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",
@@ -46,7 +45,6 @@
                   "id": 5,
                   "name": "y",
                   "kind": 32768,
-                  "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",

--- a/src/test/converter/export-with-local/specs.json
+++ b/src/test/converter/export-with-local/specs.json
@@ -70,14 +70,12 @@
               "id": 4,
               "name": "add",
               "kind": 4096,
-              "kindString": "Call signature",
               "flags": {},
               "parameters": [
                 {
                   "id": 5,
                   "name": "x",
                   "kind": 32768,
-                  "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",

--- a/src/test/converter/export/specs.json
+++ b/src/test/converter/export/specs.json
@@ -49,14 +49,12 @@
               "id": 4,
               "name": "add",
               "kind": 4096,
-              "kindString": "Call signature",
               "flags": {},
               "parameters": [
                 {
                   "id": 5,
                   "name": "x",
                   "kind": 32768,
-                  "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",

--- a/src/test/converter/function/specs.json
+++ b/src/test/converter/function/specs.json
@@ -176,7 +176,6 @@
           "id": 4,
           "name": "exportedFunction",
           "kind": 64,
-          "kindString": "Function",
           "flags": {
             "isExported": true
           },
@@ -185,7 +184,6 @@
               "id": 5,
               "name": "exportedFunction",
               "kind": 4096,
-              "kindString": "Call signature",
               "flags": {},
               "comment": {
                 "shortText": "This is a simple exported function."
@@ -198,7 +196,7 @@
           ],
           "sources": [
             {
-              "fileName": "function.ts",
+              "fileName": "%BASE%/function/function.ts",
               "line": 10,
               "character": 32
             }

--- a/src/test/converter/generic-class/specs.json
+++ b/src/test/converter/generic-class/specs.json
@@ -90,7 +90,6 @@
               "id": 4,
               "name": "value",
               "kind": 1024,
-              "kindString": "Property",
               "flags": {
                 "isProtected": true
               },
@@ -99,7 +98,7 @@
               },
               "sources": [
                 {
-                  "fileName": "generic-class.ts",
+                  "fileName": "%BASE%/generic-class/generic-class.ts",
                   "line": 9,
                   "character": 19
                 }
@@ -113,7 +112,6 @@
               "id": 5,
               "name": "values",
               "kind": 1024,
-              "kindString": "Property",
               "flags": {
                 "isProtected": true
               },
@@ -122,7 +120,7 @@
               },
               "sources": [
                 {
-                  "fileName": "generic-class.ts",
+                  "fileName": "%BASE%/generic-class/generic-class.ts",
                   "line": 14,
                   "character": 20
                 }
@@ -300,8 +298,7 @@
               },
               "inheritedFrom": {
                 "type": "reference",
-                "name": "GenericClass.value",
-                "id": 4
+                "name": "GenericClass.value"
               }
             },
             {
@@ -331,8 +328,7 @@
               },
               "inheritedFrom": {
                 "type": "reference",
-                "name": "GenericClass.values",
-                "id": 5
+                "name": "GenericClass.values"
               }
             },
             {

--- a/src/test/converter/generic-function/specs.json
+++ b/src/test/converter/generic-function/specs.json
@@ -112,7 +112,6 @@
                   "id": 4,
                   "name": "T",
                   "kind": 131072,
-                  "kindString": "Type parameter",
                   "flags": {},
                   "comment": {
                     "text": "Generic function type parameter."
@@ -128,7 +127,6 @@
                   "id": 5,
                   "name": "value",
                   "kind": 32768,
-                  "kindString": "Parameter",
                   "flags": {},
                   "comment": {
                     "text": "Generic function parameter."

--- a/src/test/converter/getter-setter/specs.json
+++ b/src/test/converter/getter-setter/specs.json
@@ -45,14 +45,12 @@
               "id": 4,
               "name": "name",
               "kind": 262144,
-              "kindString": "Accessor",
               "flags": {},
               "getSignature": [
                 {
                   "id": 5,
                   "name": "__get",
                   "kind": 524288,
-                  "kindString": "Get signature",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",
@@ -88,12 +86,12 @@
               ],
               "sources": [
                 {
-                  "fileName": "getter-setter.ts",
+                  "fileName": "%BASE%/getter-setter/getter-setter.ts",
                   "line": 6,
                   "character": 12
                 },
                 {
-                  "fileName": "getter-setter.ts",
+                  "fileName": "%BASE%/getter-setter/getter-setter.ts",
                   "line": 7,
                   "character": 12
                 }

--- a/src/test/converter/implicit-types/specs.json
+++ b/src/test/converter/implicit-types/specs.json
@@ -27,13 +27,12 @@
               "id": 4,
               "name": "end",
               "kind": 1024,
-              "kindString": "Property",
               "flags": {
                 "isExported": true
               },
               "sources": [
                 {
-                  "fileName": "implicit-types.ts",
+                  "fileName": "%BASE%/implicit-types/implicit-types.ts",
                   "line": 1,
                   "character": 54
                 }
@@ -86,13 +85,12 @@
           "id": 5,
           "name": "_breakpoints",
           "kind": 32,
-          "kindString": "Variable",
           "flags": {
             "isLet": true
           },
           "sources": [
             {
-              "fileName": "implicit-types.ts",
+              "fileName": "%BASE%/implicit-types/implicit-types.ts",
               "line": 3,
               "character": 16
             }

--- a/src/test/converter/interface-empty/specs.json
+++ b/src/test/converter/interface-empty/specs.json
@@ -28,13 +28,12 @@
               "id": 4,
               "name": "name",
               "kind": 1024,
-              "kindString": "Property",
               "flags": {
                 "isPrivate": true
               },
               "sources": [
                 {
-                  "fileName": "interface-empty.ts",
+                  "fileName": "%BASE%/interface-empty/interface-empty.ts",
                   "line": 12,
                   "character": 16
                 }
@@ -48,7 +47,6 @@
               "id": 5,
               "name": "goto",
               "kind": 2048,
-              "kindString": "Method",
               "flags": {
                 "isPublic": true
               },
@@ -67,7 +65,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "interface-empty.ts",
+                  "fileName": "%BASE%/interface-empty/interface-empty.ts",
                   "line": 13,
                   "character": 15
                 }

--- a/src/test/converter/interface-implementation/specs.json
+++ b/src/test/converter/interface-implementation/specs.json
@@ -997,7 +997,6 @@
                   "id": 4,
                   "name": "T",
                   "kind": 131072,
-                  "kindString": "Type parameter",
                   "flags": {}
                 }
               ],
@@ -1006,7 +1005,6 @@
                   "id": 5,
                   "name": "__call",
                   "kind": 4096,
-                  "kindString": "Call signature",
                   "flags": {},
                   "comment": {
                     "shortText": "Function signature of an event listener callback"

--- a/src/test/converter/literal-object-callbacks/specs.json
+++ b/src/test/converter/literal-object-callbacks/specs.json
@@ -18,7 +18,6 @@
           "id": 4,
           "name": "onError",
           "kind": 64,
-          "kindString": "Function",
           "flags": {
             "isLet": true
           },
@@ -27,7 +26,6 @@
               "id": 5,
               "name": "onError",
               "kind": 4096,
-              "kindString": "Call signature",
               "flags": {},
               "type": {
                 "type": "intrinsic",
@@ -37,7 +35,7 @@
           ],
           "sources": [
             {
-              "fileName": "literal-object-callbacks.ts",
+              "fileName": "%BASE%/literal-object-callbacks/literal-object-callbacks.ts",
               "line": 2,
               "character": 11
             }

--- a/src/test/converter/literal-object/specs.json
+++ b/src/test/converter/literal-object/specs.json
@@ -87,14 +87,12 @@
               "id": 4,
               "name": "valueY",
               "kind": 64,
-              "kindString": "Function",
               "flags": {},
               "signatures": [
                 {
                   "id": 5,
                   "name": "valueY",
                   "kind": 4096,
-                  "kindString": "Call signature",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",
@@ -104,7 +102,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "literal-object.ts",
+                  "fileName": "%BASE%/literal-object/literal-object.ts",
                   "line": 6,
                   "character": 10
                 }

--- a/src/test/converter/literal-type/specs.json
+++ b/src/test/converter/literal-type/specs.json
@@ -283,11 +283,10 @@
                   "id": 5,
                   "name": "valueY",
                   "kind": 32,
-                  "kindString": "Variable",
                   "flags": {},
                   "sources": [
                     {
-                      "fileName": "literal-type.ts",
+                      "fileName": "%BASE%/literal-type/literal-type.ts",
                       "line": 3,
                       "character": 10
                     }
@@ -327,11 +326,10 @@
                   "id": 4,
                   "name": "valueZ",
                   "kind": 32,
-                  "kindString": "Variable",
                   "flags": {},
                   "sources": [
                     {
-                      "fileName": "literal-type.ts",
+                      "fileName": "%BASE%/literal-type/literal-type.ts",
                       "line": 2,
                       "character": 10
                     }

--- a/src/test/converter/react/specs.json
+++ b/src/test/converter/react/specs.json
@@ -18,9 +18,28 @@
           "id": 5,
           "name": "Demo",
           "kind": 128,
-          "kindString": "Class",
           "flags": {},
           "children": [
+            {
+              "id": 6,
+              "name": "foo",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPrivate": true
+              },
+              "sources": [
+                {
+                  "fileName": "react.tsx",
+                  "line": 14,
+                  "character": 15
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            },
             {
               "id": 7,
               "name": "constructor",
@@ -69,240 +88,6 @@
               "overwrites": {
                 "type": "reference",
                 "name": "Component.__constructor"
-              }
-            },
-            {
-              "id": 34,
-              "name": "context",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {},
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 142,
-                  "character": 15
-                }
-              ],
-              "type": {
-                "type": "reference",
-                "name": "__type"
-              },
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.context"
-              }
-            },
-            {
-              "id": 6,
-              "name": "foo",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {
-                "isPrivate": true
-              },
-              "sources": [
-                {
-                  "fileName": "react.tsx",
-                  "line": 14,
-                  "character": 15
-                }
-              ],
-              "type": {
-                "type": "intrinsic",
-                "name": "number"
-              }
-            },
-            {
-              "id": 32,
-              "name": "props",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {},
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 140,
-                  "character": 13
-                }
-              ],
-              "type": {
-                "type": "reference",
-                "name": "DemoProps",
-                "id": 2
-              },
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.props"
-              }
-            },
-            {
-              "id": 35,
-              "name": "refs",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {},
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 143,
-                  "character": 12
-                }
-              ],
-              "type": {
-                "type": "reflection",
-                "declaration": {
-                  "id": 36,
-                  "name": "__type",
-                  "kind": 65536,
-                  "kindString": "Type literal",
-                  "flags": {},
-                  "indexSignature": [
-                    {
-                      "id": 37,
-                      "name": "__index",
-                      "kind": 8192,
-                      "kindString": "Index signature",
-                      "flags": {},
-                      "parameters": [
-                        {
-                          "id": 38,
-                          "name": "key",
-                          "kind": 32768,
-                          "kindString": "Parameter",
-                          "flags": {},
-                          "type": {
-                            "type": "intrinsic",
-                            "name": "string"
-                          }
-                        }
-                      ],
-                      "type": {
-                        "type": "reference",
-                        "name": "Component",
-                        "typeArguments": [
-                          {
-                            "type": "intrinsic",
-                            "name": "any"
-                          },
-                          {
-                            "type": "intrinsic",
-                            "name": "any"
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "sources": [
-                    {
-                      "fileName": "react.d.ts",
-                      "line": 143,
-                      "character": 13
-                    }
-                  ]
-                }
-              },
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.refs"
-              }
-            },
-            {
-              "id": 33,
-              "name": "state",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {},
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 141,
-                  "character": 13
-                }
-              ],
-              "type": {
-                "type": "intrinsic",
-                "name": "any"
-              },
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.state"
-              }
-            },
-            {
-              "id": 27,
-              "name": "forceUpdate",
-              "kind": 2048,
-              "kindString": "Method",
-              "flags": {},
-              "signatures": [
-                {
-                  "id": 28,
-                  "name": "forceUpdate",
-                  "kind": 4096,
-                  "kindString": "Call signature",
-                  "flags": {},
-                  "parameters": [
-                    {
-                      "id": 29,
-                      "name": "callBack",
-                      "kind": 32768,
-                      "kindString": "Parameter",
-                      "flags": {
-                        "isOptional": true
-                      },
-                      "type": {
-                        "type": "reflection",
-                        "declaration": {
-                          "id": 30,
-                          "name": "__type",
-                          "kind": 65536,
-                          "kindString": "Type literal",
-                          "flags": {},
-                          "signatures": [
-                            {
-                              "id": 31,
-                              "name": "__call",
-                              "kind": 4096,
-                              "kindString": "Call signature",
-                              "flags": {},
-                              "type": {
-                                "type": "intrinsic",
-                                "name": "any"
-                              }
-                            }
-                          ],
-                          "sources": [
-                            {
-                              "fileName": "react.d.ts",
-                              "line": 138,
-                              "character": 30
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  ],
-                  "type": {
-                    "type": "intrinsic",
-                    "name": "void"
-                  },
-                  "inheritedFrom": {
-                    "type": "reference",
-                    "name": "Component.forceUpdate"
-                  }
-                }
-              ],
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 138,
-                  "character": 19
-                }
-              ],
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.forceUpdate"
               }
             },
             {
@@ -549,40 +334,225 @@
                 "type": "reference",
                 "name": "Component.setState"
               }
-            }
-          ],
-          "groups": [
-            {
-              "title": "Constructors",
-              "kind": 512,
-              "children": [
-                7
-              ]
             },
             {
-              "title": "Properties",
-              "kind": 1024,
-              "children": [
-                34,
-                6,
-                32,
-                35,
-                33
-              ]
-            },
-            {
-              "title": "Methods",
+              "id": 27,
+              "name": "forceUpdate",
               "kind": 2048,
-              "children": [
-                27,
-                10,
-                12
-              ]
+              "kindString": "Method",
+              "flags": {},
+              "signatures": [
+                {
+                  "id": 28,
+                  "name": "forceUpdate",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "parameters": [
+                    {
+                      "id": 29,
+                      "name": "callBack",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 30,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 31,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "type": {
+                                "type": "intrinsic",
+                                "name": "any"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "react.d.ts",
+                              "line": 138,
+                              "character": 30
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Component.forceUpdate"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 138,
+                  "character": 19
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.forceUpdate"
+              }
+            },
+            {
+              "id": 32,
+              "name": "props",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {},
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 140,
+                  "character": 13
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "DemoProps",
+                "id": 2
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.props"
+              }
+            },
+            {
+              "id": 33,
+              "name": "state",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {},
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 141,
+                  "character": 13
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "any"
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.state"
+              }
+            },
+            {
+              "id": 34,
+              "name": "context",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {},
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 142,
+                  "character": 15
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "__type"
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.context"
+              }
+            },
+            {
+              "id": 35,
+              "name": "refs",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {},
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 143,
+                  "character": 12
+                }
+              ],
+              "type": {
+                "type": "reflection",
+                "declaration": {
+                  "id": 36,
+                  "name": "__type",
+                  "kind": 65536,
+                  "kindString": "Type literal",
+                  "flags": {},
+                  "indexSignature": [
+                    {
+                      "id": 37,
+                      "name": "__index",
+                      "kind": 8192,
+                      "kindString": "Index signature",
+                      "flags": {},
+                      "parameters": [
+                        {
+                          "id": 38,
+                          "name": "key",
+                          "kind": 32768,
+                          "kindString": "Parameter",
+                          "flags": {},
+                          "type": {
+                            "type": "intrinsic",
+                            "name": "string"
+                          }
+                        }
+                      ],
+                      "type": {
+                        "type": "reference",
+                        "name": "Component",
+                        "typeArguments": [
+                          {
+                            "type": "intrinsic",
+                            "name": "any"
+                          },
+                          {
+                            "type": "intrinsic",
+                            "name": "any"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "sources": [
+                    {
+                      "fileName": "react.d.ts",
+                      "line": 143,
+                      "character": 13
+                    }
+                  ]
+                }
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.refs"
+              }
             }
           ],
           "sources": [
             {
-              "fileName": "react.tsx",
+              "fileName": "%BASE%/react/react.tsx",
               "line": 12,
               "character": 10
             }
@@ -594,8 +564,7 @@
               "typeArguments": [
                 {
                   "type": "reference",
-                  "name": "DemoProps",
-                  "id": 2
+                  "name": "DemoProps"
                 },
                 {
                   "type": "intrinsic",
@@ -616,11 +585,10 @@
               "id": 4,
               "name": "age",
               "kind": 1024,
-              "kindString": "Property",
               "flags": {},
               "sources": [
                 {
-                  "fileName": "react.tsx",
+                  "fileName": "%BASE%/react/react.tsx",
                   "line": 8,
                   "character": 7
                 }

--- a/src/test/converter/this/specs.json
+++ b/src/test/converter/this/specs.json
@@ -41,7 +41,6 @@
                   "id": 4,
                   "name": "chain",
                   "kind": 4096,
-                  "kindString": "Call signature",
                   "flags": {},
                   "comment": {
                     "shortText": "Chain method that returns this."

--- a/src/test/converter/type-operator/specs.json
+++ b/src/test/converter/type-operator/specs.json
@@ -18,7 +18,6 @@
           "id": 5,
           "name": "GenericClass",
           "kind": 128,
-          "kindString": "Class",
           "flags": {
             "isExported": true
           },
@@ -69,18 +68,9 @@
               }
             }
           ],
-          "groups": [
-            {
-              "title": "Properties",
-              "kind": 1024,
-              "children": [
-                7
-              ]
-            }
-          ],
           "sources": [
             {
-              "fileName": "type-operator.ts",
+              "fileName": "%BASE%/type-operator/type-operator.ts",
               "line": 13,
               "character": 25
             }
@@ -129,13 +119,12 @@
               "id": 4,
               "name": "b",
               "kind": 1024,
-              "kindString": "Property",
               "flags": {
                 "isExported": true
               },
               "sources": [
                 {
-                  "fileName": "type-operator.ts",
+                  "fileName": "%BASE%/type-operator/type-operator.ts",
                   "line": 10,
                   "character": 5
                 }

--- a/src/test/converter/union-or-intersection/specs.json
+++ b/src/test/converter/union-or-intersection/specs.json
@@ -71,7 +71,6 @@
           "id": 4,
           "name": "SecondType",
           "kind": 256,
-          "kindString": "Interface",
           "flags": {
             "isExported": true
           },
@@ -83,7 +82,6 @@
               "id": 5,
               "name": "secondProperty",
               "kind": 1024,
-              "kindString": "Property",
               "flags": {
                 "isExported": true
               },
@@ -92,7 +90,7 @@
               },
               "sources": [
                 {
-                  "fileName": "union-or-intersection.ts",
+                  "fileName": "%BASE%/union-or-intersection/union-or-intersection.ts",
                   "line": 20,
                   "character": 18
                 }
@@ -103,18 +101,9 @@
               }
             }
           ],
-          "groups": [
-            {
-              "title": "Properties",
-              "kind": 1024,
-              "children": [
-                5
-              ]
-            }
-          ],
           "sources": [
             {
-              "fileName": "union-or-intersection.ts",
+              "fileName": "%BASE%/union-or-intersection/union-or-intersection.ts",
               "line": 15,
               "character": 27
             }
@@ -171,8 +160,7 @@
                           },
                           {
                             "type": "reference",
-                            "name": "SecondType",
-                            "id": 4
+                            "name": "SecondType"
                           }
                         ]
                       }
@@ -243,8 +231,7 @@
                   },
                   {
                     "type": "reference",
-                    "name": "SecondType",
-                    "id": 4
+                    "name": "SecondType"
                   }
                 ]
               }

--- a/src/test/converter/variable/specs.json
+++ b/src/test/converter/variable/specs.json
@@ -62,13 +62,12 @@
           "id": 4,
           "name": "myVar",
           "kind": 32,
-          "kindString": "Variable",
           "flags": {
             "isExported": true
           },
           "sources": [
             {
-              "fileName": "variable.ts",
+              "fileName": "%BASE%/variable/variable.ts",
               "line": 3,
               "character": 16
             }

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -134,7 +134,7 @@ $ typedoc
 				</ul>
 				<h4 id="theming">Theming</h4>
 				<ul>
-					<li><code>--theme &lt;default|minimal|path/to/theme&gt;|theme-module-name</code><br>
+					<li><code>--theme &lt;default|minimal|path/to/theme&gt;|theme-module-name&gt;</code><br>
 					Specify the path to the theme that should be used.</li>
 					<li><code>--name &lt;Documentation title&gt;</code><br>
 					Set the name of the project that will be used in the header of the template.</li>

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -104,7 +104,7 @@ $ typedoc
 					<li><code>--json &lt;path/to/output.json&gt;</code><br>
 					Specifies the location and file name a json file describing the project is written to. When specified no documentation will be generated.</li>
 					<li><code>--listInvalidSymbolLinks</code><br>
-					Emits a list of broken symbol <code>[[navigation]]</code> links after documentation generation</li>
+					Emits a list of broken symbol <code>[[navigation]]</code> links after documentation generation.</li>
 				</ul>
 				<h4 id="source-file-handling">Source file handling</h4>
 				<ul>
@@ -128,7 +128,7 @@ $ typedoc
 					<li><code>--module &lt;commonjs, amd, system or umd&gt;</code><br>
 					Specify module code generation: &quot;commonjs&quot;, &quot;amd&quot;, &quot;system&quot; or &quot;umd&quot;.</li>
 					<li><code>--target &lt;ES3, ES5, or ES6&gt;</code><br>
-					Specify ECMAScript target version: &quot;ES3&quot; (default), &quot;ES5&quot; or &quot;ES6&quot;</li>
+					Specify ECMAScript target version: &quot;ES3&quot; (default), &quot;ES5&quot; or &quot;ES6&quot;.</li>
 					<li><code>--tsconfig &lt;path/to/tsconfig.json&gt;</code><br>
 					Specify a typescript config file that should be loaded. If not specified TypeDoc will look for <code>tsconfig.json</code> in the current directory.</li>
 				</ul>
@@ -139,7 +139,7 @@ $ typedoc
 					<li><code>--name &lt;Documentation title&gt;</code><br>
 					Set the name of the project that will be used in the header of the template.</li>
 					<li><code>--readme &lt;path/to/readme|none&gt;</code><br>
-						Path to the readme file that should be displayed on the index page. Pass <code>none</code> to disable the index page
+						Path to the readme file that should be displayed on the index page. Pass <code>none</code> to disable the index page.
 					and start the documentation on the globals page.</li>
 					<li><code>--plugin</code><br>
 					Specify the npm plugins that should be loaded. Omit to load all installed plugins, set to <code>none</code> to load no plugins.</li>
@@ -148,7 +148,7 @@ $ typedoc
 					<li><code>--gaID</code><br>
 					Set the Google Analytics tracking ID and activate tracking code.</li>
 					<li><code>--gaSite &lt;site&gt;</code><br>
-					Set the site name for Google Analytics. Defaults to <code>auto</code></li>
+					Set the site name for Google Analytics. Defaults to <code>auto</code>.</li>
 					<li><code>--entryPoint &lt;fully.qualified.name&gt;</code><br>
 					Specifies the fully qualified name of the root symbol. Defaults to global namespace.</li>
 					<li><code>--gitRevision &lt;revision|branch&gt;</code><br>
@@ -172,7 +172,7 @@ $ typedoc
 					<li><code>--help</code><br>
 					Display all TypeDoc options.</li>
 					<li><code>--logger</code><br>
-					Specify the logger that should be used, <code>none</code> or <code>console</code></li>
+					Specify the logger that should be used, <code>none</code> or <code>console</code>.</li>
 				</ul>
 				<h4 id="configuration-file">Configuration file</h4>
 				<p>Example of a <code>typedoc.js</code> configuration file: </p>
@@ -195,11 +195,11 @@ $ typedoc
 				<a href="https://www.npmjs.org/package/grunt-typedoc">https://www.npmjs.org/package/grunt-typedoc</a></p>
 				<h2 id="plugins">Plugins</h2>
 				<ul>
-					<li><a href="https://github.com/tgreyjs/typedoc-plugin-markdown">Markdown</a> - Generates Markdown output. Exposes a theme and additional arguments for rendering markdown</li>
-					<li><a href="https://github.com/christopherthielen/typedoc-plugin-external-module-name">External Module Name</a> - Set the name of TypeDoc external modules</li>
-					<li><a href="https://github.com/gdelmas/typedoc-plugin-sourcefile-url">Sourcefile URL</a> - Set custom source file URL links</li>
-					<li><a href="https://github.com/christopherthielen/typedoc-plugin-internal-external">Internal/External Module</a> - Explicitly mark modules as <code>@internal</code> or <code>@external</code></li>
-					<li><a href="https://github.com/christopherthielen/typedoc-plugin-single-line-tags">Single Line Tags</a> - Process certain <code>@tags</code> as single lines</li>
+					<li><a href="https://github.com/tgreyjs/typedoc-plugin-markdown">Markdown</a> - Generates Markdown output. Exposes a theme and additional arguments for rendering markdown.</li>
+					<li><a href="https://github.com/christopherthielen/typedoc-plugin-external-module-name">External Module Name</a> - Set the name of TypeDoc external modules.</li>
+					<li><a href="https://github.com/gdelmas/typedoc-plugin-sourcefile-url">Sourcefile URL</a> - Set custom source file URL links.</li>
+					<li><a href="https://github.com/christopherthielen/typedoc-plugin-internal-external">Internal/External Module</a> - Explicitly mark modules as <code>@internal</code> or <code>@external</code>.</li>
+					<li><a href="https://github.com/christopherthielen/typedoc-plugin-single-line-tags">Single Line Tags</a> - Process certain <code>@tags</code> as single lines.</li>
 				</ul>
 				<h2 id="advanced-guides-and-docs">Advanced guides and docs</h2>
 				<p>Visit our homepage for advanced guides and an extensive API documentation:<br>

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -92,24 +92,24 @@ $ typedoc
 				<h3 id="important-note">Important note</h3>
 				<p>Starting with version 0.2, TypeDoc no longer can predict whether files should be treated as modules
 					or whether the project should be compiled into one big namespace. You must specify the <code>mode</code> argument
-				in order to change the behaviour of TypeDoc.</p>
+				in order to change the behavior of TypeDoc.</p>
 				<h3 id="arguments">Arguments</h3>
 				<ul>
 					<li><code>--out &lt;path/to/documentation/&gt;</code><br>
 					Specifies the location the documentation should be written to.</li>
 					<li><code>--mode &lt;file|modules&gt;</code><br>
-					Specifies the output mode the project is used to be compiled with.</li>
+					Specifies the output mode the project is used to be compiled with. Use <code>file</code> to treat files as modules and <code>modules</code> to compile the project into one big namespace. </li>
 					<li><code>--options</code><br>
-					Specify a js option file that should be loaded. If not specified TypeDoc will look for &#39;typedoc.js&#39; in the current directory.</li>
+					Specify a <code>.js</code> or <code>.ts</code> TypeDoc configuration file that should be loaded. If not specified TypeDoc will look for <code>typedoc.js</code> in the current directory. See <a href="#user-content-configuration-file">Configuration file</a></li>
 					<li><code>--json &lt;path/to/output.json&gt;</code><br>
 					Specifies the location and file name a json file describing the project is written to. When specified no documentation will be generated.</li>
-					<li><code>--ignoreCompilerErrors</code><br>
-					Should TypeDoc still generate documentation pages even after the compiler has returned errors?</li>
+					<li><code>--listInvalidSymbolLinks</code><br>
+					Emits a list of broken symbol <code>[[navigation]]</code> links after documentation generation</li>
 				</ul>
 				<h4 id="source-file-handling">Source file handling</h4>
 				<ul>
 					<li><code>--exclude &lt;pattern&gt;</code><br>
-					Exclude files by the given pattern when a path is provided as source. Supports standard minimatch patterns (see <a href="https://github.com/TypeStrong/typedoc/issues/170">#170</a>)</li>
+					Exclude files by the given pattern when a path is provided as source. Supports standard <a href="https://github.com/isaacs/minimatch">minimatch patterns</a> (see <a href="https://github.com/TypeStrong/typedoc/issues/170">#170</a>)</li>
 					<li><code>--includeDeclarations</code><br>
 					Turn on parsing of .d.ts declaration files.</li>
 					<li><code>--externalPattern &lt;pattern&gt;</code><br>
@@ -123,14 +123,18 @@ $ typedoc
 				</ul>
 				<h4 id="typescript-compiler">TypeScript compiler</h4>
 				<ul>
+					<li><code>--ignoreCompilerErrors</code><br>
+					Should TypeDoc still generate documentation pages even after the compiler has returned errors?</li>
 					<li><code>--module &lt;commonjs, amd, system or umd&gt;</code><br>
 					Specify module code generation: &quot;commonjs&quot;, &quot;amd&quot;, &quot;system&quot; or &quot;umd&quot;.</li>
 					<li><code>--target &lt;ES3, ES5, or ES6&gt;</code><br>
 					Specify ECMAScript target version: &quot;ES3&quot; (default), &quot;ES5&quot; or &quot;ES6&quot;</li>
+					<li><code>--tsconfig &lt;path/to/tsconfig.json&gt;</code><br>
+					Specify a typescript config file that should be loaded. If not specified TypeDoc will look for <code>tsconfig.json</code> in the current directory.</li>
 				</ul>
 				<h4 id="theming">Theming</h4>
 				<ul>
-					<li><code>--theme &lt;default|minimal|path/to/theme&gt;</code><br>
+					<li><code>--theme &lt;default|minimal|path/to/theme&gt;|theme-module-name</code><br>
 					Specify the path to the theme that should be used.</li>
 					<li><code>--name &lt;Documentation title&gt;</code><br>
 					Set the name of the project that will be used in the header of the template.</li>
@@ -138,7 +142,7 @@ $ typedoc
 						Path to the readme file that should be displayed on the index page. Pass <code>none</code> to disable the index page
 					and start the documentation on the globals page.</li>
 					<li><code>--plugin</code><br>
-					Specify the npm plugins that should be loaded. Omit to load all installed plugins, set to &#39;none&#39; to load no plugins.</li>
+					Specify the npm plugins that should be loaded. Omit to load all installed plugins, set to <code>none</code> to load no plugins.</li>
 					<li><code>--hideGenerator</code><br>
 					Do not print the TypeDoc link at the end of the page.</li>
 					<li><code>--gaID</code><br>
@@ -152,14 +156,14 @@ $ typedoc
 				</ul>
 				<h4 id="content">Content</h4>
 				<ul>
-					<li><p><code>--includes &lt;path/to/includes&gt;</code><br>
-							Specifies the location to look for included documents. One may use <code>[[include:FILENAME]]</code>
-						in comments to include documents from this location.</p>
-					</li>
-					<li><p><code>--media &lt;path/to/media&gt;</code><br>
-							Specifies the location with media files that should be copied to the output directory. In order to create
-						a link to media files use the pattern <code>media://FILENAME</code> in comments.</p>
-					</li>
+					<li><code>--includes &lt;path/to/includes&gt;</code><br>
+						Specifies the location to look for included documents. One may use <code>[[include:FILENAME]]</code>
+					in comments to include documents from this location.</li>
+					<li><code>--media &lt;path/to/media&gt;</code><br>
+						Specifies the location with media files that should be copied to the output directory. In order to create
+					a link to media files use the pattern <code>media://FILENAME</code> in comments.</li>
+					<li><code>--toc</code><br>
+					Specifies the top level table of contents.</li>
 				</ul>
 				<h4 id="miscellaneous">Miscellaneous</h4>
 				<ul>
@@ -167,7 +171,19 @@ $ typedoc
 					Display the version number of TypeDoc.</li>
 					<li><code>--help</code><br>
 					Display all TypeDoc options.</li>
+					<li><code>--logger</code><br>
+					Specify the logger that should be used, <code>none</code> or <code>console</code></li>
 				</ul>
+				<h4 id="configuration-file">Configuration file</h4>
+				<p>Example of a <code>typedoc.js</code> configuration file: </p>
+				<pre><code class="lang-js"><span class="hljs-built_in">module</span>.exports = {
+  <span class="hljs-attr">src</span>: [<span class="hljs-string">'./src/index.ts'</span>, <span class="hljs-string">'./typings/'</span>],
+  <span class="hljs-attr">mode</span>: <span class="hljs-string">'file'</span>,
+  <span class="hljs-attr">out</span>: <span class="hljs-string">'./docs'</span>,
+  <span class="hljs-attr">includeDeclarations</span>: <span class="hljs-literal">true</span>
+};
+</code></pre>
+				<h2 id="build-tools-integration">Build Tools integration</h2>
 				<h3 id="webpack">Webpack</h3>
 				<p>There is a plugin available to run TypeDoc with Webpack created by Microsoft. You can find it on NPM:<br>
 				<a href="https://www.npmjs.com/package/typedoc-webpack-plugin">https://www.npmjs.com/package/typedoc-webpack-plugin</a></p>
@@ -179,6 +195,7 @@ $ typedoc
 				<a href="https://www.npmjs.org/package/grunt-typedoc">https://www.npmjs.org/package/grunt-typedoc</a></p>
 				<h2 id="plugins">Plugins</h2>
 				<ul>
+					<li><a href="https://github.com/tgreyjs/typedoc-plugin-markdown">Markdown</a> - Generates Markdown output. Exposes a theme and additional arguments for rendering markdown</li>
 					<li><a href="https://github.com/christopherthielen/typedoc-plugin-external-module-name">External Module Name</a> - Set the name of TypeDoc external modules</li>
 					<li><a href="https://github.com/gdelmas/typedoc-plugin-sourcefile-url">Sourcefile URL</a> - Set custom source file URL links</li>
 					<li><a href="https://github.com/christopherthielen/typedoc-plugin-internal-external">Internal/External Module</a> - Explicitly mark modules as <code>@internal</code> or <code>@external</code></li>


### PR DESCRIPTION
Adds to README.md:
 * missing config properties 
 *little example of a typedoc.js configuration file
 * reference to typedoc-plugin-markdown
 * adds a little description in --mode taken from above comment that  describes what mode=file or modules mean