### PR TITLE
Allow installing `typedoc` from git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "test": "mocha -t 10000 --exit dist/test",
     "build": "grunt build_and_test",
     "prepublish": "npm run build",
+    "prepare": "grunt",
     "grunt": "grunt",
     "clean": "rm -rf node_modules package-lock.json lib coverage .tscache"
   },


### PR DESCRIPTION
The `prepare` script was introduced in npm 5 to distinguish between build steps and other prepublish tasks (which should be run from the `prepublishOnly` script.

npm no longer runs the `prepublish` script when installing from git repositories, but it will install dev deps and run `prepare` if it's present. Both are run before publishing.