### PR TITLE
update typescript to 3.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "progress": "^2.0.0",
     "shelljs": "^0.8.2",
     "typedoc-default-themes": "^0.5.0",
-    "typescript": "3.1.x"
+    "typescript": "3.2.x"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.4",

--- a/src/test/converter/destructuring/specs.json
+++ b/src/test/converter/destructuring/specs.json
@@ -109,11 +109,8 @@
             }
           ],
           "type": {
-            "type": "array",
-            "elementType": {
-              "type": "intrinsic",
-              "name": "number"
-            }
+            "type": "intrinsic",
+            "name": "Object"
           }
         },
         {
@@ -130,11 +127,8 @@
             }
           ],
           "type": {
-            "type": "array",
-            "elementType": {
-              "type": "intrinsic",
-              "name": "number"
-            }
+            "type": "intrinsic",
+            "name": "Object"
           }
         },
         {

--- a/src/test/renderer/specs/modules/_typescript_1_5_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_5_.html
@@ -140,7 +140,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
 					<a name="destructarraywithignoresrest" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</h3>
-					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
+					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Object</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.5.ts#L20">typescript-1.5.ts:20</a></li>
@@ -150,7 +150,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
 					<a name="destructarraywithrest" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>Rest</h3>
-					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
+					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Object</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/typescript-1.5.ts#L15">typescript-1.5.ts:15</a></li>


### PR DESCRIPTION
The changes in destructuring handling are caused by this PR in Typescript: https://github.com/Microsoft/TypeScript/pull/27587

Rest parameters are defined by this code, so it now returns an object type with multiple type parameters (roughly as `Object<number, number>`), instead of `Array<number>` as it was before