### PR TITLE
Category improvements

### DIFF
--- a/src/lib/models/ReflectionGroup.ts
+++ b/src/lib/models/ReflectionGroup.ts
@@ -1,4 +1,5 @@
 import { Reflection, ReflectionKind } from './reflections/abstract';
+import { ReflectionCategory } from './ReflectionCategory';
 
 /**
  * A group of reflections. All reflections in a group are of the same kind.
@@ -63,6 +64,11 @@ export class ReflectionGroup {
     someChildrenAreExported?: boolean;
 
     /**
+     * Categories contained within this group.
+     */
+    categories?: ReflectionCategory[];
+
+    /**
      * Create a new ReflectionGroup instance.
      *
      * @param title The title of this group.
@@ -104,6 +110,15 @@ export class ReflectionGroup {
             });
 
             result['children'] = children;
+        }
+
+        if (this.categories) {
+            const categories: any[] = [];
+            this.categories.forEach((category) => {
+                categories.push(category.toObject());
+            });
+
+            result['categories'] = categories;
         }
 
         return result;

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -1,7 +1,6 @@
 import { SourceFile, SourceDirectory } from '../sources/index';
 import { Reflection, ReflectionKind } from './abstract';
 import { ContainerReflection } from './container';
-import { ReflectionCategory } from '../ReflectionCategory';
 
 /**
  * A reflection that represents the root of the project.
@@ -26,11 +25,6 @@ export class ProjectReflection extends ContainerReflection {
      * A list of all source files within the project.
      */
     files: SourceFile[] = [];
-
-    /**
-     * All reflections categorized.
-     */
-    categories?: ReflectionCategory[];
 
     /**
      * The name of the project.
@@ -122,26 +116,5 @@ export class ProjectReflection extends ContainerReflection {
         }
 
         return undefined;
-    }
-
-    /**
-     * Return a raw object representation of this reflection.
-     * @deprecated Use serializers instead
-     */
-    toObject(): any {
-        const result = super.toObject();
-
-        if (this.categories) {
-            const categories: any[] = [];
-            this.categories.forEach((category) => {
-                categories.push(category.toObject());
-            });
-
-            if (categories.length > 0) {
-                result['categories'] = categories;
-            }
-        }
-
-        return result;
     }
 }

--- a/src/lib/models/sources/directory.ts
+++ b/src/lib/models/sources/directory.ts
@@ -1,5 +1,4 @@
 import { Reflection } from '../reflections/abstract';
-import { ReflectionCategory } from '../ReflectionCategory';
 import { ReflectionGroup } from '../ReflectionGroup';
 import { SourceFile } from './file';
 
@@ -22,8 +21,6 @@ export class SourceDirectory {
     directories: {[name: string]: SourceDirectory} = {};
 
     groups?: ReflectionGroup[];
-
-    categories?: ReflectionCategory[];
 
     /**
      * A list of all files in this directory.

--- a/src/lib/models/sources/file.ts
+++ b/src/lib/models/sources/file.ts
@@ -1,7 +1,6 @@
 import * as Path from 'path';
 
 import { Reflection } from '../reflections/abstract';
-import { ReflectionCategory } from '../ReflectionCategory';
 import { ReflectionGroup } from '../ReflectionGroup';
 import { SourceDirectory } from './directory';
 
@@ -80,11 +79,6 @@ export class SourceFile {
      * A grouped list of the reflections declared in this file.
      */
     groups?: ReflectionGroup[];
-
-    /**
-     * A categorized list of the reflections declared in this file.
-     */
-    categories?: ReflectionCategory[];
 
     /**
      * Create a new SourceFile instance.

--- a/src/lib/serialization/browser.ts
+++ b/src/lib/serialization/browser.ts
@@ -56,6 +56,10 @@ export interface GroupsContainer<T> {
   groups: T[];
 }
 
+export interface CategoriesContainer<T> {
+  categories: T[];
+}
+
 export interface ContainerReflectionContainer<TChildren> {
   children: TChildren[];
 }
@@ -147,6 +151,7 @@ export interface ParameterReflectionObject extends  ReflectionObject,
 export interface ContainerReflectionObject extends  ReflectionObject,
                                                     Partial<SourceReferenceContainer<SourceReferenceObject>>,
                                                     Partial<GroupsContainer<ReflectionGroupObject>>,
+                                                    Partial<CategoriesContainer<ReflectionCategoryObject>>,
                                                     ContainerReflectionContainer<ReflectionObject> {}
 
 export interface DeclarationReflectionObject extends  ContainerReflectionObject,
@@ -283,6 +288,23 @@ export interface ReflectionGroupObject {
 
   /**
    * A list of reflection id's for this group.
+   */
+  children?: number[];
+
+  /**
+   * A list of categories for this group.
+   */
+  categories?: ReflectionCategoryObject[];
+}
+
+export interface ReflectionCategoryObject {
+  /**
+   * The title, a string representation of the typescript kind, of this category.
+   */
+  title: string;
+
+  /**
+   * A list of reflection id's for this category.
    */
   children?: number[];
 }

