### PR TITLE
Replace array `indexOf` checks with `includes`

### DIFF
--- a/src/lib/converter/context.ts
+++ b/src/lib/converter/context.ts
@@ -218,7 +218,7 @@ export class Context {
      * @param callback  The callback that should be executed.
      */
     withSourceFile(node: ts.SourceFile, callback: Function) {
-        let isExternal = this.fileNames.indexOf(node.fileName) === -1;
+        let isExternal = !this.fileNames.includes(node.fileName);
         if (!isExternal && this.externalPattern) {
             isExternal = this.externalPattern.some(mm => mm.match(node.fileName));
         }
@@ -322,7 +322,7 @@ export class Context {
 
         if (baseNode.symbol) {
             const id = this.getSymbolID(baseNode.symbol)!;
-            if (this.inheritedChildren && this.inheritedChildren.indexOf(id) !== -1) {
+            if (this.inheritedChildren && this.inheritedChildren.includes(id)) {
                 return target;
             } else {
                 this.inheritedChildren = this.inheritedChildren || [];

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -312,7 +312,7 @@ export class Converter extends ChildableComponent<Application, ConverterComponen
      * @return The resulting reflection or undefined.
      */
     convertNode(context: Context, node: ts.Node): Reflection | undefined {
-        if (context.visitStack.indexOf(node) !== -1) {
+        if (context.visitStack.includes(node)) {
             return;
         }
 

--- a/src/lib/converter/factories/declaration.ts
+++ b/src/lib/converter/factories/declaration.ts
@@ -81,12 +81,12 @@ export function createDeclaration(context: Context, node: ts.Declaration, kind: 
     // Test whether the node is static, when merging a module to a class make the node static
     let isConstructorProperty = false;
     let isStatic = false;
-    if (nonStaticKinds.indexOf(kind) === -1) {
+    if (!nonStaticKinds.includes(kind)) {
         isStatic = !!(modifiers & ts.ModifierFlags.Static);
         if (container.kind === ReflectionKind.Class) {
             if (node.parent && node.parent.kind === ts.SyntaxKind.Constructor) {
                 isConstructorProperty = true;
-            } else if (!node.parent || nonStaticMergeKinds.indexOf(node.parent.kind) === -1) {
+            } else if (!node.parent || !nonStaticMergeKinds.includes(node.parent.kind)) {
                 isStatic = true;
             }
         }
@@ -179,7 +179,7 @@ function mergeDeclarations(context: Context, reflection: DeclarationReflection, 
 
     if (
         context.isInherit &&
-        (context.inherited || []).indexOf(reflection.name) !== -1 &&
+        (context.inherited || []).includes(reflection.name) &&
         (node.parent === context.inheritParent || reflection.flags.isConstructorProperty)
     ) {
         if (!reflection.overwrites) {

--- a/src/lib/converter/nodes/block.ts
+++ b/src/lib/converter/nodes/block.ts
@@ -87,7 +87,7 @@ export class BlockConverter extends ConverterNodeComponent<ts.SourceFile|ts.Bloc
             const statements: ts.Statement[] = [];
 
             node.statements.forEach((statement) => {
-                if (preferred.indexOf(statement.kind) !== -1) {
+                if (preferred.includes(statement.kind)) {
                     this.owner.convertNode(context, statement);
                 } else {
                     statements.push(statement);

--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -63,7 +63,7 @@ export class CommentPlugin extends ConverterComponent {
     }
 
     private storeModuleComment(comment: string, reflection: Reflection) {
-        const isPreferred = (comment.toLowerCase().indexOf('@preferred') !== -1);
+        const isPreferred = (comment.toLowerCase().includes('@preferred'));
 
         if (this.comments[reflection.id]) {
             const info = this.comments[reflection.id];

--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -322,7 +322,7 @@ export class CommentPlugin extends ConverterComponent {
         });
 
         for (let key in project.symbolMapping) {
-            if (project.symbolMapping.hasOwnProperty(key) && deletedIds.indexOf(project.symbolMapping[key]) !== -1) {
+            if (project.symbolMapping.hasOwnProperty(key) && deletedIds.includes(project.symbolMapping[key])) {
                 delete project.symbolMapping[key];
             }
         }

--- a/src/lib/converter/plugins/DynamicModulePlugin.ts
+++ b/src/lib/converter/plugins/DynamicModulePlugin.ts
@@ -54,7 +54,7 @@ export class DynamicModulePlugin extends ConverterComponent {
     private onDeclaration(context: Context, reflection: Reflection, node?: ts.Node) {
         if (reflection.kindOf(ReflectionKind.ExternalModule)) {
             let name = reflection.name;
-            if (name.indexOf('/') === -1) {
+            if (!name.includes('/')) {
                 return;
             }
 

--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -100,7 +100,7 @@ export class Repository {
      * @returns TRUE when the file is part of the repository, otherwise FALSE.
      */
     contains(fileName: string): boolean {
-        return this.files.indexOf(fileName) !== -1;
+        return this.files.includes(fileName);
     }
 
     /**

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -94,7 +94,7 @@ export class PackagePlugin extends ConverterComponent {
         let dirName: string, parentDir = Path.resolve(Path.dirname(fileName));
         do {
             dirName = parentDir;
-            if (this.visited.indexOf(dirName) !== -1) {
+            if (this.visited.includes(dirName)) {
                 break;
             }
 

--- a/src/lib/converter/plugins/TypePlugin.ts
+++ b/src/lib/converter/plugins/TypePlugin.ts
@@ -111,7 +111,7 @@ export class TypePlugin extends ConverterComponent {
     }
 
     private postpone(reflection: DeclarationReflection) {
-        if (this.reflections.indexOf(reflection) === -1) {
+        if (!this.reflections.includes(reflection)) {
             this.reflections.push(reflection);
         }
     }

--- a/src/lib/converter/types/reference.ts
+++ b/src/lib/converter/types/reference.ts
@@ -112,7 +112,7 @@ export class ReferenceConverter extends ConverterTypeComponent implements TypeNo
      */
     private convertLiteral(context: Context, symbol: ts.Symbol, node?: ts.Node): Type | undefined {
         for (let declaration of symbol.declarations) {
-            if (context.visitStack.indexOf(declaration) !== -1) {
+            if (context.visitStack.includes(declaration)) {
                 if (declaration.kind === ts.SyntaxKind.TypeLiteral ||
                         declaration.kind === ts.SyntaxKind.ObjectLiteralExpression) {
                     // TODO: Check if this type assertion is safe and document.

--- a/src/lib/models/reflections/abstract.ts
+++ b/src/lib/models/reflections/abstract.ts
@@ -219,12 +219,12 @@ export class ReflectionFlags extends Array<string> {
     private setSingleFlag(flag: ReflectionFlag, set: boolean) {
         const name = ReflectionFlag[flag].replace(/(.)([A-Z])/g, (m, a, b) => a + ' ' + b.toLowerCase());
         if (!set && this.hasFlag(flag)) {
-            if (relevantFlags.indexOf(flag) !== -1) {
+            if (relevantFlags.includes(flag)) {
                 this.splice(this.indexOf(name), 1);
             }
             this.flags ^= flag;
         } else if (set && !this.hasFlag(flag)) {
-            if (relevantFlags.indexOf(flag) !== -1) {
+            if (relevantFlags.includes(flag)) {
                 this.push(name);
             }
             this.flags |= flag;
@@ -441,7 +441,7 @@ export abstract class Reflection {
                 target._aliases = [];
             }
             let suffix = '', index = 0;
-            while (target._aliases.indexOf(alias + suffix) !== -1) {
+            while (target._aliases.includes(alias + suffix)) {
                 suffix = '-' + (++index).toString();
             }
 

--- a/src/lib/output/plugins/NavigationPlugin.ts
+++ b/src/lib/output/plugins/NavigationPlugin.ts
@@ -48,7 +48,7 @@ export class NavigationPlugin extends RendererComponent {
             item.isInPath  = false;
             item.isVisible = item.isGlobals;
 
-            if (item.url === page.url || (item.dedicatedUrls && item.dedicatedUrls.indexOf(page.url) !== -1)) {
+            if (item.url === page.url || (item.dedicatedUrls && item.dedicatedUrls.includes(page.url))) {
                 currentItems.push(item);
             }
 

--- a/src/lib/output/plugins/TocPlugin.ts
+++ b/src/lib/output/plugins/TocPlugin.ts
@@ -63,7 +63,7 @@ export class TocPlugin extends RendererComponent {
         } else {
             children.forEach((child: DeclarationReflection) => {
 
-                if (restriction && restriction.length > 0 && restriction.indexOf(child.name) === -1) {
+                if (restriction && restriction.length > 0 && !restriction.includes(child.name)) {
                     return;
                 }
 
@@ -72,7 +72,7 @@ export class TocPlugin extends RendererComponent {
                 }
 
                 const item = NavigationItem.create(child, parent, true);
-                if (trail.indexOf(child) !== -1) {
+                if (trail.includes(child)) {
                     item.isInPath  = true;
                     item.isCurrent = (trail[trail.length - 1] === child);
                     TocPlugin.buildToc(child, trail, item);

--- a/src/lib/output/utils/resources/helpers.ts
+++ b/src/lib/output/utils/resources/helpers.ts
@@ -41,7 +41,7 @@ export class HelperStack extends ResourceStack<Helper> {
             const helpers = resources[resourceName].getHelpers();
 
             for (let name in helpers) {
-                if (this.registeredNames.indexOf(name) !== -1) {
+                if (this.registeredNames.includes(name)) {
                     continue;
                 }
                 this.registeredNames.push(name);

--- a/src/lib/output/utils/resources/templates.ts
+++ b/src/lib/output/utils/resources/templates.ts
@@ -39,7 +39,7 @@ export class PartialStack extends TemplateStack {
         const resources = this.getAllResources();
 
         for (let name in resources) {
-            if (this.registeredNames.indexOf(name) !== -1) {
+            if (this.registeredNames.includes(name)) {
                 continue;
             }
             this.registeredNames.push(name);

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -114,7 +114,7 @@ export class OptionDeclaration {
                         value = map.has(key) ? map.get(key) : value;
                     } else if (key in map) {
                         value = map[key];
-                    } else if (values.indexOf(value) === -1 && errorCallback) {
+                    } else if (!values.includes(value) && errorCallback) {
                         if (this.mapError) {
                             errorCallback(this.mapError);
                         } else {

--- a/src/lib/utils/options/sources/component.ts
+++ b/src/lib/utils/options/sources/component.ts
@@ -28,7 +28,7 @@ export class ComponentSource extends OptionsComponent {
             return;
         }
 
-        if (this.knownComponents.indexOf(name) === -1) {
+        if (!this.knownComponents.includes(name)) {
             this.knownComponents.push(name);
             this.owner.addDeclarations(component.getOptionDeclarations());
         }

--- a/src/lib/utils/options/sources/typescript.ts
+++ b/src/lib/utils/options/sources/typescript.ts
@@ -28,7 +28,7 @@ export class TypeScriptSource extends OptionsComponent {
         this.declarations = [];
 
         for (let declaration of _ts.optionDeclarations) {
-            if (TypeScriptSource.IGNORED.indexOf(declaration.name) === -1) {
+            if (!TypeScriptSource.IGNORED.includes(declaration.name)) {
                 this.addTSOption(declaration);
             }
         }

--- a/src/test/typedoc.ts
+++ b/src/test/typedoc.ts
@@ -15,55 +15,55 @@ describe('TypeDoc', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.notEqual(expanded.indexOf(Path.join(inputFiles, 'class.ts')), -1);
-            Assert.equal(expanded.indexOf(inputFiles), -1);
+            Assert.ok(expanded.includes(Path.join(inputFiles, 'class.ts')));
+            Assert.ok(!expanded.includes(inputFiles));
         });
         it('expands input files', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class', 'class.ts');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.notEqual(expanded.indexOf(inputFiles), -1);
+            Assert.ok(expanded.includes(inputFiles));
         });
         it('honors the exclude argument even on a fixed directory list', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class');
             application.options.setValue('exclude', '**/class.ts');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class.ts')), -1);
-            Assert.equal(expanded.indexOf(inputFiles), -1);
+            Assert.ok(!expanded.includes(Path.join(inputFiles, 'class.ts')));
+            Assert.ok(!expanded.includes(inputFiles));
         });
         it('honors the exclude argument even on a fixed file list', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class', 'class.ts');
             application.options.setValue('exclude', '**/class.ts');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.equal(expanded.indexOf(inputFiles), -1);
+            Assert.ok(!expanded.includes(inputFiles));
         });
         it('supports multiple excludes', function() {
             const inputFiles = Path.join(__dirname, 'converter');
             application.options.setValue('exclude', '**/+(class|access).ts');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class', 'class.ts')), -1);
-            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'access', 'access.ts')), -1);
-            Assert.equal(expanded.indexOf(inputFiles), -1);
+            Assert.ok(!expanded.includes(Path.join(inputFiles, 'class', 'class.ts')));
+            Assert.ok(!expanded.includes(Path.join(inputFiles, 'access', 'access.ts')));
+            Assert.ok(!expanded.includes(inputFiles));
         });
         it('supports array of excludes', function() {
             const inputFiles = Path.join(__dirname, 'converter');
             application.options.setValue('exclude', [ '**/class.ts', '**/access.ts' ]);
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'class', 'class.ts')), -1);
-            Assert.equal(expanded.indexOf(Path.join(inputFiles, 'access', 'access.ts')), -1);
-            Assert.equal(expanded.indexOf(inputFiles), -1);
+            Assert.ok(!expanded.includes(Path.join(inputFiles, 'class', 'class.ts')));
+            Assert.ok(!expanded.includes(Path.join(inputFiles, 'access', 'access.ts')));
+            Assert.ok(!expanded.includes(inputFiles));
         });
         it('supports excluding directories beginning with dots', function() {
             const inputFiles = __dirname;
             application.options.setValue('exclude', '**/+(.dot)/**');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.equal(expanded.indexOf(Path.join(inputFiles, '.dot', 'index.d.ts')), -1);
-            Assert.equal(expanded.indexOf(inputFiles), -1);
+            Assert.ok(!expanded.includes(Path.join(inputFiles, '.dot', 'index.d.ts')));
+            Assert.ok(!expanded.includes(inputFiles));
         });
         it('Honors the exclude option even if a module is imported', () => {
             application.options.setValue('exclude', '**/b.d.ts');

--- a/src/test/typedoc.ts
+++ b/src/test/typedoc.ts
@@ -15,55 +15,55 @@ describe('TypeDoc', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.ok(expanded.includes(Path.join(inputFiles, 'class.ts')));
-            Assert.ok(!expanded.includes(inputFiles));
+            Assert(expanded.includes(Path.join(inputFiles, 'class.ts')));
+            Assert(!expanded.includes(inputFiles));
         });
         it('expands input files', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class', 'class.ts');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.ok(expanded.includes(inputFiles));
+            Assert(expanded.includes(inputFiles));
         });
         it('honors the exclude argument even on a fixed directory list', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class');
             application.options.setValue('exclude', '**/class.ts');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.ok(!expanded.includes(Path.join(inputFiles, 'class.ts')));
-            Assert.ok(!expanded.includes(inputFiles));
+            Assert(!expanded.includes(Path.join(inputFiles, 'class.ts')));
+            Assert(!expanded.includes(inputFiles));
         });
         it('honors the exclude argument even on a fixed file list', function() {
             const inputFiles = Path.join(__dirname, 'converter', 'class', 'class.ts');
             application.options.setValue('exclude', '**/class.ts');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.ok(!expanded.includes(inputFiles));
+            Assert(!expanded.includes(inputFiles));
         });
         it('supports multiple excludes', function() {
             const inputFiles = Path.join(__dirname, 'converter');
             application.options.setValue('exclude', '**/+(class|access).ts');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.ok(!expanded.includes(Path.join(inputFiles, 'class', 'class.ts')));
-            Assert.ok(!expanded.includes(Path.join(inputFiles, 'access', 'access.ts')));
-            Assert.ok(!expanded.includes(inputFiles));
+            Assert(!expanded.includes(Path.join(inputFiles, 'class', 'class.ts')));
+            Assert(!expanded.includes(Path.join(inputFiles, 'access', 'access.ts')));
+            Assert(!expanded.includes(inputFiles));
         });
         it('supports array of excludes', function() {
             const inputFiles = Path.join(__dirname, 'converter');
             application.options.setValue('exclude', [ '**/class.ts', '**/access.ts' ]);
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.ok(!expanded.includes(Path.join(inputFiles, 'class', 'class.ts')));
-            Assert.ok(!expanded.includes(Path.join(inputFiles, 'access', 'access.ts')));
-            Assert.ok(!expanded.includes(inputFiles));
+            Assert(!expanded.includes(Path.join(inputFiles, 'class', 'class.ts')));
+            Assert(!expanded.includes(Path.join(inputFiles, 'access', 'access.ts')));
+            Assert(!expanded.includes(inputFiles));
         });
         it('supports excluding directories beginning with dots', function() {
             const inputFiles = __dirname;
             application.options.setValue('exclude', '**/+(.dot)/**');
             const expanded = application.expandInputFiles([inputFiles]);
 
-            Assert.ok(!expanded.includes(Path.join(inputFiles, '.dot', 'index.d.ts')));
-            Assert.ok(!expanded.includes(inputFiles));
+            Assert(!expanded.includes(Path.join(inputFiles, '.dot', 'index.d.ts')));
+            Assert(!expanded.includes(inputFiles));
         });
         it('Honors the exclude option even if a module is imported', () => {
             application.options.setValue('exclude', '**/b.d.ts');


### PR DESCRIPTION
Closes #898

Changes:

Replaced `indexOf` calls to check presence or absence with `includes` (with negation operator when checking absence).

Decisions:

1. There are some indexOf calls which use the index value to both check presence and use it to remove some elements at that position. They can be potentially refactored with separate calls to `includes` and `indexOf`, but I decided not to do that as `indexOf` alone can serve both the purposes here.

2. In testcases, replaced `assert.equal` + `indexOf` check with -1 by `assert.ok` + `includes`. This will probably show less information during error, as the actual index value won't be printed. That seems like a small price to pay.

Observations:

1. Most of the tests don't seem to fail if I change the presence or absence logic (`includes` or `!includes`) with the opposite one. I often did this mistake when working on this initially, but none of the test cases failed as they should have.
Maybe we should add some more tests around that?