### PR TITLE
chore: upgrade to typescript 3.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "progress": "^2.0.0",
     "shelljs": "^0.8.1",
     "typedoc-default-themes": "^0.5.0",
-    "typescript": "2.7.2"
+    "typescript": "^3.0.1"
   },
   "devDependencies": {
     "@types/mocha": "2.2.48",

--- a/src/lib/converter/factories/declaration.ts
+++ b/src/lib/converter/factories/declaration.ts
@@ -24,7 +24,7 @@ const nonStaticKinds = [
  * @param name  The desired name of the reflection.
  * @returns The resulting reflection.
  */
-export function createDeclaration(context: Context, node: ts.Node, kind: ReflectionKind, name?: string): DeclarationReflection {
+export function createDeclaration(context: Context, node: ts.Declaration, kind: ReflectionKind, name?: string): DeclarationReflection {
     const container = <ContainerReflection> context.scope;
     if (!(container instanceof ContainerReflection)) {
         throw new Error('Expected container reflection.');
@@ -54,7 +54,7 @@ export function createDeclaration(context: Context, node: ts.Node, kind: Reflect
     if (kind === ReflectionKind.ExternalModule) {
         isExported = true; // Always mark external modules as exported
     } else if (node.parent && node.parent.kind === ts.SyntaxKind.VariableDeclarationList) {
-        const parentModifiers = ts.getCombinedModifierFlags(node.parent.parent);
+        const parentModifiers = ts.getCombinedModifierFlags(node.parent.parent as ts.Declaration);
         isExported = isExported || !!(parentModifiers & ts.ModifierFlags.Export);
     } else {
         isExported = isExported || !!(modifiers & ts.ModifierFlags.Export);
@@ -127,7 +127,7 @@ export function createDeclaration(context: Context, node: ts.Node, kind: Reflect
  * @param node  The TypeScript node whose properties should be applies to the given reflection.
  * @returns The reflection populated with the values of the given node.
  */
-function setupDeclaration(context: Context, reflection: DeclarationReflection, node: ts.Node) {
+function setupDeclaration(context: Context, reflection: DeclarationReflection, node: ts.Declaration) {
     const modifiers = ts.getCombinedModifierFlags(node);
 
     reflection.setFlag(ReflectionFlag.External,  context.isExternal);

--- a/src/lib/converter/nodes/function.ts
+++ b/src/lib/converter/nodes/function.ts
@@ -28,7 +28,7 @@ export class FunctionConverter extends ConverterNodeComponent<ts.FunctionDeclara
         const scope   = context.scope;
         const kind    = scope.kind & ReflectionKind.ClassOrInterface ? ReflectionKind.Method : ReflectionKind.Function;
         const hasBody = !!node.body;
-        const method  = createDeclaration(context, <ts.Node> node, kind);
+        const method  = createDeclaration(context, node, kind);
 
         if (method  // child inheriting will return null on createDeclaration
             && kind & ReflectionKind.Method

--- a/src/lib/ts-internal.ts
+++ b/src/lib/ts-internal.ts
@@ -98,7 +98,7 @@ export function isBindingPattern(node: ts.Node): node is ts.BindingPattern {
 
 // https://github.com/Microsoft/TypeScript/blob/v2.1.4/src/compiler/utilities.ts#L1729
 export function getClassExtendsHeritageClauseElement(node: ts.ClassLikeDeclaration | ts.InterfaceDeclaration) {
-  return tsany.getClassExtendsHeritageClauseElement.apply(this, arguments);
+  return tsany.getClassExtendsHeritageElement.apply(this, arguments);
 }
 
 // https://github.com/Microsoft/TypeScript/blob/v2.1.4/src/compiler/utilities.ts#L1734


### PR DESCRIPTION
The PR allows typedoc to be used with typescript 3.0.x. Once the PR is merged, it should be released as new minor version.