### PR TITLE
Stricter lint config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_install: >
 
 script: >
   npm test
-  npn run lint
+  npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ before_install: >
       npm install --global npm@latest
   fi
 
-script: >
-  npm test
-  npm run lint
+script:
+ - npm test
+ - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ before_install: >
     else
       npm install --global npm@latest
   fi
+
+script: >
+  npm test
+  npn run lint

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "scripts": {
     "test": "grunt test",
     "build": "grunt build_and_test",
+    "lint": "tslint --project .",
     "prepublishOnly": "grunt build_and_test",
     "prepare": "grunt default",
     "grunt": "grunt",

--- a/src/lib/converter/nodes/block.ts
+++ b/src/lib/converter/nodes/block.ts
@@ -49,7 +49,7 @@ export class BlockConverter extends ConverterNodeComponent<ts.SourceFile|ts.Bloc
      */
     convert(context: Context, node: ts.SourceFile|ts.Block|ts.ModuleBlock): Reflection {
         if (node.kind === ts.SyntaxKind.SourceFile) {
-            this.convertSourceFile(context, <ts.SourceFile> node);
+            this.convertSourceFile(context, node);
         } else {
             this.convertStatements(context, node);
         }

--- a/src/lib/converter/nodes/export.ts
+++ b/src/lib/converter/nodes/export.ts
@@ -36,7 +36,7 @@ export class ExportConverter extends ConverterNodeComponent<ts.ExportAssignment>
 
                 const reflection = project.reflections[id];
                 if (node.isExportEquals && reflection instanceof DeclarationReflection) {
-                    (<DeclarationReflection> reflection).setFlag(ReflectionFlag.ExportAssignment, true);
+                    reflection.setFlag(ReflectionFlag.ExportAssignment, true);
                 }
                 markAsExported(reflection);
             });
