### PR TITLE
Store repository lookup path as lower case

### DIFF
--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -201,18 +201,20 @@ export class GitHubPlugin extends ConverterComponent {
 
         // Check for known repositories
         for (let path in this.repositories) {
-            if (!this.repositories.hasOwnProperty(path)) {
+            const lookupPath = path.toLowerCase();
+
+            if (!this.repositories.hasOwnProperty(lookupPath)) {
                 continue;
             }
-            if (fileName.substr(0, path.length) === path) {
-                return this.repositories[path];
+            if (fileName.substr(0, path.length).toLowerCase() === lookupPath) {
+                return this.repositories[lookupPath];
             }
         }
 
         // Try to create a new repository
         const repository = Repository.tryCreateRepository(dirName, this.gitRevision);
         if (repository) {
-            this.repositories[repository.path] = repository;
+            this.repositories[repository.path.toLowerCase()] = repository;
             return repository;
         }
 

--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -201,13 +201,11 @@ export class GitHubPlugin extends ConverterComponent {
 
         // Check for known repositories
         for (let path in this.repositories) {
-            const lookupPath = path.toLowerCase();
-
-            if (!this.repositories.hasOwnProperty(lookupPath)) {
+            if (!this.repositories.hasOwnProperty(path)) {
                 continue;
             }
-            if (fileName.substr(0, path.length).toLowerCase() === lookupPath) {
-                return this.repositories[lookupPath];
+            if (fileName.substr(0, path.length).toLowerCase() === path) {
+                return this.repositories[path];
             }
         }
 


### PR DESCRIPTION
As discussed here:

https://stackoverflow.com/questions/53396610/why-does-git-rev-parse-show-toplevel-return-different-casing-than-actual-path

the casing of paths on windows cannot be guaranteed. If a differently cased is returned from `git rev-parse --show-toplevel` than is reported as the first part of the filename's path then for every single file a new repository will be created and a new call to the git command line will be made - taking approximately 2 seconds per file. This makes it appear like typedoc has crashed (in my example I had over 1000 files).