### PR TITLE
Flatten messageText when no file is provided in the diagnostic log output

### DIFF
--- a/src/lib/utils/loggers.ts
+++ b/src/lib/utils/loggers.ts
@@ -134,7 +134,7 @@ export class Logger {
             output += '(' + ts.getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start).line + ')';
             output += ts.sys.newLine + ' ' + ts.flattenDiagnosticMessageText(diagnostic.messageText, ts.sys.newLine);
         } else {
-            output = diagnostic.messageText.toString();
+            output = ts.flattenDiagnosticMessageText(diagnostic.messageText, ts.sys.newLine);
         }
 
         switch (diagnostic.category) {


### PR DESCRIPTION
Currently, the TypeScript compiler doesn't set a `file` property on a diagnostic log object if the file cannot be written by the compiler.  A sample incoming object has the following schema:

```json
{
   "code":5055,
   "category":1,
   "messageText":{
      "messageText":"Cannot write file '/home/aru/code/project/external/leaflet.textpath.js' because it would overwrite input file.",
      "category":1,
      "code":5055,
      "next":{
         "messageText":"Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.",
         "category":1,
         "code":5068
      }
   }
}
```

In the `ConsoleLogger`, if there is no `file` property on the diagnostic object, it defaults to outputting `messageText.toString()`, which is an object in this case.  The resultant output of `Error: [object Object]` is less than helpful.

This PR updates the non-file case to use the same message flattening/stringifying method that the file case uses.

Fixes #495