### PR TITLE
Implement and use isTypeListAssignable to find super methods 

### DIFF
--- a/src/lib/converter/plugins/ImplementsPlugin.ts
+++ b/src/lib/converter/plugins/ImplementsPlugin.ts
@@ -65,7 +65,7 @@ export class ImplementsPlugin extends ConverterComponent {
                 interfaceMember.signatures.forEach((interfaceSignature: SignatureReflection) => {
                     const interfaceParameters = interfaceSignature.getParameterTypes();
                     classMember.signatures.forEach((classSignature: SignatureReflection) => {
-                        if (Type.isTypeListEqual(interfaceParameters, classSignature.getParameterTypes())) {
+                        if (Type.isTypeListAssignable(interfaceParameters, classSignature.getParameterTypes())) {
                             classSignature.implementationOf = new ReferenceType(interfaceMemberName, ReferenceType.SYMBOL_ID_RESOLVED, interfaceSignature);
                             this.copyComment(classSignature, interfaceSignature);
                         }

--- a/src/lib/models/types/abstract.ts
+++ b/src/lib/models/types/abstract.ts
@@ -87,4 +87,62 @@ export abstract class Type {
 
         return true;
     }
+
+    /**
+     * Test whether the first type list can be assigned from the second type list.
+     *
+     * @param a  The type list to assign to (Parameter list of overridden method for example).
+     * @param b  The type list to assign from (Parameter list of extending method for example).
+     * @return True if second type list can be assigned to the first type list.
+     */
+    static isTypeListAssignable(a: Type[], b: Type[]): boolean {
+        // When not enough types are present in second list then it is not assignable
+        if (a.length > b.length) {
+            return false;
+        }
+        // For each type in first list check if it is assignable from corresponding type of second list
+        for (let index = 0, count = a.length; index < count; index++) {
+            if (!a[index].isAssignableFrom(b[index])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Test whether the given type can be assigned to this type.
+     *
+     * @param type  The type to check.
+     * @return True if specified type can be assigned to this type, false if not.
+     */
+    isAssignableFrom(type: Type): boolean {
+        if (type.isTypeWrapper()) {
+            return type.isAssignableTo(this);
+        } else {
+            return this.equals(type);
+        }
+    }
+
+    /**
+     * Test whether this type can be assigned to the given type.
+     *
+     * @param type  The type to check.
+     * @return True if this type can be assigned to the given type, false if not.
+     */
+    isAssignableTo(type: Type): boolean {
+        if (type.isTypeWrapper()) {
+            return type.isAssignableFrom(this);
+        } else {
+            return this.equals(type);
+        }
+    }
+
+    /**
+     * Test wether this type wraps other types.
+     *
+     * @return True if this type wraps other types, false if not.
+     */
+    isTypeWrapper(): boolean {
+        return false;
+    }
 }

--- a/src/lib/models/types/array.ts
+++ b/src/lib/models/types/array.ts
@@ -73,4 +73,22 @@ export class ArrayType extends Type {
             return elementTypeStr + '[]';
         }
     }
+
+    /** @inheritDoc */
+    isAssignableFrom(type: Type): boolean {
+        if (type.isTypeWrapper()) {
+            return type.isAssignableTo(this);
+        } else {
+            return type instanceof ArrayType && type.elementType.isAssignableTo(this.elementType);
+        }
+    }
+
+    /** @inheritDoc */
+    isAssignableTo(type: Type): boolean {
+        if (type.isTypeWrapper()) {
+            return type.isAssignableFrom(this);
+        } else {
+            return type instanceof ArrayType && type.elementType.isAssignableFrom(this.elementType);
+        }
+    }
 }

--- a/src/lib/models/types/intersection.ts
+++ b/src/lib/models/types/intersection.ts
@@ -43,7 +43,7 @@ export class IntersectionType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: IntersectionType): boolean {
+    equals(type: Type): boolean {
         if (!(type instanceof IntersectionType)) {
             return false;
         }
@@ -74,5 +74,24 @@ export class IntersectionType extends Type {
         });
 
         return names.join(' & ');
+    }
+
+    /** @inheritDoc */
+    isAssignableTo(type: Type): boolean {
+        if (type instanceof IntersectionType) {
+            return type.isAssignableFrom(this);
+        } else {
+            return this.types.some(subType => type.isAssignableFrom(subType));
+        }
+    }
+
+    /** @inheritDoc */
+    isAssignableFrom(type: Type): boolean {
+        return this.types.every(subType => type.isAssignableTo(subType));
+    }
+
+    /** @inheritDoc */
+    isTypeWrapper(): boolean {
+        return true;
     }
 }

--- a/src/lib/models/types/intrinsic.ts
+++ b/src/lib/models/types/intrinsic.ts
@@ -43,7 +43,7 @@ export class IntrinsicType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: IntrinsicType): boolean {
+    equals(type: Type): boolean {
         return type instanceof IntrinsicType &&
             type.name === this.name;
     }

--- a/src/lib/models/types/reference.ts
+++ b/src/lib/models/types/reference.ts
@@ -83,7 +83,7 @@ export class ReferenceType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: ReferenceType): boolean {
+    equals(type: Type): boolean {
         return type instanceof ReferenceType &&
             (type.symbolID === this.symbolID || type.reflection === this.reflection);
     }

--- a/src/lib/models/types/reflection.ts
+++ b/src/lib/models/types/reflection.ts
@@ -44,7 +44,7 @@ export class ReflectionType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: ReflectionType): boolean {
+    equals(type: Type): boolean {
         return type === this;
     }
 

--- a/src/lib/models/types/string-literal.ts
+++ b/src/lib/models/types/string-literal.ts
@@ -1,4 +1,5 @@
 import { Type } from './abstract';
+import { IntrinsicType } from './intrinsic';
 
 /**
  * Represents a string literal type.
@@ -43,7 +44,7 @@ export class StringLiteralType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: StringLiteralType): boolean {
+    equals(type: Type): boolean {
         return type instanceof StringLiteralType &&
             type.value === this.value;
     }
@@ -63,5 +64,13 @@ export class StringLiteralType extends Type {
      */
     toString(): string {
         return '"' + this.value + '"';
+    }
+
+    /** @inheritDoc */
+    isAssignableTo(type: Type): boolean {
+        if (type instanceof IntrinsicType && type.name === 'string') {
+            return true;
+        }
+        return super.isAssignableTo(type);
     }
 }

--- a/src/lib/models/types/tuple.ts
+++ b/src/lib/models/types/tuple.ts
@@ -43,7 +43,7 @@ export class TupleType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: TupleType): boolean {
+    equals(type: Type): boolean {
         if (!(type instanceof TupleType)) {
             return false;
         }
@@ -74,5 +74,25 @@ export class TupleType extends Type {
         });
 
         return '[' + names.join(', ') + ']';
+    }
+
+    /** @inheritDoc */
+    isAssignableFrom(type: Type): boolean {
+        if (type.isTypeWrapper()) {
+            return type.isAssignableTo(this);
+        } else {
+            return type instanceof TupleType &&
+                type.elements.every((elementType, index) => type.elements[index].isAssignableTo(elementType));
+        }
+    }
+
+    /** @inheritDoc */
+    isAssignableTo(type: Type): boolean {
+        if (type.isTypeWrapper()) {
+            return type.isAssignableFrom(this);
+        } else {
+            return type instanceof TupleType &&
+                type.elements.every((elementType, index) => type.elements[index].isAssignableFrom(elementType));
+        }
     }
 }

--- a/src/lib/models/types/type-operator.ts
+++ b/src/lib/models/types/type-operator.ts
@@ -40,7 +40,7 @@ export class TypeOperatorType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: TypeOperatorType): boolean {
+    equals(type: Type): boolean {
         if (!(type instanceof TypeOperatorType)) {
             return false;
         }

--- a/src/lib/models/types/type-parameter.ts
+++ b/src/lib/models/types/type-parameter.ts
@@ -20,15 +20,19 @@ export class TypeParameterType extends Type {
      */
     readonly type: string = 'typeParameter';
 
+    constructor(constraint?: Type) {
+        super();
+        this.constraint = constraint;
+    }
+
     /**
      * Clone this type.
      *
      * @return A clone of this type.
      */
     clone(): Type {
-        const clone = new TypeParameterType();
+        const clone = new TypeParameterType(this.constraint);
         clone.name = this.name;
-        clone.constraint = this.constraint;
         return clone;
     }
 
@@ -38,7 +42,7 @@ export class TypeParameterType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: TypeParameterType): boolean {
+    equals(type: Type): boolean {
         if (!(type instanceof TypeParameterType)) {
             return false;
         }
@@ -72,5 +76,20 @@ export class TypeParameterType extends Type {
      */
     toString() {
         return this.name;
+    }
+
+    /** @inheritDoc */
+    isAssignableTo(type: Type): boolean {
+        return this.constraint != null && type.isAssignableFrom(this.constraint);
+    }
+
+    /** @inheritDoc */
+    isAssignableFrom(type: Type): boolean {
+        return this.constraint == null || type.isAssignableTo(this.constraint);
+    }
+
+    /** @inheritDoc */
+    isTypeWrapper(): boolean {
+        return true;
     }
 }

--- a/src/lib/models/types/union.ts
+++ b/src/lib/models/types/union.ts
@@ -43,7 +43,7 @@ export class UnionType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: UnionType): boolean {
+    equals(type: Type): boolean {
         if (!(type instanceof UnionType)) {
             return false;
         }
@@ -74,5 +74,24 @@ export class UnionType extends Type {
         });
 
         return names.join(' | ');
+    }
+
+    /** @inheritDoc */
+    isAssignableTo(type: Type): boolean {
+        return this.types.every(subType => type.isAssignableFrom(subType));
+    }
+
+    /** @inheritDoc */
+    isAssignableFrom(type: Type): boolean {
+        if (type instanceof UnionType) {
+            return type.isAssignableTo(this);
+        } else {
+            return this.types.some(subType => type.isAssignableTo(subType));
+        }
+    }
+
+    /** @inheritDoc */
+    isTypeWrapper(): boolean {
+        return true;
     }
 }

--- a/src/lib/models/types/unknown.ts
+++ b/src/lib/models/types/unknown.ts
@@ -39,7 +39,7 @@ export class UnknownType extends Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
-    equals(type: UnknownType): boolean {
+    equals(type: Type): boolean {
         return type instanceof UnknownType &&
             type.name === this.name;
     }

--- a/src/test/converter/inheritdoc/inheritdoc.ts
+++ b/src/test/converter/inheritdoc/inheritdoc.ts
@@ -1,0 +1,140 @@
+/**
+ * Base interface short text.
+ *
+ * Base interface text.
+ */
+export interface BaseInterface<T> {
+    /**
+     * Method with generic return type.
+     *
+     * @param a - Numeric parameter A.
+     * @return Generic return type.
+     */
+    methodWithGenericReturnType(a: number): T;
+
+    /**
+     * Method with generic parameter 2.
+     *
+     * @param b - Generic parameter.
+     */
+    methodWithGenericParameter(b: T): void;
+
+    undocumentedMethod(c: string): number;
+
+    /**
+     * Method with optional generic parameter.
+     *
+     * @param e - Some numeric parameter.
+     * @param f - Optional generic parameter.
+     */
+    methodWithOptionalGenericParameter(e: number, f?: T): void;
+
+    /**
+     * Overloaded method with no args and no return value.
+     */
+    overloadedMethod(): void;
+
+    /**
+     * Overloaded method with numeric arg and string return value.
+     *
+     * @param n  The numeric argument.
+     * @return The string return value.
+     */
+    overloadedMethod(n: number): string;
+
+    /**
+     * Overloaded method with generic arg and numeric return value.
+     *
+     * @param t  The generic argument.
+     * @return The numeric return value.
+     */
+    overloadedMethod(t: T): number;
+
+    /**
+     * Overloaded method with boolean and optional generic arg and numeric return value.
+     *
+     * @param b  The boolean argument.
+     * @param t  The optional generic argument.
+     * @return The numeric return value.
+     */
+    overloadedMethod(b: boolean, t?: T): number;
+
+    /**
+     * Overloaded method with Date and nullable generic arg and numeric return value.
+     *
+     * @param d  The date argument.
+     * @param t  The nullable generic argument.
+     * @return The numeric return value.
+     */
+    overloadedMethod(d: Date, t: T | null): number;
+
+    /**
+     * Method with a union parameter and return value.
+     *
+     * @param a  A number or a string.
+     * @return A string or a number.
+     */
+    unionParamMethod(a: number | string): string | number;
+
+    /**
+     * Method with one numeric parameter but implemented with an additional optional parameter.
+     *
+     * @param a  Numeric parameter.
+     */
+    extendedMethod(a: number): void;
+}
+
+/**
+ * Concrete class short text.
+ *
+ * Concrete class text.
+ */
+export class ConcreteClass implements BaseInterface<string> {
+    /** @inheritDoc */
+    methodWithGenericReturnType(a2: number): string {
+        return '' + a2;
+    }
+
+    /** @inheritDoc */
+    methodWithGenericParameter(b2: string): void {}
+
+    /**
+     * No doc is copied from interface because no documentation is present there.
+     *
+     * @inheritDoc
+     */
+    undocumentedMethod(c2: string): number {
+        return 0;
+    }
+
+    /** @inheritDoc */
+    methodWithOptionalGenericParameter(e2: number, f2?: string): void {}
+
+    /** @inheritDoc */
+    overloadedMethod(): void;
+
+    /** @inheritDoc */
+    overloadedMethod(n2: number): string;
+
+    /** @inheritDoc */
+    overloadedMethod(t2: string): number;
+
+    /** @inheritDoc */
+    overloadedMethod(b2: boolean, t2?: string): number;
+
+    /** @inheritDoc */
+    overloadedMethod(d2: Date, t2: string | null): number;
+
+    overloadedMethod(a?: any, b?: any): number | string {
+        return 0;
+    }
+
+    /** @inheritDoc */
+    unionParamMethod(a: number | string): string | number {
+        return a;
+    }
+
+    /** @inheritDoc */
+    extendedMethod(a2: number, b2?: string): void {
+    }
+}

--- a/src/test/converter/inheritdoc/specs.json
+++ b/src/test/converter/inheritdoc/specs.json
@@ -52,9 +52,6 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {},
-                      "comment": {
-                        "text": "Numeric parameter.\n"
-                      },
                       "type": {
                         "type": "intrinsic",
                         "name": "number"
@@ -123,9 +120,6 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {},
-                      "comment": {
-                        "text": "Generic parameter.\n"
-                      },
                       "type": {
                         "type": "intrinsic",
                         "name": "string"
@@ -182,9 +176,6 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {},
-                      "comment": {
-                        "text": "Numeric parameter A."
-                      },
                       "type": {
                         "type": "intrinsic",
                         "name": "number"
@@ -240,9 +231,6 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {},
-                      "comment": {
-                        "text": "Some numeric parameter."
-                      },
                       "type": {
                         "type": "intrinsic",
                         "name": "number"
@@ -255,9 +243,6 @@
                       "kindString": "Parameter",
                       "flags": {
                         "isOptional": true
-                      },
-                      "comment": {
-                        "text": "Optional generic parameter.\n"
                       },
                       "type": {
                         "type": "intrinsic",
@@ -604,9 +589,6 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {},
-                      "comment": {
-                        "text": "A number or a string."
-                      },
                       "type": {
                         "type": "union",
                         "types": [

--- a/src/test/converter/inheritdoc/specs.json
+++ b/src/test/converter/inheritdoc/specs.json
@@ -1,0 +1,1316 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "flags": {},
+  "children": [
+    {
+      "id": 1,
+      "name": "\"inheritdoc\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/inheritdoc/inheritdoc.ts",
+      "children": [
+        {
+          "id": 35,
+          "name": "ConcreteClass",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "Concrete class short text.",
+            "text": "Concrete class text.\n"
+          },
+          "children": [
+            {
+              "id": 64,
+              "name": "extendedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 65,
+                  "name": "extendedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with one numeric parameter but implemented with an additional optional parameter."
+                  },
+                  "parameters": [
+                    {
+                      "id": 66,
+                      "name": "a2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "Numeric parameter.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 67,
+                      "name": "b2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.extendedMethod",
+                    "id": 33
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 138,
+                  "character": 18
+                }
+              ],
+              "implementationOf": {
+                "type": "reference",
+                "name": "BaseInterface.extendedMethod",
+                "id": 32
+              }
+            },
+            {
+              "id": 39,
+              "name": "methodWithGenericParameter",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 40,
+                  "name": "methodWithGenericParameter",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with generic parameter 2."
+                  },
+                  "parameters": [
+                    {
+                      "id": 41,
+                      "name": "b2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "Generic parameter.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.methodWithGenericParameter",
+                    "id": 8
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 99,
+                  "character": 30
+                }
+              ],
+              "implementationOf": {
+                "type": "reference",
+                "name": "BaseInterface.methodWithGenericParameter",
+                "id": 7
+              }
+            },
+            {
+              "id": 36,
+              "name": "methodWithGenericReturnType",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 37,
+                  "name": "methodWithGenericReturnType",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with generic return type.",
+                    "returns": "Generic return type.\n"
+                  },
+                  "parameters": [
+                    {
+                      "id": 38,
+                      "name": "a2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "Numeric parameter A."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "string"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.methodWithGenericReturnType",
+                    "id": 5
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 94,
+                  "character": 31
+                }
+              ],
+              "implementationOf": {
+                "type": "reference",
+                "name": "BaseInterface.methodWithGenericReturnType",
+                "id": 4
+              }
+            },
+            {
+              "id": 45,
+              "name": "methodWithOptionalGenericParameter",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 46,
+                  "name": "methodWithOptionalGenericParameter",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with optional generic parameter."
+                  },
+                  "parameters": [
+                    {
+                      "id": 47,
+                      "name": "e2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "Some numeric parameter."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 48,
+                      "name": "f2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "Optional generic parameter.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.methodWithOptionalGenericParameter",
+                    "id": 14
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 111,
+                  "character": 38
+                }
+              ],
+              "implementationOf": {
+                "type": "reference",
+                "name": "BaseInterface.methodWithOptionalGenericParameter",
+                "id": 13
+              }
+            },
+            {
+              "id": 49,
+              "name": "overloadedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 50,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with no args and no return value."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.overloadedMethod",
+                    "id": 18
+                  }
+                },
+                {
+                  "id": 51,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with no args and no return value."
+                  },
+                  "parameters": [
+                    {
+                      "id": 52,
+                      "name": "n2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "string"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.overloadedMethod",
+                    "id": 21
+                  }
+                },
+                {
+                  "id": 53,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with no args and no return value."
+                  },
+                  "parameters": [
+                    {
+                      "id": 54,
+                      "name": "t2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.overloadedMethod",
+                    "id": 21
+                  }
+                },
+                {
+                  "id": 55,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with no args and no return value."
+                  },
+                  "parameters": [
+                    {
+                      "id": 56,
+                      "name": "b2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "boolean"
+                      }
+                    },
+                    {
+                      "id": 57,
+                      "name": "t2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.overloadedMethod",
+                    "id": 23
+                  }
+                },
+                {
+                  "id": 58,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with no args and no return value."
+                  },
+                  "parameters": [
+                    {
+                      "id": 59,
+                      "name": "d2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "reference",
+                        "name": "Date"
+                      }
+                    },
+                    {
+                      "id": 60,
+                      "name": "t2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "union",
+                        "types": [
+                          {
+                            "type": "intrinsic",
+                            "name": "string"
+                          },
+                          {
+                            "type": "intrinsic",
+                            "name": "null"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.overloadedMethod",
+                    "id": 26
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 114,
+                  "character": 20
+                },
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 117,
+                  "character": 20
+                },
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 120,
+                  "character": 20
+                },
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 123,
+                  "character": 20
+                },
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 126,
+                  "character": 20
+                },
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 128,
+                  "character": 20
+                }
+              ],
+              "implementationOf": {
+                "type": "reference",
+                "name": "BaseInterface.overloadedMethod",
+                "id": 17
+              }
+            },
+            {
+              "id": 42,
+              "name": "undocumentedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 43,
+                  "name": "undocumentedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "No doc is copied from interface because no documentation is present there.",
+                    "tags": [
+                      {
+                        "tag": "inheritdoc",
+                        "text": "\n"
+                      }
+                    ]
+                  },
+                  "parameters": [
+                    {
+                      "id": 44,
+                      "name": "c2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.undocumentedMethod",
+                    "id": 11
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 106,
+                  "character": 22
+                }
+              ],
+              "implementationOf": {
+                "type": "reference",
+                "name": "BaseInterface.undocumentedMethod",
+                "id": 10
+              }
+            },
+            {
+              "id": 61,
+              "name": "unionParamMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 62,
+                  "name": "unionParamMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with a union parameter and return value.",
+                    "returns": "A string or a number.\n"
+                  },
+                  "parameters": [
+                    {
+                      "id": 63,
+                      "name": "a",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A number or a string."
+                      },
+                      "type": {
+                        "type": "union",
+                        "types": [
+                          {
+                            "type": "intrinsic",
+                            "name": "number"
+                          },
+                          {
+                            "type": "intrinsic",
+                            "name": "string"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "union",
+                    "types": [
+                      {
+                        "type": "intrinsic",
+                        "name": "string"
+                      },
+                      {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    ]
+                  },
+                  "implementationOf": {
+                    "type": "reference",
+                    "name": "BaseInterface.unionParamMethod",
+                    "id": 30
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 133,
+                  "character": 20
+                }
+              ],
+              "implementationOf": {
+                "type": "reference",
+                "name": "BaseInterface.unionParamMethod",
+                "id": 29
+              }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                64,
+                39,
+                36,
+                45,
+                49,
+                42,
+                61
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "inheritdoc.ts",
+              "line": 92,
+              "character": 26
+            }
+          ],
+          "implementedTypes": [
+            {
+              "type": "reference",
+              "name": "BaseInterface",
+              "id": 2,
+              "typeArguments": [
+                {
+                  "type": "intrinsic",
+                  "name": "string"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "name": "BaseInterface",
+          "kind": 256,
+          "kindString": "Interface",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "Base interface short text.",
+            "text": "Base interface text.\n"
+          },
+          "typeParameter": [
+            {
+              "id": 3,
+              "name": "T",
+              "kind": 131072,
+              "kindString": "Type parameter",
+              "flags": {}
+            }
+          ],
+          "children": [
+            {
+              "id": 32,
+              "name": "extendedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 33,
+                  "name": "extendedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with one numeric parameter but implemented with an additional optional parameter."
+                  },
+                  "parameters": [
+                    {
+                      "id": 34,
+                      "name": "a",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "Numeric parameter.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 84,
+                  "character": 18
+                }
+              ]
+            },
+            {
+              "id": 7,
+              "name": "methodWithGenericParameter",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 8,
+                  "name": "methodWithGenericParameter",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with generic parameter 2."
+                  },
+                  "parameters": [
+                    {
+                      "id": 9,
+                      "name": "b",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "Generic parameter.\n"
+                      },
+                      "type": {
+                        "type": "typeParameter",
+                        "name": "T"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 20,
+                  "character": 30
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "name": "methodWithGenericReturnType",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 5,
+                  "name": "methodWithGenericReturnType",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with generic return type.",
+                    "returns": "Generic return type.\n"
+                  },
+                  "parameters": [
+                    {
+                      "id": 6,
+                      "name": "a",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "Numeric parameter A."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "typeParameter",
+                    "name": "T"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 13,
+                  "character": 31
+                }
+              ]
+            },
+            {
+              "id": 13,
+              "name": "methodWithOptionalGenericParameter",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 14,
+                  "name": "methodWithOptionalGenericParameter",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with optional generic parameter."
+                  },
+                  "parameters": [
+                    {
+                      "id": 15,
+                      "name": "e",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "Some numeric parameter."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 16,
+                      "name": "f",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "Optional generic parameter.\n"
+                      },
+                      "type": {
+                        "type": "typeParameter",
+                        "name": "T"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 30,
+                  "character": 38
+                }
+              ]
+            },
+            {
+              "id": 17,
+              "name": "overloadedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 18,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with no args and no return value."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                },
+                {
+                  "id": 19,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with numeric arg and string return value.",
+                    "returns": "The string return value.\n"
+                  },
+                  "parameters": [
+                    {
+                      "id": 20,
+                      "name": "n",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The numeric argument."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "string"
+                  }
+                },
+                {
+                  "id": 21,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with generic arg and numeric return value.",
+                    "returns": "The numeric return value.\n"
+                  },
+                  "parameters": [
+                    {
+                      "id": 22,
+                      "name": "t",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The generic argument."
+                      },
+                      "type": {
+                        "type": "typeParameter",
+                        "name": "T"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                },
+                {
+                  "id": 23,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with boolean and optional generic arg and numeric return value.",
+                    "returns": "The numeric return value.\n"
+                  },
+                  "parameters": [
+                    {
+                      "id": 24,
+                      "name": "b",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The boolean argument."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "boolean"
+                      }
+                    },
+                    {
+                      "id": 25,
+                      "name": "t",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "The optional generic argument."
+                      },
+                      "type": {
+                        "type": "typeParameter",
+                        "name": "T"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                },
+                {
+                  "id": 26,
+                  "name": "overloadedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Overloaded method with Date and nullable generic arg and numeric return value.",
+                    "returns": "The numeric return value.\n"
+                  },
+                  "parameters": [
+                    {
+                      "id": 27,
+                      "name": "d",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The date argument."
+                      },
+                      "type": {
+                        "type": "reference",
+                        "name": "Date"
+                      }
+                    },
+                    {
+                      "id": 28,
+                      "name": "t",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The nullable generic argument."
+                      },
+                      "type": {
+                        "type": "union",
+                        "types": [
+                          {
+                            "type": "typeParameter",
+                            "name": "T"
+                          },
+                          {
+                            "type": "intrinsic",
+                            "name": "null"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 35,
+                  "character": 20
+                },
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 43,
+                  "character": 20
+                },
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 51,
+                  "character": 20
+                },
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 60,
+                  "character": 20
+                },
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 69,
+                  "character": 20
+                }
+              ]
+            },
+            {
+              "id": 10,
+              "name": "undocumentedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 11,
+                  "name": "undocumentedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "parameters": [
+                    {
+                      "id": 12,
+                      "name": "c",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 22,
+                  "character": 22
+                }
+              ]
+            },
+            {
+              "id": 29,
+              "name": "unionParamMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 30,
+                  "name": "unionParamMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Method with a union parameter and return value.",
+                    "returns": "A string or a number.\n"
+                  },
+                  "parameters": [
+                    {
+                      "id": 31,
+                      "name": "a",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A number or a string."
+                      },
+                      "type": {
+                        "type": "union",
+                        "types": [
+                          {
+                            "type": "intrinsic",
+                            "name": "number"
+                          },
+                          {
+                            "type": "intrinsic",
+                            "name": "string"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "union",
+                    "types": [
+                      {
+                        "type": "intrinsic",
+                        "name": "string"
+                      },
+                      {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "inheritdoc.ts",
+                  "line": 77,
+                  "character": 20
+                }
+              ]
+            }
+          ],
+          "groups": [
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                32,
+                7,
+                4,
+                13,
+                17,
+                10,
+                29
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "inheritdoc.ts",
+              "line": 6,
+              "character": 30
+            }
+          ],
+          "implementedBy": [
+            {
+              "type": "reference",
+              "name": "ConcreteClass",
+              "id": 35
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Classes",
+          "kind": 128,
+          "children": [
+            35
+          ]
+        },
+        {
+          "title": "Interfaces",
+          "kind": 256,
+          "children": [
+            2
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "inheritdoc.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "External modules",
+      "kind": 1,
+      "children": [
+        1
+      ]
+    }
+  ]
+}

--- a/src/test/types.ts
+++ b/src/test/types.ts
@@ -1,0 +1,201 @@
+import Assert = require('assert');
+import {
+    IntrinsicType, UnionType, ArrayType, IntersectionType, TypeParameterType, StringLiteralType
+} from '../lib/models';
+
+const stringType = new IntrinsicType('string');
+const numberType = new IntrinsicType('number');
+const booleanType = new IntrinsicType('boolean');
+const stringArrayType = new ArrayType(stringType);
+const numberArrayType = new ArrayType(numberType);
+const stringNumberUnionType = new UnionType([ stringType, numberType ]);
+const numberStringUnionType = new UnionType([ numberType, stringType ]);
+const stringNumberIntersectionType = new IntersectionType([ stringType, numberType ]);
+const stringBooleanIntersectionType = new IntersectionType([ stringType, booleanType ]);
+const numberStringIntersectionType = new IntersectionType([ numberType, stringType ]);
+const numberBooleanUnionType = new UnionType([ numberType, booleanType ]);
+const stringParamType = new TypeParameterType(stringType);
+const numberParamType = new TypeParameterType(numberType);
+const booleanParamType = new TypeParameterType(booleanType);
+const anyParamType = new TypeParameterType();
+const stringParamArrayType = new ArrayType(stringParamType);
+
+describe('ArrayType', () => {
+    it('is assignable to compatible types', () => {
+        const type = new ArrayType(stringType);
+        Assert(type.isAssignableTo(type));
+        Assert(type.isAssignableTo(stringArrayType));
+        Assert(type.isAssignableTo(anyParamType));
+        Assert(type.isAssignableTo(stringParamArrayType));
+    });
+    it('is not assignable to incompatible types', () => {
+        const type = new ArrayType(stringType);
+        Assert(!type.isAssignableTo(stringType));
+        Assert(!type.isAssignableTo(numberArrayType));
+        Assert(!type.isAssignableTo(numberType));
+        Assert(!type.isAssignableTo(booleanType));
+        Assert(!type.isAssignableTo(stringParamType));
+        Assert(!type.isAssignableTo(numberParamType));
+        Assert(!type.isAssignableTo(numberBooleanUnionType));
+        Assert(!type.isAssignableTo(stringNumberUnionType));
+        Assert(!type.isAssignableTo(stringNumberIntersectionType));
+    });
+    it('is assignable from compatible types', () => {
+        const type = new ArrayType(stringType);
+        Assert(type.isAssignableFrom(type));
+        Assert(type.isAssignableFrom(stringArrayType));
+        Assert(type.isAssignableFrom(stringParamArrayType));
+    });
+    it('is not assignable from incompatible types', () => {
+        const type = new ArrayType(stringType);
+        Assert(!type.isAssignableFrom(booleanType));
+        Assert(!type.isAssignableFrom(booleanParamType));
+        Assert(!type.isAssignableFrom(stringNumberUnionType));
+        Assert(!type.isAssignableFrom(anyParamType));
+        Assert(!type.isAssignableFrom(numberArrayType));
+    });
+});
+
+describe('IntersectionType', () => {
+    it('is assignable to compatible types', () => {
+        const type = new IntersectionType([ stringType, numberType ]);
+        Assert(type.isAssignableTo(type));
+        Assert(type.isAssignableTo(stringNumberIntersectionType));
+        Assert(type.isAssignableTo(numberStringIntersectionType));
+        Assert(type.isAssignableTo(numberType));
+        Assert(type.isAssignableTo(stringType));
+        Assert(type.isAssignableTo(stringNumberUnionType));
+        Assert(type.isAssignableTo(numberStringUnionType));
+        Assert(type.isAssignableTo(numberBooleanUnionType));
+        Assert(type.isAssignableTo(stringParamType));
+        Assert(type.isAssignableTo(numberParamType));
+        Assert(type.isAssignableTo(anyParamType));
+    });
+    it('is not assignable to incompatible types', () => {
+        const type = new IntersectionType([ stringType, numberType ]);
+        Assert(!type.isAssignableTo(booleanType));
+        Assert(!type.isAssignableTo(stringArrayType));
+        Assert(!type.isAssignableTo(stringBooleanIntersectionType));
+        Assert(!type.isAssignableTo(booleanParamType));
+    });
+    it('is assignable from compatible types', () => {
+        const type = new IntersectionType([ stringType, numberType ]);
+        Assert(type.isAssignableFrom(type));
+        Assert(type.isAssignableFrom(stringNumberIntersectionType));
+        Assert(type.isAssignableFrom(numberStringIntersectionType));
+    });
+    it('is not assignable from incompatible types', () => {
+        const type = new IntersectionType([ stringType, numberType ]);
+        Assert(!type.isAssignableFrom(stringType));
+        Assert(!type.isAssignableFrom(numberType));
+        Assert(!type.isAssignableFrom(booleanType));
+        Assert(!type.isAssignableFrom(stringArrayType));
+        Assert(!type.isAssignableFrom(stringNumberUnionType));
+        Assert(!type.isAssignableFrom(numberStringUnionType));
+        Assert(!type.isAssignableFrom(stringBooleanIntersectionType));
+        Assert(!type.isAssignableFrom(numberBooleanUnionType));
+        Assert(!type.isAssignableFrom(stringParamType));
+        Assert(!type.isAssignableFrom(numberParamType));
+        Assert(!type.isAssignableFrom(booleanParamType));
+        Assert(!type.isAssignableFrom(anyParamType));
+    });
+});
+
+describe('IntrinsicType', () => {
+    it('is assignable to compatible types', () => {
+        const type = new IntrinsicType('string');
+        Assert(type.isAssignableTo(type));
+        Assert(type.isAssignableTo(stringType));
+        Assert(type.isAssignableTo(stringNumberUnionType));
+        Assert(type.isAssignableTo(stringParamType));
+        Assert(type.isAssignableTo(anyParamType));
+    });
+    it('is not assignable to incompatible types', () => {
+        const type = new IntrinsicType('string');
+        Assert(!type.isAssignableTo(numberType));
+        Assert(!type.isAssignableTo(numberBooleanUnionType));
+        Assert(!type.isAssignableTo(stringArrayType));
+        Assert(!type.isAssignableTo(stringNumberIntersectionType));
+        Assert(!type.isAssignableTo(numberParamType));
+    });
+    it('is assignable from compatible types', () => {
+        const type = new IntrinsicType('string');
+        Assert(type.isAssignableFrom(type));
+        Assert(type.isAssignableFrom(stringType));
+        Assert(type.isAssignableFrom(stringNumberIntersectionType));
+        Assert(type.isAssignableFrom(stringParamType));
+    });
+    it('is not assignable from incompatible types', () => {
+        const type = new IntrinsicType('string');
+        Assert(!type.isAssignableFrom(numberType));
+        Assert(!type.isAssignableFrom(stringArrayType));
+        Assert(!type.isAssignableFrom(stringNumberUnionType));
+        Assert(!type.isAssignableFrom(anyParamType));
+        Assert(!type.isAssignableFrom(numberParamType));
+    });
+});
+
+describe('StringLiteralType', () => {
+    it('is assignable to compatible types', () => {
+        const type = new StringLiteralType('test');
+        Assert(type.isAssignableTo(type));
+        Assert(type.isAssignableTo(stringType));
+        Assert(type.isAssignableTo(new StringLiteralType('test')));
+        Assert(type.isAssignableTo(stringParamType));
+        Assert(type.isAssignableTo(anyParamType));
+    });
+    it('is not assignable to incompatible types', () => {
+        const type = new StringLiteralType('test');
+        Assert(!type.isAssignableTo(new StringLiteralType('test2')));
+    });
+    it('is assignable from compatible types', () => {
+        const type = new StringLiteralType('test');
+        Assert(type.isAssignableFrom(new StringLiteralType('test')));
+    });
+    it('is not assignable from incompatible types', () => {
+        const type = new StringLiteralType('test');
+        Assert(!type.isAssignableFrom(stringType));
+        Assert(!type.isAssignableFrom(stringParamType));
+    });
+});
+
+describe('UnionType', () => {
+    it('is assignable to compatible types', () => {
+        const type = new UnionType([ stringType, numberType ]);
+        Assert(type.isAssignableTo(type));
+        Assert(type.isAssignableTo(stringNumberUnionType));
+        Assert(type.isAssignableTo(numberStringUnionType));
+        Assert(type.isAssignableTo(anyParamType));
+    });
+    it('is not assignable to incompatible types', () => {
+        const type = new UnionType([ stringType, numberType ]);
+        Assert(!type.isAssignableTo(numberType));
+        Assert(!type.isAssignableTo(booleanType));
+        Assert(!type.isAssignableTo(stringType));
+        Assert(!type.isAssignableTo(stringArrayType));
+        Assert(!type.isAssignableTo(stringParamType));
+        Assert(!type.isAssignableTo(numberParamType));
+        Assert(!type.isAssignableTo(numberBooleanUnionType));
+        Assert(!type.isAssignableTo(stringNumberIntersectionType));
+        Assert(!type.isAssignableTo(stringBooleanIntersectionType));
+    });
+    it('is assignable from compatible types', () => {
+        const type = new UnionType([ stringType, numberType ]);
+        Assert(type.isAssignableFrom(type));
+        Assert(type.isAssignableFrom(stringNumberUnionType));
+        Assert(type.isAssignableFrom(numberStringUnionType));
+        Assert(type.isAssignableFrom(stringNumberIntersectionType));
+        Assert(type.isAssignableFrom(stringType));
+        Assert(type.isAssignableFrom(numberType));
+        Assert(type.isAssignableFrom(numberParamType));
+        Assert(type.isAssignableFrom(stringParamType));
+        Assert(type.isAssignableFrom(stringBooleanIntersectionType));
+    });
+    it('is not assignable from incompatible types', () => {
+        const type = new UnionType([ stringType, numberType ]);
+        Assert(!type.isAssignableFrom(booleanType));
+        Assert(!type.isAssignableFrom(booleanParamType));
+        Assert(!type.isAssignableFrom(numberBooleanUnionType));
+        Assert(!type.isAssignableFrom(stringArrayType));
+    });
+});


### PR DESCRIPTION
The previously used isTypeListEqual method only works when method signature is exactly the same so it breaks when widening a signature or using generic types. This new method instead checks if the type used in the interface can be assigned to the type used in the implementation.

Fixes #793.
