### PR TITLE
Fix option file resolution

### DIFF
--- a/src/lib/utils/options/readers/typedoc.ts
+++ b/src/lib/utils/options/readers/typedoc.ts
@@ -64,6 +64,8 @@ export class TypedocReader extends OptionsComponent {
      * @return the typedoc.(js|json) file path or undefined
      */
     findTypedocFile(path: string): string | undefined {
+        path = Path.resolve(path);
+
         if (FS.existsSync(path) && FS.statSync(path).isFile()) {
             return path;
         }


### PR DESCRIPTION
As suspected, the options path needs to be passed through `path.resolve`, I confirmed this fixes the iov-core reproduction.

Fixes #945 