### PR TITLE
Added declarationMap to list of ignored tsconfig options.

### DIFF
--- a/src/lib/utils/options/sources/typescript.ts
+++ b/src/lib/utils/options/sources/typescript.ts
@@ -14,7 +14,7 @@ export class TypeScriptSource extends OptionsComponent {
      */
     static IGNORED: string[] = [
         'out', 'version', 'help',
-        'watch', 'declaration', 'declarationDir', 'mapRoot',
+        'watch', 'declaration', 'declarationDir', 'declarationMap', 'mapRoot',
         'sourceMap', 'inlineSources', 'removeComments'
     ];
 


### PR DESCRIPTION
Otherwise, setting declarationMap causes an error "declarationMap requires declaration to be set".

Fixes #844

Didn't see any framework to test tsconfigs...