@@ -44,7 +44,7 @@ export class ExportConverter extends ConverterNodeComponent<ts.ExportAssignment>
 
         function markAsExported(reflection: Reflection) {
             if (reflection instanceof DeclarationReflection) {
-                (<DeclarationReflection> reflection).setFlag(ReflectionFlag.Exported, true);
+                reflection.setFlag(ReflectionFlag.Exported, true);
             }
 
             reflection.traverse(markAsExported);

--- a/src/lib/converter/nodes/signature-call.ts
+++ b/src/lib/converter/nodes/signature-call.ts
@@ -28,7 +28,7 @@ export class SignatureConverter extends ConverterNodeComponent<ts.FunctionExpres
         const scope = <DeclarationReflection> context.scope;
         if (scope instanceof DeclarationReflection) {
             const name = scope.kindOf(ReflectionKind.FunctionOrMethod) ? scope.name : '__call';
-            const signature = createSignature(context, <ts.SignatureDeclaration> node, name, ReflectionKind.CallSignature);
+            const signature = createSignature(context, node, name, ReflectionKind.CallSignature);
             if (!scope.signatures) {
                 scope.signatures = [];
             }

--- a/src/lib/converter/nodes/variable-statement.ts
+++ b/src/lib/converter/nodes/variable-statement.ts
@@ -25,7 +25,7 @@ export class VariableStatementConverter extends ConverterNodeComponent<ts.Variab
         if (node.declarationList && node.declarationList.declarations) {
             node.declarationList.declarations.forEach((variableDeclaration) => {
                 if (_ts.isBindingPattern(variableDeclaration.name)) {
-                    this.convertBindingPattern(context, <ts.BindingPattern> variableDeclaration.name);
+                    this.convertBindingPattern(context, variableDeclaration.name);
                 } else {
                     this.owner.convertNode(context, variableDeclaration);
                 }
@@ -46,7 +46,7 @@ export class VariableStatementConverter extends ConverterNodeComponent<ts.Variab
             this.owner.convertNode(context, element);
 
             if (_ts.isBindingPattern(element.name)) {
-                this.convertBindingPattern(context, <ts.BindingPattern> element.name);
+                this.convertBindingPattern(context, element.name);
             }
         });
     }

--- a/src/lib/converter/plugins/CategoryPlugin.ts
+++ b/src/lib/converter/plugins/CategoryPlugin.ts
@@ -36,13 +36,12 @@ export class CategoryPlugin extends ConverterComponent {
      */
     private onResolve(context: Context, reflection: Reflection) {
         if (reflection instanceof ContainerReflection) {
-            const container = <ContainerReflection> reflection;
-            if (container.children && container.children.length > 0) {
-                container.children.sort(GroupPlugin.sortCallback);
-                container.categories = CategoryPlugin.getReflectionCategories(container.children);
+            if (reflection.children && reflection.children.length > 0) {
+                reflection.children.sort(GroupPlugin.sortCallback);
+                reflection.categories = CategoryPlugin.getReflectionCategories(reflection.children);
             }
-            if (container.categories && container.categories.length > 1) {
-                container.categories.sort(CategoryPlugin.sortCatCallback);
+            if (reflection.categories && reflection.categories.length > 1) {
+                reflection.categories.sort(CategoryPlugin.sortCatCallback);
             }
         }
     }

--- a/src/lib/converter/plugins/GroupPlugin.ts
+++ b/src/lib/converter/plugins/GroupPlugin.ts
@@ -87,10 +87,9 @@ export class GroupPlugin extends ConverterComponent {
         reflection.kindString = GroupPlugin.getKindSingular(reflection.kind);
 
         if (reflection instanceof ContainerReflection) {
-            const container = <ContainerReflection> reflection;
-            if (container.children && container.children.length > 0) {
-                container.children.sort(GroupPlugin.sortCallback);
-                container.groups = GroupPlugin.getReflectionGroups(container.children);
+            if (reflection.children && reflection.children.length > 0) {
+                reflection.children.sort(GroupPlugin.sortCallback);
+                reflection.groups = GroupPlugin.getReflectionGroups(reflection.children);
             }
         }
     }

--- a/src/lib/converter/plugins/ImplementsPlugin.ts
+++ b/src/lib/converter/plugins/ImplementsPlugin.ts
@@ -109,9 +109,8 @@ export class ImplementsPlugin extends ConverterComponent {
                     return;
                 }
 
-                const source = <DeclarationReflection> (<ReferenceType> type).reflection;
-                if (source && source.kindOf(ReflectionKind.Interface)) {
-                    this.analyzeClass(context, reflection, source);
+                if (type.reflection && type.reflection.kindOf(ReflectionKind.Interface)) {
+                    this.analyzeClass(context, reflection, <DeclarationReflection> type.reflection);
                 }
             });
         }

--- a/src/lib/converter/plugins/TypePlugin.ts
+++ b/src/lib/converter/plugins/TypePlugin.ts
@@ -69,14 +69,14 @@ export class TypePlugin extends ConverterComponent {
             if (!types) {
                 return;
             }
-            types.forEach((type: ReferenceType) => {
+            types.forEach(type => {
                 if (!(type instanceof ReferenceType)) {
                     return;
                 }
                 if (!type.reflection || !(type.reflection instanceof DeclarationReflection)) {
                     return;
                 }
-                callback(<DeclarationReflection> type.reflection);
+                callback(type.reflection);
             });
         }
 
@@ -91,28 +91,19 @@ export class TypePlugin extends ConverterComponent {
 
         function resolveType(reflection: Reflection, type: Type) {
             if (type instanceof ReferenceType) {
-                const referenceType: ReferenceType = <ReferenceType> type;
-                if (referenceType.symbolID === ReferenceType.SYMBOL_ID_RESOLVE_BY_NAME) {
-                    referenceType.reflection = reflection.findReflectionByName(referenceType.name);
-                } else if (!referenceType.reflection && referenceType.symbolID !== ReferenceType.SYMBOL_ID_RESOLVED) {
-                    referenceType.reflection = project.reflections[project.symbolMapping[referenceType.symbolID]];
+                if (type.symbolID === ReferenceType.SYMBOL_ID_RESOLVE_BY_NAME) {
+                    type.reflection = reflection.findReflectionByName(type.name);
+                } else if (!type.reflection && type.symbolID !== ReferenceType.SYMBOL_ID_RESOLVED) {
+                    type.reflection = project.reflections[project.symbolMapping[type.symbolID]];
                 }
 
-                if (referenceType.typeArguments) {
-                    referenceType.typeArguments.forEach((typeArgument: Type) => {
-                        resolveType(reflection, typeArgument);
-                    });
+                if (type.typeArguments) {
+                    resolveTypes(reflection, type.typeArguments);
                 }
             } else if (type instanceof TupleType) {
-                const tupleType: TupleType = <TupleType> type;
-                for (let index = 0, count = tupleType.elements.length; index < count; index++) {
-                    resolveType(reflection, tupleType.elements[index]);
-                }
+                resolveTypes(reflection, type.elements);
             } else if (type instanceof UnionType || type instanceof IntersectionType) {
-                const unionOrIntersectionType: UnionType | IntersectionType = <UnionType | IntersectionType> type;
-                for (let index = 0, count = unionOrIntersectionType.types.length; index < count; index++) {
-                    resolveType(reflection, unionOrIntersectionType.types[index]);
-                }
+                resolveTypes(reflection, type.types);
             } else if (type instanceof ArrayType) {
                 resolveType(reflection, type.elementType);
             }

--- a/src/lib/models/comments/comment.ts
+++ b/src/lib/models/comments/comment.ts
@@ -42,7 +42,7 @@ export class Comment {
      * @returns TRUE when this comment has a visible component.
      */
     hasVisibleComponent(): boolean {
-        return <boolean> (!!this.shortText || !!this.text || !!this.tags);
+        return !!this.shortText || !!this.text || !!this.tags;
     }
 
     /**

--- a/src/lib/models/reflections/abstract.ts
+++ b/src/lib/models/reflections/abstract.ts
@@ -466,7 +466,7 @@ export abstract class Reflection {
      * @returns TRUE when this reflection has a visible comment.
      */
     hasComment(): boolean {
-        return <boolean> (this.comment && this.comment.hasVisibleComponent());
+        return this.comment && this.comment.hasVisibleComponent();
     }
 
     hasGetterOrSetter(): boolean {

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -157,7 +157,7 @@ export class DeclarationReflection extends ContainerReflection implements Defaul
         }
 
         if (this.type instanceof ReflectionType) {
-            callback((<ReflectionType> this.type).declaration, TraverseProperty.TypeLiteral);
+            callback(this.type.declaration, TraverseProperty.TypeLiteral);
         }
 
         if (this.signatures) {

--- a/src/lib/models/reflections/parameter.ts
+++ b/src/lib/models/reflections/parameter.ts
@@ -19,7 +19,7 @@ export class ParameterReflection extends Reflection implements DefaultValueConta
      */
     traverse(callback: TraverseCallback) {
         if (this.type instanceof ReflectionType) {
-            callback((<ReflectionType> this.type).declaration, TraverseProperty.TypeLiteral);
+            callback(this.type.declaration, TraverseProperty.TypeLiteral);
         }
 
         super.traverse(callback);

--- a/src/lib/models/reflections/signature.ts
+++ b/src/lib/models/reflections/signature.ts
@@ -54,7 +54,7 @@ export class SignatureReflection extends Reflection implements TypeContainer, Ty
      */
     traverse(callback: TraverseCallback) {
         if (this.type instanceof ReflectionType) {
-            callback((<ReflectionType> this.type).declaration, TraverseProperty.TypeLiteral);
+            callback(this.type.declaration, TraverseProperty.TypeLiteral);
         }
 
         if (this.typeParameters) {

--- a/src/lib/output/themes/DefaultTheme.ts
+++ b/src/lib/output/themes/DefaultTheme.ts
@@ -329,7 +329,7 @@ export class DefaultTheme extends Theme {
         for (let id in event.project.reflections) {
             const reflection = event.project.reflections[id];
             if (reflection instanceof DeclarationReflection) {
-                DefaultTheme.applyReflectionClasses(<DeclarationReflection> reflection);
+                DefaultTheme.applyReflectionClasses(reflection);
             }
 
             if (reflection instanceof ContainerReflection && reflection['groups']) {

--- a/src/lib/utils/component.ts
+++ b/src/lib/utils/component.ts
@@ -12,8 +12,8 @@ export interface Component extends AbstractComponent<ComponentHost> {
 
 }
 
-export interface ComponentClass<T extends Component> extends Function {
-    new(owner: ComponentHost): T;
+export interface ComponentClass<T extends Component, O extends ComponentHost = ComponentHost> extends Function {
+    new(owner: O): T;
 }
 
 export interface ComponentOptions {
@@ -64,7 +64,7 @@ export function Component(options: ComponentOptions): ClassDecorator {
 }
 
 export function Option(options: DeclarationOption): PropertyDecorator {
-    return function(target: AbstractComponent<any>, propertyKey: string) {
+    return function(target: object, propertyKey: string | symbol) {
         if (!(target instanceof AbstractComponent)) {
             throw new Error('The `Option` decorator can only be used on properties within an `AbstractComponent` subclass.');
         }
@@ -212,7 +212,7 @@ export abstract class ChildableComponent<O extends ComponentHost, C extends Comp
         return !!(this._componentChildren && this._componentChildren[name]);
     }
 
-    addComponent<T extends C & Component>(name: string, componentClass: T|ComponentClass<T>): T {
+    addComponent<T extends C & Component>(name: string, componentClass: T|ComponentClass<T, O>): T {
         if (!this._componentChildren) {
             this._componentChildren = {};
         }
@@ -220,7 +220,9 @@ export abstract class ChildableComponent<O extends ComponentHost, C extends Comp
         if (this._componentChildren[name]) {
             throw new Error('The component `%s` has already been added.');
         } else {
-            const component: T = typeof componentClass === 'function' ? new (<ComponentClass<T>> componentClass)(this) : <T> componentClass;
+            const component: T = typeof componentClass === 'function'
+                ? new (<ComponentClass<T>> componentClass)(this)
+                : componentClass;
             const event = new ComponentEvent(ComponentEvent.ADDED, this, component);
 
             this.bubble(event);

--- a/src/lib/utils/events.ts
+++ b/src/lib/utils/events.ts
@@ -486,7 +486,7 @@ export class EventDispatcher {
                 }
             });
         } else {
-            eventsApi(triggerApi, this._events, <EventMap|string> name, void 0, args);
+            eventsApi(triggerApi, this._events, name, void 0, args);
         }
 
         return this;

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -131,7 +131,7 @@ export class Options extends ChildableComponent<Application, OptionsComponent> {
     }
 
     setValue(name: string|OptionDeclaration, value: any, errorCallback?: Function) {
-        const declaration = name instanceof OptionDeclaration ? name : this.getDeclaration(<string> name);
+        const declaration = name instanceof OptionDeclaration ? name : this.getDeclaration(name);
         if (!declaration) {
             return;
         }
@@ -158,12 +158,9 @@ export class Options extends ChildableComponent<Application, OptionsComponent> {
     }
 
     addDeclaration(declaration: OptionDeclaration|DeclarationOption) {
-        let decl: OptionDeclaration;
-        if (!(declaration instanceof OptionDeclaration)) {
-            decl = new OptionDeclaration(<DeclarationOption> declaration);
-        } else {
-            decl = <OptionDeclaration> declaration;
-        }
+        const decl = declaration instanceof OptionDeclaration
+            ? declaration
+            : new OptionDeclaration(declaration);
 
         for (let name of decl.getNames()) {
             if (name in this.declarations) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     ],
     "target": "es5",
     "noImplicitAny": false,
+    "strictFunctionTypes": true,
     "removeComments": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,13 +1,12 @@
 {
 	"rules": {
 		"align": false,
-		"ban": [],
 		"class-name": true,
 		"comment-format": [ true, "check-space" ],
 		"curly": true,
 		"eofline": true,
 		"forin": false,
-		"indent": [ true, "spaces" ],
+		"indent": [ true, "spaces", 4 ],
 		"interface-name": [ true, "never-prefix" ],
 		"jsdoc-format": true,
 		"label-position": true,
@@ -29,6 +28,7 @@
 		"no-string-literal": false,
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
+		"no-unnecessary-type-assertion": true,
 		"no-unused-expression": false,
 		"no-use-before-declare": false,
 		"no-var-keyword": true,


### PR DESCRIPTION
Also turns on strictFunctionTypes, which required an update to the `ComponentClass` interface.

This change makes typedoc less likely to break if types change in the future since it removes type assertions which aren't currently needed.

Running `grunt build_and_test` will **not** lint files with the new `no-unnecessary-type-assertion` rule as it appears the plugin does not support that option. Once #836 is resolved, this should no longer be an issue. It is also important to be aware that some editor plugins (notably tslint for vscode) do not show rules which require type information.

I have added a `npm run lint` task which will run tslint directly and show lint errors from tslint rules which require type information and configured Travis to run this task when building.