### PR TITLE
Fix gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Disable core.autocrlf's line ending conversion behavior to prevent test failures on Windows
-* text=lf
+* text=auto eol=lf


### PR DESCRIPTION
text=lf isn't a valid combination and I was getting lf/crlf errors on windows.