### PR TITLE
Fix missing reflection flags in JSON output

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,17 +4,17 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "identifier": "build",
-      "type": "grunt",
-      "task": "default",
+      "label": "build",
+      "type": "shell",
+      "command": "npm run grunt -- default",
       "problemMatcher": [
         "$tsc"
       ]
     },
     {
-      "identifier": "build_and_test",
-      "type": "grunt",
-      "task": "build_and_test",
+      "label": "build_and_test",
+      "type": "shell",
+      "command": "npm run grunt -- build_and_test",
       "problemMatcher": [
         "$tsc"
       ]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Build Status](https://travis-ci.org/TypeStrong/typedoc.svg?branch=master)](https://travis-ci.org/TypeStrong/typedoc)
 [![NPM Version](https://badge.fury.io/js/typedoc.svg)](http://badge.fury.io/js/typedoc)
 [![Chat on Gitter](https://badges.gitter.im/TypeStrong/typedoc.svg)](https://gitter.im/TypeStrong/typedoc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Greenkeeper Enabled](https://badges.greenkeeper.io/TypeStrong/typedoc.svg)](https://greenkeeper.io/)
 
 ## Installation
 

--- a/src/lib/serialization/serializers/reflections/abstract.ts
+++ b/src/lib/serialization/serializers/reflections/abstract.ts
@@ -3,6 +3,7 @@ import { Reflection, TraverseProperty } from '../../../models';
 
 import { ReflectionSerializerComponent } from '../../components';
 import { DecoratorWrapper } from '../models';
+import { ReflectionFlags } from '../../../models/reflections/abstract';
 
 @Component({name: 'serializer:reflection'})
 export class ReflectionSerializer extends ReflectionSerializerComponent<Reflection> {
@@ -32,12 +33,8 @@ export class ReflectionSerializer extends ReflectionSerializerComponent<Reflecti
       obj.comment = this.owner.toObject(reflection.comment);
     }
 
-    for (let key in reflection.flags) {
-      // tslint:disable-next-line:triple-equals
-      if (parseInt(key, 10) == <any> key || key === 'flags') {
-        continue;
-      }
-      if (reflection.flags[key]) {
+    for (const key of Object.getOwnPropertyNames(ReflectionFlags.prototype)) {
+      if (reflection.flags[key] === true) {
         obj.flags[key] = true;
       }
     }


### PR DESCRIPTION
Fixes #888 

Also updates the tasks.json file to fix deprecation warnings in latest VSCode (identifier property -> label property). The grunt task type was failing to discover the tasks for some reason, which made debugging fail, so I switched to the shell type.

This commit should really just include f807868, not the merge commit or the GreenKeeper commit, I'm not quite sure why they were included since they provide no additional changes.