### PR TITLE
Remove reflection perf

### DIFF
--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -222,9 +222,6 @@ export class CommentPlugin extends ConverterComponent {
 
         if (this.hidden) {
             const project = context.project;
-            // this.hidden.forEach((reflection) => {
-            //     CommentPlugin.removeReflection(project, reflection);
-            // });
             CommentPlugin.removeReflections(project, this.hidden);
         }
     }
@@ -341,7 +338,6 @@ export class CommentPlugin extends ConverterComponent {
         reflection.traverse((child) => CommentPlugin.removeReflection(project, child, deletedIds));
 
         const parent = <DeclarationReflection> reflection.parent;
-
         parent.traverse((child: Reflection, property: TraverseProperty) => {
             if (child === reflection) {
                 switch (property) {

--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -222,9 +222,10 @@ export class CommentPlugin extends ConverterComponent {
 
         if (this.hidden) {
             const project = context.project;
-            this.hidden.forEach((reflection) => {
-                CommentPlugin.removeReflection(project, reflection);
-            });
+            // this.hidden.forEach((reflection) => {
+            //     CommentPlugin.removeReflection(project, reflection);
+            // });
+            CommentPlugin.removeReflections(project, this.hidden);
         }
     }
 
@@ -315,12 +316,32 @@ export class CommentPlugin extends ConverterComponent {
     }
 
     /**
+     * Remove the specified reflections from the project.
+     */
+    static removeReflections(project: ProjectReflection, reflections: Reflection[]) {
+        const deletedIds = new Array<number>();
+        reflections.forEach((reflection) => {
+            CommentPlugin.removeReflection(project, reflection, deletedIds);
+        });
+
+        for (let key in project.symbolMapping) {
+            if (project.symbolMapping.hasOwnProperty(key) && deletedIds.indexOf(project.symbolMapping[key]) !== -1) {
+                delete project.symbolMapping[key];
+            }
+        }
+    }
+
+    /**
      * Remove the given reflection from the project.
      */
-    static removeReflection(project: ProjectReflection, reflection: Reflection) {
-        reflection.traverse((child) => CommentPlugin.removeReflection(project, child));
+    private static removeReflection(project: ProjectReflection, reflection: Reflection, deletedIds: number[]) {
+        // keep track of the reflections that have been deleted
+        deletedIds.push(reflection.id);
+
+        reflection.traverse((child) => CommentPlugin.removeReflection(project, child, deletedIds));
 
         const parent = <DeclarationReflection> reflection.parent;
+
         parent.traverse((child: Reflection, property: TraverseProperty) => {
             if (child === reflection) {
                 switch (property) {
@@ -374,11 +395,5 @@ export class CommentPlugin extends ConverterComponent {
 
         let id = reflection.id;
         delete project.reflections[id];
-
-        for (let key in project.symbolMapping) {
-            if (project.symbolMapping.hasOwnProperty(key) && project.symbolMapping[key] === id) {
-                delete project.symbolMapping[key];
-            }
-        }
     }
 }

--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -316,7 +316,7 @@ export class CommentPlugin extends ConverterComponent {
      * Remove the specified reflections from the project.
      */
     static removeReflections(project: ProjectReflection, reflections: Reflection[]) {
-        const deletedIds = new Array<number>();
+        const deletedIds: number[] = [];
         reflections.forEach((reflection) => {
             CommentPlugin.removeReflection(project, reflection, deletedIds);
         });
@@ -332,9 +332,6 @@ export class CommentPlugin extends ConverterComponent {
      * Remove the given reflection from the project.
      */
     private static removeReflection(project: ProjectReflection, reflection: Reflection, deletedIds: number[]) {
-        // keep track of the reflections that have been deleted
-        deletedIds.push(reflection.id);
-
         reflection.traverse((child) => CommentPlugin.removeReflection(project, child, deletedIds));
 
         const parent = <DeclarationReflection> reflection.parent;
@@ -391,5 +388,8 @@ export class CommentPlugin extends ConverterComponent {
 
         let id = reflection.id;
         delete project.reflections[id];
+
+        // keep track of the reflections that have been deleted
+        deletedIds.push(id);
     }
 }


### PR DESCRIPTION
There's a performance bug in the removeReflection because the symbolMapping is enumerated for each call. I have a large library where there are many types and members marked as @hidden. The CommentsPlugIn stores those in the hidden array and then later invokes the removeReflection for each. Each time the method is invoked it iterates the entire symbolMapping of the project which in my case started with around 90k items. So there were about 35k hidden items which including descendants resulted in about 300k calls to removeReflection. 

This change breaks that up so that it invokes the removeReflection for each hidden item as it did except it does not touch the symbolMapping. It just tracks the id's of the items processed. Then after all the hidden items have been processed, it can just enumerate that once and use the id's of the hidden reflections and their descendants to determine which need to be deleted.