### PR TITLE
Fix interface merging flagged as static

### DIFF
--- a/src/lib/converter/factories/declaration.ts
+++ b/src/lib/converter/factories/declaration.ts
@@ -15,6 +15,14 @@ const nonStaticKinds = [
 ];
 
 /**
+ * List of ts kinds leading to none static merge.
+ */
+const nonStaticMergeKinds = [
+    ts.SyntaxKind.ClassDeclaration,
+    ts.SyntaxKind.InterfaceDeclaration
+];
+
+/**
  * Create a declaration reflection from the given TypeScript node.
  *
  * @param context  The context object describing the current state the converter is in. The
@@ -78,7 +86,7 @@ export function createDeclaration(context: Context, node: ts.Node, kind: Reflect
         if (container.kind === ReflectionKind.Class) {
             if (node.parent && node.parent.kind === ts.SyntaxKind.Constructor) {
                 isConstructorProperty = true;
-            } else if (!node.parent || node.parent.kind !== ts.SyntaxKind.ClassDeclaration) {
+            } else if (!node.parent || nonStaticMergeKinds.indexOf(node.parent.kind) === -1) {
                 isStatic = true;
             }
         }

--- a/src/test/converter/class/class.ts
+++ b/src/test/converter/class/class.ts
@@ -84,6 +84,20 @@ export class TestAbstractClassImplementation extends TestAbstractClass {
     protected myAbstractMethod(): void { }
 }
 
+export interface TestSubClass {
+    /**
+     * mergedMethod short text.
+     */
+    mergedMethod();
+}
+
+export module TestSubClass {
+    /**
+     * staticMergedMethod short text.
+     */
+    export function staticMergedMethod() { }
+}
+
 /**
  * This class will not appear when `excludeNotExported=true`
  */

--- a/src/test/converter/class/specs-without-exported.json
+++ b/src/test/converter/class/specs-without-exported.json
@@ -769,6 +769,38 @@
               }
             },
             {
+              "id": 42,
+              "name": "mergedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 43,
+                  "name": "mergedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "mergedMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "any"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "class.ts",
+                  "line": 91,
+                  "character": 16
+                }
+              ]
+            },
+            {
               "id": 19,
               "name": "protectedMethod",
               "kind": 2048,
@@ -855,6 +887,39 @@
               }
             },
             {
+              "id": 44,
+              "name": "staticMergedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isStatic": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 45,
+                  "name": "staticMergedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "staticMergedMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "class.ts",
+                  "line": 98,
+                  "character": 38
+                }
+              ]
+            },
+            {
               "id": 32,
               "name": "staticMethod",
               "kind": 2048,
@@ -921,8 +986,10 @@
               "title": "Methods",
               "kind": 2048,
               "children": [
+                42,
                 19,
                 17,
+                44,
                 32
               ]
             }
@@ -932,6 +999,16 @@
               "fileName": "class.ts",
               "line": 51,
               "character": 25
+            },
+            {
+              "fileName": "class.ts",
+              "line": 87,
+              "character": 29
+            },
+            {
+              "fileName": "class.ts",
+              "line": 94,
+              "character": 26
             }
           ],
           "extendedTypes": [


### PR DESCRIPTION
In the current version of typedoc, augmenting classes through interface merging is leading to the isStatic flag being set to true:

```
export class A {
}

export interface A {
    /**
     * This method will be flagged as static despite being an instance one.
     */
    mergeMethod();
}
```
I added the corresponding fix and test in the PR. Let me know if you need anything else.