--- a/src/lib/serialization/index.ts
+++ b/src/lib/serialization/index.ts
@@ -22,6 +22,7 @@ export {
   ParameterReflectionSerializer,
   ProjectReflectionSerializer,
   ReferenceTypeSerializer,
+  ReflectionCategorySerializer,
   ReflectionGroupSerializer,
   ReflectionSerializer,
   ReflectionTypeSerializer,

--- a/src/lib/serialization/serializers/index.ts
+++ b/src/lib/serialization/serializers/index.ts
@@ -4,4 +4,5 @@ export * from './comments';
 export * from './sources';
 export * from './decorator';
 export * from './reflection-group';
+export * from './reflection-category';
 export * from './models';

--- a/src/lib/serialization/serializers/reflection-category.ts
+++ b/src/lib/serialization/serializers/reflection-category.ts
@@ -1,0 +1,42 @@
+import { Component } from '../../utils/component';
+import { ReflectionCategory } from '../../models/ReflectionCategory';
+
+import { SerializerComponent } from '../components';
+
+@Component({name: 'serializer:reflection-category'})
+export class ReflectionCategorySerializer extends SerializerComponent<ReflectionCategory> {
+
+  static PRIORITY = 1000;
+
+  /**
+   * Filter for instances of [[ReflectionCategory]]
+   */
+  serializeGroup(instance: any): boolean {
+    return instance instanceof ReflectionCategory;
+  }
+
+  serializeGroupSymbol = ReflectionCategory;
+
+  initialize(): void {
+    super.initialize();
+  }
+
+  supports(r: unknown) {
+    return r instanceof ReflectionCategory;
+  }
+
+  toObject(category: ReflectionCategory, obj?: any): any {
+    obj = obj || {};
+
+    Object.assign(obj, {
+      title: category.title
+    });
+
+    if (category.children && category.children.length > 0) {
+      obj.children = category.children.map( child => child.id );
+    }
+
+    return obj;
+  }
+
+}

--- a/src/lib/serialization/serializers/reflection-group.ts
+++ b/src/lib/serialization/serializers/reflection-group.ts
@@ -37,6 +37,10 @@ export class ReflectionGroupSerializer extends SerializerComponent<ReflectionGro
       obj.children = group.children.map( child => child.id );
     }
 
+    if (group.categories && group.categories.length > 0) {
+      obj.categories = group.categories.map( category => this.owner.toObject(category) );
+    }
+
     return obj;
   }
 

--- a/src/lib/serialization/serializers/reflections/container.ts
+++ b/src/lib/serialization/serializers/reflections/container.ts
@@ -19,7 +19,7 @@ export class ContainerReflectionSerializer extends ReflectionSerializerComponent
     }
 
     if (container.categories && container.categories.length > 0) {
-      obj.categroies = container.categories.map( category => this.owner.toObject(category) );
+      obj.categories = container.categories.map( category => this.owner.toObject(category) );
     }
 
     if (container.sources && container.sources.length > 0) {

--- a/src/lib/serialization/serializers/reflections/container.ts
+++ b/src/lib/serialization/serializers/reflections/container.ts
@@ -18,6 +18,10 @@ export class ContainerReflectionSerializer extends ReflectionSerializerComponent
       obj.groups = container.groups.map( group => this.owner.toObject(group) );
     }
 
