### PR TITLE
Adds developer / contributor documentation explaining typedoc architecture

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,15 @@
+# Developer & Contributor documentation
+
+This directory contains documentation for plugin authors and contributors to the typedoc codebase.
+
+It explains typedoc's internal architecture.
+
+It's a work-in-progress.  I'm pulling wisdom and docs from various sources, linking to the original source and author.
+
+## Misc
+
+*Notes that don't have a home elsewhere*
+
+https://github.com/TypeStrong/typedoc/issues/595#issuecomment-445489632
+
+> The event system allows plugins to react to different events (see src/lib/converter/plugins). A lot of the component hierarchy is to allow instanceof checks. ComponentHost is just an interface saying that the component has access to the application instance. AbstractComponent sets up some basic event dispatching and initializing semantics. ChildableComponent is the base for creating wrapper components that can have components added to it and is used for TypeDoc's major components like the converter and renderer. Some of the base component classes are defined in src/lib/utils/component.ts and src/lib/converter/components.ts.

--- a/docs/developer/components.md
+++ b/docs/developer/components.md
@@ -1,0 +1,146 @@
+*Copied from https://gist.github.com/mootari/d39895574c8deacc57d0fc04eb0d21ca*
+*Original author: https://github.com/mootari*
+
+# Components
+
+## Instantiation
+
+Components that extend from ChildableComponent may specify a childClass. Any included/required component extending from that class will automatically be added to the parent component's _defaultComponents and instantiated along with its parent. This behavior is provided by the Component decorator.
+
+
+## Converter Components
+
+All default converter components extend from ConverterComponent. When the `converter` component is instantiated any converter component that has been required at this point will be added to it.
+
+### Node Converters
+
+A node converter receives a TypeScript Declaration and returns a TypeDoc Reflection model. Node converter components extend from ConverterNodeComponent.
+
+Components:
+- `node:accessor` (AccessorConverter)
+- `node:alias` (AliasConverter)
+- `node:block` (BlockConverter)
+- `node:class` (ClassConverter)
+- `node:constructor` (ConstructorConverter)
+- `node:enum` (EnumConverter)
+- `node:export` (ExportConverter)
+- `node:function` (FunctionConverter)
+- `node:interface` (InterfaceConverter)
+- `node:literal-object` (ObjectLiteralConverter)
+- `node:literal-type` (TypeLiteralConverter)
+- `node:module` (ModuleConverter)
+- `node:signature-call` (SignatureConverter)
+- `node:signature-index` (IndexSignatureConverter)
+- `node:variable-statement` (VariableStatementConverter)
+- `node:variable` (VariableConverter)
+
+### Type Converters
+
+A type converter receives a TypeScript Type and returns a TypeDoc Type model. Type converter components extend from ConverterTypeComponent.
+
+Components:
+- `type:alias` (AliasConverter)
+- `type:array` (ArrayConverter)
+- `type:binding-array` (BindingArrayConverter)
+- `type:binding-object` (BindingObjectConverter)
+- `type:enum` (EnumConverter)
+- `type:intrinsic` (IntrinsicConverter)
+- `type:reference` (ReferenceConverter)
+- `type:string-literal` (StringLiteralConverter)
+- `type:this` (ThisConverter)
+- `type:tuple` (TupleConverter)
+- `type:type-operator` (TypeOperatorConverter)
+- `type:type-parameter` (TypeParameterConverter)
+- `type:union-or-intersection` (UnionOrIntersectionConverter)
+- `type:unknown` (UnknownConverter)
+
+### Converter Plugins
+
+Converter plugins perform various specialized tasks.
+
+Components:
+- `category` (CategoryPlugin):
+  Sorts and categorizes the found reflections in the resolving phase, sets the ´category´ property of all reflections.
+- `comment` (CommentPlugin):
+  Parses javadoc comments and attaches Comment model instances to the generated reflections.
+- `decorator` (DecoratorPlugin):
+  Detects decorators.
+- `deep-comment` (DeepCommentPlugin):
+  Moves comments with dot syntax to their target.
+- `dynamic-module` (DynamicModulePlugin):
+  Truncates the names of dynamic modules to not include the project's base path.
+- `git-hub` (GitHubPlugin):
+  Watches for repositories with GitHub origin and links their source files to the related GitHub pages.
+- `group` (GroupPlugin):
+  Sorts and groups the found reflections in the resolving phase, sets the ´groups´ property of all reflections.
+- `implements` (ImplementsPlugin):
+  Detects interface implementations of functions and properties on classes and links them.
+- `package` (PackagePlugin):
+  Tries to find the package.json and readme.md files of the current project by traversing the file tree upwards, appends the contents to the ProjectReflection.
+- `source` (SourcePlugin):
+  Attaches source file information to reflections.
+- `type` (TypePlugin):
+  Converts all instances of LateResolvingType to their renderable equivalents.
+
+
+## Renderer Components
+
+All default renderer components extend from RendererComponent. When the `renderer` component is instantiated any renderer component that has been required at this point will be added to it.
+
+Components:
+- `assets` (AssetsPlugin):
+  Copies the subdirectory ´assets´ from the current themes source folder to the output directory.
+- `javascript-index` (JavascriptIndexPlugin):
+  Exports an index of the project to a javascript file that can be used to build a simple search function.
+- `layout` (LayoutPlugin):
+  Wraps the generated output with the default layout template.
+- `marked-links` (MarkedLinksPlugin):
+  Builds links in markdown texts.
+- `marked` (MarkedPlugin):
+  Exposes the markdown, compact and relativeURL helper to handlebars.
+- `navigation` (NavigationPlugin):
+  Exposes the navigation structure of the documentation to the rendered templates.
+- `pretty-print` (PrettyPrintPlugin):
+  Reformats the generated HTML, reducing the output size by about a third.
+- `toc` (TocPlugin):
+  Generates a table of contents for the current page (starting at the nearest module) and stores it in the PageEvent.
+
+
+## Serializers
+
+Serializers receive various types of data and return a JSON object.
+
+Components:
+- `serializer:comment-tag` (CommentTagSerializer)
+- `serializer:comment` (CommentSerializer)
+- `serializer:decorator-container` (DecoratorContainerSerializer)
+- `serializer:reflection-group` (ReflectionGroupSerializer)
+- `serializer:reflection` (ReflectionSerializer)
+- `serializer:container-reflection` (ContainerReflectionSerializer)
+- `serializer:declaration-reflection` (DeclarationReflectionSerializer)
+- `serializer:parameter-reflection` (ParameterReflectionSerializer)
+- `serializer:project-reflection` (ProjectReflectionSerializer)
+- `serializer:signature-reflection` (SignatureReflectionSerializer)
+- `serializer:type-parameter-reflection` (TypeParameterReflectionSerializer)
+- `serializer:source-reference-container` (SourceReferenceContainerSerializer)
+- `serializer:type` (TypeSerializer)
+- `serializer:array-type` (ArrayTypeSerializer)
+- `serializer:intersection-type` (IntersectionTypeSerializer)
+- `serializer:intrinsic-type` (IntrinsicTypeSerializer)
+- `serializer:reference-type` (ReferenceTypeSerializer)
+- `serializer:reflection-type` (ReflectionTypeSerializer)
+- `serializer:string-literal-type` (StringLiteralTypeSerializer)
+- `serializer:tuple-type` (TupleTypeSerializer)
+- `serializer:type-operator-type` (TypeOperatorTypeSerializer)
+- `serializer:type-parameter-type` (TypeParameterTypeSerializer)
+- `serializer:unknown-type` (UnknownTypeSerializer)
+
+
+## Option Readers
+
+Components:
+- `options:tsconfig` (TSConfigReader)
+- `options:arguments` (ArgumentsReader)
+- `options:typedoc` (TypedocReader)
+- `options:component` (ComponentSource)
+- `options:typescript` (TypeScriptSource)

