### PR TITLE
Don't limit option files to standard names

### DIFF
--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -48,7 +48,7 @@ export class TSConfigReader extends OptionsComponent {
         if (TSConfigReader.OPTIONS_KEY in event.data) {
             const tsconfig = event.data[TSConfigReader.OPTIONS_KEY];
 
-            if (/tsconfig\.json$/.test(tsconfig)) {
+            if (FS.existsSync(tsconfig)) {
                 file = Path.resolve(tsconfig);
             } else {
                 file = ts.findConfigFile(tsconfig, ts.sys.fileExists);
@@ -59,8 +59,14 @@ export class TSConfigReader extends OptionsComponent {
                 return;
             }
         } else if (TSConfigReader.PROJECT_KEY in event.data) {
-            // The `project` option may be a directory or file, so use TS to find it
-            file = ts.findConfigFile(event.data[TSConfigReader.PROJECT_KEY], ts.sys.fileExists);
+            const resolved = Path.resolve(event.data[TSConfigReader.PROJECT_KEY]);
+            // If the file exists, use it
+            if (FS.existsSync(resolved)) {
+                file = resolved;
+            } else {
+                // Use TS to find the file, since it could be a directory
+                file = ts.findConfigFile(resolved, ts.sys.fileExists);
+            }
         } else if (this.application.isCLI) {
             // No file or directory has been specified so find the file in the root of the project
             file = ts.findConfigFile('.', ts.sys.fileExists);

--- a/src/lib/utils/options/readers/typedoc.ts
+++ b/src/lib/utils/options/readers/typedoc.ts
@@ -50,7 +50,7 @@ export class TypedocReader extends OptionsComponent {
                 return;
             }
         } else if (this.application.isCLI) {
-            file = this.findTypedocFile();
+            file = this.findTypedocFile(process.cwd());
         }
 
         file && this.load(event, file);
@@ -63,8 +63,8 @@ export class TypedocReader extends OptionsComponent {
      *   typedoc file will be attempted to be found at the root of this path
      * @return the typedoc.(js|json) file path or undefined
      */
-    findTypedocFile(path: string = process.cwd()): string | undefined {
-        if (/typedoc\.js(on)?$/.test(path)) {
+    findTypedocFile(path: string): string | undefined {
+        if (FS.existsSync(path) && FS.statSync(path).isFile()) {
             return path;
         }
 


### PR DESCRIPTION
I believe this should resolve any issues with files that were accepted in v0.13 being rejected in v0.14.

Fixes #942
