### PR TITLE
Fix indentation rules in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+indent_size = 2


### PR DESCRIPTION
I notice that the .editorconfig specifies 2-space indents but should be specifying 4.