--- a/docs/developer/events.md
+++ b/docs/developer/events.md
@@ -1,0 +1,70 @@
+*Copied from https://gist.github.com/mootari/d39895574c8deacc57d0fc04eb0d21ca*
+*Original author: https://github.com/mootari*
+
+# Events
+
+## Components
+
+- `ComponentEvent.ADDED (event: ComponentEvent)`
+- `ComponentEvent.REMOVED(event: ComponentEvent)`
+
+## Options
+
+- `DiscoverEvent.DISCOVER (event: DiscoverEvent)`
+
+## Conversion
+
+### General Events
+
+- `Converter.EVENT_BEGIN (context: Context)`:
+  Triggered when the converter begins converting a project.
+- `Converter.EVENT_END (context: Context)`:
+  Triggered when the converter has finished converting a project.
+
+### Factory Events
+
+- `Converter.EVENT_FILE_BEGIN (context: Context, project: ProjectReflection, node: TypeScript.SourceFile)`:
+  Triggered when the converter begins converting a source file.
+- `Converter.EVENT_CREATE_DECLARATION (context: Context, declaration: DeclarationReflection, node?: TypeScript.TypeReferenceNode)`:
+  Triggered when the converter has created a declaration reflection.
+- `Converter.EVENT_CREATE_SIGNATURE (context: Context, signature: SignatureReflection, node: TypeScript.SignatureDeclaration)`:
+  Triggered when the converter has created a signature reflection.
+- `Converter.EVENT_CREATE_PARAMETER (context: Context, parameter: ParameterReflection, node: TypeScript.ParameterDeclaration)`:
+  Triggered when the converter has created a parameter reflection.
+- `Converter.EVENT_CREATE_TYPE_PARAMETER (context: Context, typeParameter: TypeParameterReflection, node: TypeScript.TypeParameterDeclaration)`:
+  Triggered when the converter has created a type parameter reflection.
+- `Converter.EVENT_FUNCTION_IMPLEMENTATION (context: Context, method: DeclarationReflection, node: TypeScript.Node | TypeScript.FunctionDeclaration | TypeScript.MethodDeclaration)`:
+  Triggered when the converter has found a function implementation.
+
+### Resolve Events
+
+- `Converter.EVENT_RESOLVE_BEGIN (context: Context)`:
+  Triggered when the converter begins resolving a project.
+- `Converter.EVENT_RESOLVE (context: Context, reflection: Reflection)`:
+  Triggered when the converter resolves a reflection.
+- `Converter.EVENT_RESOLVE_END (context: Context)`:
+  Triggered when the converter has finished resolving a project.
+
+## Output
+
+### Rendering
+
+While a project is being processed Renderer triggers a series of events. These can be listened to in order to control the flow or manipulate the output.
+
+- `RendererEvent.BEGIN (event: RenderEvent)`:
+  Triggered before the renderer starts rendering a project. By calling event.preventDefault the entire render process can be canceled.
+- `PageEvent.BEGIN (page: PageEvent)`:
+  Triggered before a document will be rendered.
+- `PageEvent.END (page: PageEvent)`:
+  Triggered after a document has been rendered, just before it is written to disc.
+- `RendererEvent.END (event: RenderEvent)`:
+  Triggered after the renderer has written all documents.
+
+### Plugins
+
+- `MarkdownEvent.PARSE (event: MarkdownEvent)`:
+  Triggered on the renderer when this plugin parses a markdown string.
+
+## Serialization
+
+Todo. See lib/serialization/serializer.ts

