### PR TITLE
Adds helper that removes double-quotes from string

### DIFF
--- a/src/lib/output/helpers/remove-quotes.ts
+++ b/src/lib/output/helpers/remove-quotes.ts
@@ -1,0 +1,11 @@
+/**
+ * Removes any double-quotes from the input string
+ *
+ * @param str  The string that should be updated.
+ * @return     The original string, omitting double quotes (`"`).
+ */
+export function removeQuotes(options: any): string {
+    let str = typeof options === 'string' ? options : options.fn(this);
+    str = str.replace(/"/g, '');
+    return str;
+}


### PR DESCRIPTION
In my Typedoc generation, the modules are shown in quotes
This introduces a helper that will remove quotes in my theme