### PR TITLE
Prevent unnecessary outer directory searches

### DIFF
--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -83,43 +83,31 @@ export class PackagePlugin extends ConverterComponent {
      * @param node  The node that is currently processed if available.
      */
     private onBeginDocument(context: Context, reflection: Reflection, node?: ts.SourceFile) {
+        let packageAndReadmeFound = () => (this.noReadmeFile || this.readmeFile) && this.packageFile;
+        let reachedTopDirectory = dirName => dirName !== Path.resolve(Path.join(dirName, '..'));
+        let visitedDirBefore = dirName => this.visited.indexOf(dirName) !== -1;
+
         if (!node) {
-            return;
-        }
-        if ((this.noReadmeFile || this.readmeFile) && this.packageFile) {
             return;
         }
 
         const fileName = node.fileName;
-        let dirName: string, parentDir = Path.resolve(Path.dirname(fileName));
-        do {
-            dirName = parentDir;
-            if (this.visited.indexOf(dirName) !== -1) {
-                break;
-            }
-
-            if ((this.noReadmeFile || this.readmeFile) && this.packageFile) {
-                break;
-            }
-
-            if ((this.noReadmeFile || this.readmeFile) && this.packageFile) {
-                break;
-            }
-
+        let dirName = Path.resolve(Path.dirname(fileName));
+        while (!packageAndReadmeFound() && !reachedTopDirectory(dirName) && !visitedDirBefore(dirName)) {
             FS.readdirSync(dirName).forEach((file) => {
-                const lfile = file.toLowerCase();
-                if (!this.noReadmeFile && !this.readmeFile && lfile === 'readme.md') {
+                const lowercaseFileName = file.toLowerCase();
+                if (!this.noReadmeFile && !this.readmeFile && lowercaseFileName === 'readme.md') {
                     this.readmeFile = Path.join(dirName, file);
                 }
 
-                if (!this.packageFile && lfile === 'package.json') {
+                if (!this.packageFile && lowercaseFileName === 'package.json') {
                     this.packageFile = Path.join(dirName, file);
                 }
             });
 
             this.visited.push(dirName);
-            parentDir = Path.resolve(Path.join(dirName, '..'));
-        } while (dirName !== parentDir);
+            dirName = Path.resolve(Path.join(dirName, '..'));
+        }
     }
 
     /**

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -86,7 +86,7 @@ export class PackagePlugin extends ConverterComponent {
         if (!node) {
             return;
         }
-        if (this.readmeFile && this.packageFile) {
+        if ((this.noReadmeFile || this.readmeFile) && this.packageFile) {
             return;
         }
 
@@ -95,6 +95,14 @@ export class PackagePlugin extends ConverterComponent {
         do {
             dirName = parentDir;
             if (this.visited.indexOf(dirName) !== -1) {
+                break;
+            }
+
+            if ((this.noReadmeFile || this.readmeFile) && this.packageFile) {
+                break;
+            }
+
+            if ((this.noReadmeFile || this.readmeFile) && this.packageFile) {
                 break;
             }
 

--- a/src/test/converter/class/specs.json
+++ b/src/test/converter/class/specs.json
@@ -939,6 +939,72 @@
               }
             },
             {
+              "id": 42,
+              "name": "mergedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isStatic": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 43,
+                  "name": "mergedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "mergedMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "any"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "class.ts",
+                  "line": 91,
+                  "character": 16
+                }
+              ]
+            },
+            {
+              "id": 49,
+              "name": "staticMergedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isStatic": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 50,
+                  "name": "staticMergedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "staticMergedMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "class.ts",
+                  "line": 98,
+                  "character": 38
+                }
+              ]
+            },
+            {
               "id": 32,
               "name": "staticMethod",
               "kind": 2048,
@@ -1007,6 +1073,8 @@
               "children": [
                 19,
                 17,
+                42,
+                49,
                 32
               ]
             }


### PR DESCRIPTION
When searching up a directory tree without the added checks, every directory may be scanned until the outermost directory is reached even when the project files have already been found. This can cause avoidable permission errors when using the default options and thus typedoc to break on out-of-the-box builds for the simplest of projects. Without these checks, typedoc will always error on some setups.

* Stops the search when readme.md and package.json are found.
* Stops the search when `--readme = none` and package.json is found.