--- a/docs/developer/misc.md
+++ b/docs/developer/misc.md
@@ -1,0 +1,13 @@
+
+
+The event system allows plugins to react to different events (see src/lib/converter/plugins).
+
+A lot of the component hierarchy is to allow instanceof checks.
+
+ComponentHost is just an interface saying that the component has access to the application instance.
+
+AbstractComponent sets up some basic event dispatching and initializing semantics.
+
+ChildableComponent is the base for creating wrapper components that can have components added to it and is used for TypeDoc's major components like the converter and renderer.
+
+Some of the base component classes are defined in src/lib/utils/component.ts and src/lib/converter/components.ts.

--- a/docs/developer/options.md
+++ b/docs/developer/options.md
@@ -1,0 +1,53 @@
+*Copied from https://gist.github.com/mootari/d39895574c8deacc57d0fc04eb0d21ca*
+*Original author: https://github.com/mootari*
+
+# Component options
+
+Below is a list of all component classes (with their component names) that expose options.
+
+Application (`application`, internal):
+- `logger`
+- `ignoreCompilerErrors`
+- `exclude`
+
+Converter (`converter`, internal):
+- `name`
+- `externalPattern`
+- `includeDeclarations`
+- `excludeExternals`
+- `excludeNotExported`
+- `excludePrivate`
+
+BlockConverter (`node:block`):
+- `mode`
+
+GitHubPlugin (`git-hub`):
+- `gitRevision`
+
+PackagePlugin (`package`):
+- `readme`
+
+MarkedLinksPlugin (`marked-links`):
+- `listInvalidSymbolLinks`
+
+MarkedPlugin (`marked`):
+- `includes`
+- `media`
+
+Renderer (`renderer`, internal):
+- `theme`
+- `disableOutputCheck`
+- `gaID`
+- `gaSite`
+- `hideGenerator`
+- `entryPoint`
+- `toc`
+
+TSConfigReader (`options:tsconfig`):
+- `tsconfig`
+
+TypedocReader (`options:typedoc`):
+- `options`
+
+PluginHost (`plugin-host`, internal):
+- `plugin`


### PR DESCRIPTION
This PR adds some developer-facing documentation for typedoc contributors.  I figure it's better to have something in master than to require contributors to google around for github threads and gists.

@mootari I copied the gist you posted last year: https://github.com/TypeStrong/typedoc/issues/595#issuecomment-353752599  Is that ok?