### PR TITLE
Enable rendering of tables in Markdown

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -26,3 +26,11 @@ $ examples --out path/to/documentation/ path/to/example/project/
 
 * `--example <project>`<br>
   Example explanation.
+
+### List
+
+| Tables | Are | Cool |
+|----------|:-------------:|------:|
+| col 1 is | left-aligned | $1600 |
+| col 2 is | centered | $12 |
+| col 3 is | right-aligned | $1 |

--- a/src/lib/output/plugins/MarkedPlugin.ts
+++ b/src/lib/output/plugins/MarkedPlugin.ts
@@ -87,6 +87,8 @@ export class MarkedPlugin extends ContextAwareRendererComponent {
         Handlebars.registerHelper('relativeURL', (url: string) => url ? this.getRelativeUrl(url) : url);
 
         Marked.setOptions({
+            gfm: true,
+            tables: true,
             highlight: (text: any, lang: any) => this.getHighlighted(text, lang)
         });
     }

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -81,6 +81,31 @@
 					<li><code>--example &lt;project&gt;</code><br>
 					Example explanation.</li>
 				</ul>
+				<h3 id="list">List</h3>
+				<table>
+					<thead>
+						<tr>
+							<th>Tables</th>
+							<th align="center">Are</th>
+							<th align="right">Cool</th>
+						</tr>
+					</thead>
+					<tbody><tr>
+							<td>col 1 is</td>
+							<td align="center">left-aligned</td>
+							<td align="right">$1600</td>
+						</tr>
+						<tr>
+							<td>col 2 is</td>
+							<td align="center">centered</td>
+							<td align="right">$12</td>
+						</tr>
+						<tr>
+							<td>col 3 is</td>
+							<td align="center">right-aligned</td>
+							<td align="right">$1</td>
+						</tr>
+				</tbody></table>
 			</div>
 		</div>
 		<div class="col-4 col-menu menu-sticky-wrap menu-highlight">


### PR DESCRIPTION
(Closes #899)

This enables rendering of tables in Markdown files (e.g. README.md files) in the resulting documentation.

Note: tables aren't part of the standard Markdown specifications, but are an extension of the Github Flavored Markdown. In order to enable [rendering of tables in Marked.js](https://marked.js.org/#/USING_ADVANCED.md#options), I also had to enable GFM support. While all tests for typedoc succeeded, this change _might_ break some Markdown currently in use.