### PR TITLE
fix: allow higher versions of typescript to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "progress": "^2.0.0",
     "shelljs": "^0.8.2",
     "typedoc-default-themes": "^0.5.0",
-    "typescript": "3.2.x"
+    "typescript": "^3.2.x"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.4",


### PR DESCRIPTION
This is a real problem.

If I installed a different version of typescript in a project, this package will overwrite the ./node_modules/.bin/tsc with typedoc's typescript version.

I'm even thinking if this should be a dependency at all, just a peerDependency.