### PR TITLE
Add localization plugin to Readme.md plugin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ There is a plugin available to run TypeDoc with Grunt created by Bart van der Sc
 * [Sourcefile URL](https://github.com/gdelmas/typedoc-plugin-sourcefile-url) - Set custom source file URL links
 * [Internal/External Module](https://github.com/christopherthielen/typedoc-plugin-internal-external) - Explicitly mark modules as `@internal` or `@external`
 * [Single Line Tags](https://github.com/christopherthielen/typedoc-plugin-single-line-tags) - Process certain `@tags` as single lines
+* [Localization](https://github.com/IgniteUI/typedoc-plugin-localization) - Generate documentation for different languages
 
 ## Advanced guides and docs
 

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -182,6 +182,7 @@ $ typedoc</code></pre>
 					<li><a href="https://github.com/gdelmas/typedoc-plugin-sourcefile-url">Sourcefile URL</a> - Set custom source file URL links</li>
 					<li><a href="https://github.com/christopherthielen/typedoc-plugin-internal-external">Internal/External Module</a> - Explicitly mark modules as <code>@internal</code> or <code>@external</code></li>
 					<li><a href="https://github.com/christopherthielen/typedoc-plugin-single-line-tags">Single Line Tags</a> - Process certain <code>@tags</code> as single lines</li>
+					<li><a href="https://github.com/IgniteUI/typedoc-plugin-localization">Localization</a> - Generate documentation for different languages</li>
 				</ul>
 				<h2 id="advanced-guides-and-docs">Advanced guides and docs</h2>
 				<p>Visit our homepage for advanced guides and an extensive API documentation:<br>


### PR DESCRIPTION
Adding localization plugin in the plugin section. 

This plugin will ease every user, to:
1. Generate a json files with all code comments based on the project structure
2. Edit the json with the translation on the desired language
3. Re-generate the typodoc documentation with the updated jason for the new language