+    if (container.categories && container.categories.length > 0) {
+      obj.categroies = container.categories.map( category => this.owner.toObject(category) );
+    }
+
     if (container.sources && container.sources.length > 0) {
       obj.sources = container.sources
         .map( source => this.owner

--- a/src/test/converter/category/category.ts
+++ b/src/test/converter/category/category.ts
@@ -1,0 +1,115 @@
+/**
+ * TestClass comment short text.
+ *
+ * TestClass comment text.
+ *
+ * @see [[TestClass]] @ fixtures
+ * @category Test
+ */
+export class TestClass {
+
+    /**
+     * publicProperty short text.
+     * @category Test
+     */
+    public publicProperty: string;
+
+    /**
+     * privateProperty short text.
+     */
+    private privateProperty: number[];
+
+    /**
+     * privateProperty short text.
+     */
+    static staticProperty: TestClass;
+
+    /**
+     * Constructor short text.
+     */
+    constructor() { }
+
+    /**
+     * publicMethod short text.
+     * @category Test
+     */
+    public publicMethod() {}
+
+    /**
+     * protectedMethod short text.
+     * @category Test
+     */
+    protected protectedMethod() {}
+
+    /**
+     * privateMethod short text.
+     */
+    private privateMethod() {}
+
+    /**
+     * staticMethod short text.
+     */
+    static staticMethod() {}
+}
+
+export class TestSubClass extends TestClass {
+    /**
+     * publicMethod short text.
+     */
+    public publicMethod() {}
+
+    /**
+     * protectedMethod short text.
+     */
+    protected protectedMethod() {}
+
+    /**
+     * Constructor short text.
+     *
+     * @param p1 Constructor param
+     * @param p2 Private string property
+     * @param p3 Public number property
+     * @param p4 Public implicit any property
+     */
+    constructor(p1, private p2: string, public p3: number, public p4) {
+        super();
+    }
+}
+
+export abstract class TestAbstractClass {
+    abstract myAbstractProperty: string;
+
+    protected abstract myAbstractMethod(): void;
+}
+
+export class TestAbstractClassImplementation extends TestAbstractClass {
+    myAbstractProperty: string;
+
+    protected myAbstractMethod(): void { }
+}
+
+export interface TestSubClass {
+    /**
+     * mergedMethod short text.
+     */
+    mergedMethod();
+}
+
+export module TestSubClass {
+    /**
+     * staticMergedMethod short text.
+     */
+    export function staticMergedMethod() { }
+}
+
+/**
+ * This class will not appear when `excludeNotExported=true`
+ */
+abstract class NotExportedClass {
+    /**
+     * Adds two numbers
+     */
+    add(a: number, b: number) {
+        a + b;
+    }
+}

--- a/src/test/converter/category/specs.json
+++ b/src/test/converter/category/specs.json
@@ -1,0 +1,1231 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "flags": {},
+  "children": [
+    {
+      "id": 1,
+      "name": "\"category\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/category/category.ts",
+      "children": [
+        {
+          "id": 44,
+          "name": "NotExportedClass",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isAbstract": true
+          },
+          "comment": {
+            "shortText": "This class will not appear when `excludeNotExported=true`"
+          },
+          "children": [
+            {
+              "id": 45,
+              "name": "add",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {},
+              "signatures": [
+                {
+                  "id": 46,
+                  "name": "add",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Adds two numbers"
+                  },
+                  "parameters": [
+                    {
+                      "id": 47,
+                      "name": "a",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 48,
+                      "name": "b",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 112,
+                  "character": 7
+                }
+              ]
+            }
+          ],
+          "groups": [
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                45
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "category.ts",
+              "line": 108,
+              "character": 31
+            }
+          ]
+        },
+        {
+          "id": 34,
+          "name": "TestAbstractClass",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true,
+            "isAbstract": true
+          },
+          "children": [
+            {
+              "id": 35,
+              "name": "myAbstractProperty",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true,
+                "isAbstract": true
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 80,
+                  "character": 31
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              }
+            },
+            {
+              "id": 36,
+              "name": "myAbstractMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isProtected": true,
+                "isExported": true,
+                "isAbstract": true
+              },
+              "signatures": [
+                {
+                  "id": 37,
+                  "name": "myAbstractMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 82,
+                  "character": 39
+                }
+              ]
+            }
+          ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                35
+              ]
+            },
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                36
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "category.ts",
+              "line": 79,
+              "character": 39
+            }
+          ],
+          "extendedBy": [
+            {
+              "type": "reference",
+              "name": "TestAbstractClassImplementation",
+              "id": 38
+            }
+          ]
+        },
+        {
+          "id": 38,
+          "name": "TestAbstractClassImplementation",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "children": [
+            {
+              "id": 39,
+              "name": "myAbstractProperty",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 86,
+                  "character": 22
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              },
+              "overwrites": {
+                "type": "reference",
+                "name": "TestAbstractClass.myAbstractProperty",
+                "id": 35
+              }
+            },
+            {
+              "id": 40,
+              "name": "myAbstractMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isProtected": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 41,
+                  "name": "myAbstractMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "overwrites": {
+                    "type": "reference",
+                    "name": "TestAbstractClass.myAbstractMethod",
+                    "id": 36
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 88,
+                  "character": 30
+                }
+              ],
+              "overwrites": {
+                "type": "reference",
+                "name": "TestAbstractClass.myAbstractMethod",
+                "id": 36
+              }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                39
+              ]
+            },
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                40
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "category.ts",
+              "line": 85,
+              "character": 44
+            }
+          ],
+          "extendedTypes": [
+            {
+              "type": "reference",
+              "name": "TestAbstractClass",
+              "id": 34
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "name": "TestClass",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "TestClass comment short text.",
+            "text": "TestClass comment text.\n",
+            "tags": [
+              {
+                "tag": "see",
+                "text": "[[TestClass]] @ fixtures"
+              },
+              {
+                "tag": "category",
+                "text": "Test\n"
+              }
+            ]
+          },
+          "children": [
+            {
+              "id": 6,
+              "name": "constructor",
+              "kind": 512,
+              "kindString": "Constructor",
+              "flags": {
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "Constructor short text."
+              },
+              "signatures": [
+                {
+                  "id": 7,
+                  "name": "new TestClass",
+                  "kind": 16384,
+                  "kindString": "Constructor signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Constructor short text."
+                  },
+                  "type": {
+                    "type": "reference",
+                    "name": "TestClass",
+                    "id": 2
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 25,
+                  "character": 37
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "name": "privateProperty",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPrivate": true,
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "privateProperty short text."
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 20,
+                  "character": 27
+                }
+              ],
+              "type": {
+                "type": "array",
+                "elementType": {
+                  "type": "intrinsic",
+                  "name": "number"
+                }
+              }
+            },
+            {
+              "id": 3,
+              "name": "publicProperty",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPublic": true,
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "publicProperty short text.",
+                "tags": [
+                  {
+                    "tag": "category",
+                    "text": "Test\n"
+                  }
+                ]
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 15,
+                  "character": 25
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              }
+            },
+            {
+              "id": 5,
+              "name": "staticProperty",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isStatic": true,
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "privateProperty short text."
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 25,
+                  "character": 25
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "TestClass",
+                "id": 2
+              }
+            },
+            {
+              "id": 12,
+              "name": "privateMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isPrivate": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 13,
+                  "name": "privateMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "privateMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 47,
+                  "character": 25
+                }
+              ]
+            },
+            {
+              "id": 10,
+              "name": "protectedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isProtected": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 11,
+                  "name": "protectedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "protectedMethod short text.",
+                    "tags": [
+                      {
+                        "tag": "category",
+                        "text": "Test\n"
+                      }
+                    ]
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 42,
+                  "character": 29
+                }
+              ]
+            },
+            {
+              "id": 8,
+              "name": "publicMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isPublic": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 9,
+                  "name": "publicMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "publicMethod short text.",
+                    "tags": [
+                      {
+                        "tag": "category",
+                        "text": "Test\n"
+                      }
+                    ]
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 36,
+                  "character": 23
+                }
+              ]
+            },
+            {
+              "id": 14,
+              "name": "staticMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isStatic": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 15,
+                  "name": "staticMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "staticMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 52,
+                  "character": 23
+                }
+              ]
+            }
+          ],
+          "groups": [
+            {
+              "title": "Constructors",
+              "kind": 512,
+              "children": [
+                6
+              ]
+            },
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                4,
+                3,
+                5
+              ],
+              "categories": [
+                {
+                  "title": "Other",
+                  "children": [
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "title": "Test",
+                  "children": [
+                    3
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                12,
+                10,
+                8,
+                14
+              ],
+              "categories": [
+                {
+                  "title": "Other",
+                  "children": [
+                    12,
+                    14
+                  ]
+                },
+                {
+                  "title": "Test",
+                  "children": [
+                    10,
+                    8
+                  ]
+                }
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "category.ts",
+              "line": 9,
+              "character": 22
+            }
+          ],
+          "extendedBy": [
+            {
+              "type": "reference",
+              "name": "TestSubClass",
+              "id": 16
+            }
+          ]
+        },
+        {
+          "id": 16,
+          "name": "TestSubClass",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "children": [
+            {
+              "id": 21,
+              "name": "constructor",
+              "kind": 512,
+              "kindString": "Constructor",
+              "flags": {
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "Constructor short text."
+              },
+              "signatures": [
+                {
+                  "id": 25,
+                  "name": "new TestSubClass",
+                  "kind": 16384,
+                  "kindString": "Constructor signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Constructor short text."
+                  },
+                  "parameters": [
+                    {
+                      "id": 26,
+                      "name": "p1",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Constructor param"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    },
+                    {
+                      "id": 27,
+                      "name": "p2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Private string property"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
+                      }
+                    },
+                    {
+                      "id": 28,
+                      "name": "p3",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Public number property"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 29,
+                      "name": "p4",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "shortText": "Public implicit any property\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "reference",
+                    "name": "TestSubClass",
+                    "id": 16
+                  },
+                  "overwrites": {
+                    "type": "reference",
+                    "name": "TestClass.__constructor",
+                    "id": 6
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 64,
+                  "character": 34
+                }
+              ],
+              "overwrites": {
+                "type": "reference",
+                "name": "TestClass.__constructor",
+                "id": 6
+              }
+            },
+            {
+              "id": 22,
+              "name": "p2",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPrivate": true,
+                "isExported": true,
+                "isConstructorProperty": true
+              },
+              "comment": {
+                "shortText": "Private string property"
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 74,
+                  "character": 30
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              }
+            },
+            {
+              "id": 23,
+              "name": "p3",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPublic": true,
+                "isExported": true,
+                "isConstructorProperty": true
+              },
+              "comment": {
+                "shortText": "Public number property"
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 74,
+                  "character": 49
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            },
+            {
+              "id": 24,
+              "name": "p4",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPublic": true,
+                "isExported": true,
+                "isConstructorProperty": true
+              },
+              "comment": {
+                "shortText": "Public implicit any property\n"
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 74,
+                  "character": 68
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "any"
+              }
+            },
+            {
+              "id": 30,
+              "name": "publicProperty",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPublic": true,
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "publicProperty short text.",
+                "tags": [
+                  {
+                    "tag": "category",
+                    "text": "Test\n"
+                  }
+                ]
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 15,
+                  "character": 25
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "string"
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "TestClass.publicProperty",
+                "id": 3
+              }
+            },
+            {
+              "id": 31,
+              "name": "staticProperty",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isStatic": true,
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "privateProperty short text."
+              },
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 25,
+                  "character": 25
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "TestClass",
+                "id": 2
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "TestClass.staticProperty",
+                "id": 5
+              }
+            },
+            {
+              "id": 42,
+              "name": "mergedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 43,
+                  "name": "mergedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "mergedMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "any"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 95,
+                  "character": 16
+                }
+              ]
+            },
+            {
+              "id": 19,
+              "name": "protectedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isProtected": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 20,
+                  "name": "protectedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "protectedMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "overwrites": {
+                    "type": "reference",
+                    "name": "TestClass.protectedMethod",
+                    "id": 10
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 64,
+                  "character": 29
+                }
+              ],
+              "overwrites": {
+                "type": "reference",
+                "name": "TestClass.protectedMethod",
+                "id": 10
+              }
+            },
+            {
+              "id": 17,
+              "name": "publicMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isPublic": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 18,
+                  "name": "publicMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "publicMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "overwrites": {
+                    "type": "reference",
+                    "name": "TestClass.publicMethod",
+                    "id": 8
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 59,
+                  "character": 23
+                }
+              ],
+              "overwrites": {
+                "type": "reference",
+                "name": "TestClass.publicMethod",
+                "id": 8
+              }
+            },
+            {
+              "id": 49,
+              "name": "staticMergedMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isStatic": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 50,
+                  "name": "staticMergedMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "staticMergedMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 102,
+                  "character": 38
+                }
+              ]
+            },
+            {
+              "id": 32,
+              "name": "staticMethod",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isStatic": true,
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 33,
+                  "name": "staticMethod",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "staticMethod short text."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "TestClass.staticMethod",
+                    "id": 14
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "category.ts",
+                  "line": 52,
+                  "character": 23
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "TestClass.staticMethod",
+                "id": 14
+              }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Constructors",
+              "kind": 512,
+              "children": [
+                21
+              ]
+            },
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                22,
+                23,
+                24,
+                30,
+                31
+              ],
+              "categories": [
+                {
+                  "title": "Other",
+                  "children": [
+                    22,
+                    23,
+                    24,
+                    31
+                  ]
+                },
+                {
+                  "title": "Test",
+                  "children": [
+                    30
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                42,
+                19,
+                17,
+                49,
+                32
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "category.ts",
+              "line": 55,
+              "character": 25
+            },
+            {
+              "fileName": "category.ts",
+              "line": 91,
+              "character": 29
+            },
+            {
+              "fileName": "category.ts",
+              "line": 98,
+              "character": 26
+            }
+          ],
+          "extendedTypes": [
+            {
+              "type": "reference",
+              "name": "TestClass",
+              "id": 2
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Classes",
+          "kind": 128,
+          "children": [
+            44,
+            34,
+            38,
+            2,
+            16
+          ],
+          "categories": [
+            {
+              "title": "Other",
+              "children": [
+                44,
+                34,
+                38,
+                16
+              ]
+            },
+            {
+              "title": "Test",
+              "children": [
+                2
+              ]
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "category.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "External modules",
+      "kind": 1,
+      "children": [
+        1
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR makes a handful of changes based on requests and feedback from #866 and #904. I've also made a PR over at https://github.com/TypeStrong/typedoc-default-themes/pull/61 to make categories more integrated into the theme.

Thanks to @rbuckton for the suggestions. I used some of the ideas from your implementation in your custom plugin.

**Group Categories**
Categories can now be used within groups or as lump categories. Lump categories mean if you have a method and property you want together, you can do so. The option `--categorizeByGroup` controls this. By default, reflections will be categorized by group (within properties, methods, etc).

**Default Category**
Uncategorized reflections will be placed in the default category. If everything falls into the default category, categories aren't used. The option `--defaultCategory` controls this. By default, the default category will be 'Other'.

**Category Ordering**
Categories can be ordered however the user wants. Using an array, the user can specify the order categories are displayed on their pages. The option `--categoryOrder` controls this. By default, they will be ordered alphabetically. An entry of '*' indicates where categories not in this list will be rendered, defaulting to the end.