### PR TITLE
Avoid documenting excluded files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/src/test/module/a.ts
+++ b/src/test/module/a.ts
@@ -1,0 +1,5 @@
+import { multiply } from './b';
+
+export function add(a: number, b: number) {
+    return a + multiply(b, 1);
+}

--- a/src/test/module/b.ts
+++ b/src/test/module/b.ts
@@ -1,0 +1,3 @@
+export function multiply(a: number, b: number) {
+    return a * b;
+}

--- a/src/test/typedoc.ts
+++ b/src/test/typedoc.ts
@@ -2,12 +2,13 @@ import { Application } from '..';
 import * as Path from 'path';
 import Assert = require('assert');
 import './.dot';
+import { Converter, Context } from '../lib/converter';
 
 describe('TypeDoc', function() {
     let application: Application;
 
     describe('Application', function() {
-        it('constructs', function() {
+        before('constructs', function() {
             application = new Application();
         });
         it('expands input directory', function() {
@@ -63,6 +64,18 @@ describe('TypeDoc', function() {
 
             Assert.equal(expanded.indexOf(Path.join(inputFiles, '.dot', 'index.d.ts')), -1);
             Assert.equal(expanded.indexOf(inputFiles), -1);
+        });
+        it('Honors the exclude option even if a module is imported', () => {
+            application.options.setValue('exclude', '**/b.d.ts');
+
+            function handler(context: Context) {
+                Assert.deepStrictEqual(context.fileNames, [
+                    Path.resolve(__dirname, 'module', 'a.d.ts').replace(/\\/g, '/')
+                ]);
+            }
+            application.converter.on(Converter.EVENT_END, handler);
+            application.convert([ Path.join(__dirname, 'module', 'a.d.ts')]);
+            application.converter.off(Converter.EVENT_END, handler);
         });
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
       "es5",
       "es2015.core",
       "es2015.collection",
-      "es2015.iterable"
+      "es2015.iterable",
+      "es2016.array.include" // Supported by Node 6+
     ],
     "target": "es2015",
     "noImplicitAny": false,


### PR DESCRIPTION
This is an attempt at correcting how the exclude option works. I'd like to get some feedback from people running into this problem before merging these changes in.

I previously [raised](https://github.com/TypeStrong/typedoc/issues/319#issuecomment-435104571) some concerns about how a change like this would affect errors/output, so here's how I decided to handle each concern:

1. If TypeScript reports that a diagnostic message is not linked to a source file, it is still logged as an error.
1. If TypeScript reports that a diagnostic message is linked to a source file returned by [Application.expandInputFiles](https://github.com/TypeStrong/typedoc/blob/master/src/lib/application.ts#L249) it is still logged as an error.
1. Otherwise, the error will be suppressed since it belongs to a file which was not originally included by the user.

I ran the project on the TypeDoc repo with the utils folder excluded and noted that classes defined in the utils folder were not present in the JSON output. In the HTML output, their name will be printed as plain text (much like `Promise`) if they are referred. I also introduced errors both in the utils folder and outside of the utils folder and noted that only errors outside of the utils folder were reported. Errors in the utils folder did not prevent output.

Fixes #319 
Fixes #839