### PR TITLE
Upgrade typescript to v3.1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3457,9 +3457,9 @@
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
+      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "progress": "^2.0.0",
     "shelljs": "^0.8.2",
     "typedoc-default-themes": "^0.5.0",
-    "typescript": "3.0.x"
+    "typescript": "3.1.x"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.4",


### PR DESCRIPTION
This pull request updates the TypeScript dependency to the latest stable v3.1.x version (currently v3.1.1).