### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,8 +4,8 @@ about: Tell about typedoc's bug
 ---
 <!--
     Thank you for contributing to Typedoc! 
-    We ask you to give a description for each part,
-    so that you may provide enough information.
+    
+    First, please use a clear and descriptive title for the issue to identify the bug.
 
     Please be as specific as possible! Provide codes, sreenshots, repositories, explanations, issues, links ... anything that could describe your point.
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Tell about typedoc's bug
+---
+<!--
+    Thank you for contributing to Typedoc! 
+    We ask you to give a description for each part,
+    so that you may provide enough information.
+
+    Please be as specific as possible! Provide codes, sreenshots, repositories, explanations, issues, links ... anything that could describe your point.
+-->
+
+## Expected Behavior
+<!--
+    According to the code or documentation, how is Typedoc supposed to work?
+-->
+
+## Actual Behavior
+<!--
+    What does Typedoc fail to do?  
+-->
+
+## Steps to reproduce the bug
+<!--
+    Tell us how we could reproduce the bug. 
+-->
+
+## Specifications
+  - Typedoc version:
+  - Node.js version:
+  - OS:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,8 @@ about: Tell about typedoc's bug
     Please be as specific as possible! Provide codes, sreenshots, repositories, explanations, issues, links ... anything that could describe your point.
 -->
 
+- [ ] I have checked [issues with bug label](https://github.com/TypeStrong/typedoc/labels/bug) and found no duplicates
+
 ## Expected Behavior
 <!--
     According to the code or documentation, how is Typedoc supposed to work?

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -4,9 +4,9 @@ about: Suggest an improvement or a feature
 ---
 <!--
     Thank you for contributing to Typedoc! 
-    We ask you to give a description for each part,
-    so that you may provide enough information.
-
+    
+    First, please use a clear and descriptive title for the issue to identify the suggestion.
+    
     Please be as specific as possible! Provide codes, sreenshots, repositories, explanations, issues, links ... anything that could describe your point.
 -->
 

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -10,6 +10,8 @@ about: Suggest an improvement or a feature
     Please be as specific as possible! Provide codes, sreenshots, repositories, explanations, issues, links ... anything that could describe your point.
 -->
 
+- [ ] I have checked [issues with enhancement label](https://github.com/TypeStrong/typedoc/labels/enhancement) and found no duplicates
+
 ## Problem
 <!--
     What is making you feel inconvenient without this improvement or feature?

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,0 +1,21 @@
+---
+name: Suggestion
+about: Suggest an improvement or a feature
+---
+<!--
+    Thank you for contributing to Typedoc! 
+    We ask you to give a description for each part,
+    so that you may provide enough information.
+
+    Please be as specific as possible! Provide codes, sreenshots, repositories, explanations, issues, links ... anything that could describe your point.
+-->
+
+## Problem
+<!--
+    What is making you feel inconvenient without this improvement or feature?
+-->
+
+## Suggestion
+<!--
+    What do you suggest to fix the problem?
+-->


### PR DESCRIPTION
## Rationale
Currently, Typedoc does not have issue templates, so I have raised an issue on that (#928)
Many people are graciously giving contributions, but sometimes it's hard to understand their intentions or their problems. Therefore it seems that it's a better approach to make an issue template.

## Templates
* Typedoc's issues can largely be divided into two: bug reports (i.e. #893, #901, #904, ...) and suggestions (i.e. #898, #895, #902, ...). That's the reason I made separate templates for each.
* I believe these templates are fully in line with what @Gerrit0 is saying in [`CONTRIBUTING.md`](https://github.com/TypeStrong/typedoc/blob/master/CONTRIBUTING.md).

## Goal
I tried to lead contributors to the right direction but did not want to annoy them with a bunch of lines of comments. Plus, as @aciccarello said, I wanted to keep it as simple as possible for the risk of submissions of issues with almost no information hidden under an already-well-written template of length.