### PR TITLE
TypeScript updated to 2.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2318,9 +2318,9 @@
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
+      "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2318,9 +2318,9 @@
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
     },
     "typescript": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
-      "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA=="
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "progress": "^2.0.0",
     "shelljs": "^0.8.1",
     "typedoc-default-themes": "^0.5.0",
-    "typescript": "2.7.2"
+    "typescript": "^2.9.1"
   },
   "devDependencies": {
     "@types/mocha": "2.2.48",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "progress": "^2.0.0",
     "shelljs": "^0.8.1",
     "typedoc-default-themes": "^0.5.0",
-    "typescript": "^2.9.1"
+    "typescript": "2.9.1"
   },
   "devDependencies": {
     "@types/mocha": "2.2.48",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "progress": "^2.0.0",
     "shelljs": "^0.8.1",
     "typedoc-default-themes": "^0.5.0",
-    "typescript": "2.9.1"
+    "typescript": "2.9.2"
   },
   "devDependencies": {
     "@types/mocha": "2.2.48",


### PR DESCRIPTION
Typescript dependency version updated to 2.9.2

fixes: https://github.com/TypeStrong/typedoc/issues/785 https://github.com/TypeStrong/typedoc/issues/733