### PR TITLE
fix highlight.js dependency: ^9.15.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1943,9 +1943,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.14.2.tgz",
+      "integrity": "sha512-Nc6YNECYpxyJABGYJAyw7dBAYbXEuIzwzkqoJnwbc1nIpCiN+3ioYf0XrBnLiyyG0JLuJhpPtt2iTSbXiKLoyA=="
     },
     "hooker": {
       "version": "0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1943,9 +1943,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.14.2.tgz",
-      "integrity": "sha512-Nc6YNECYpxyJABGYJAyw7dBAYbXEuIzwzkqoJnwbc1nIpCiN+3ioYf0XrBnLiyyG0JLuJhpPtt2iTSbXiKLoyA=="
+      "version": "9.15.6",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
+      "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ=="
     },
     "hooker": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/shelljs": "^0.8.0",
     "fs-extra": "^7.0.0",
     "handlebars": "^4.1.0",
-    "highlight.js": "~9.14.2",
+    "highlight.js": "^9.15.6",
     "lodash": "^4.17.10",
     "marked": "^0.6.0",
     "minimatch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc",
   "description": "Create api documentations for typescript projects.",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "homepage": "http://typedoc.org",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
     "@types/shelljs": "^0.8.0",
     "fs-extra": "^7.0.0",
     "handlebars": "^4.1.0",
-    "highlight.js": "^9.13.1",
+    "highlight.js": "~9.14.2",
     "lodash": "^4.17.10",
     "marked": "^0.6.0",
     "minimatch": "^3.0.0",


### PR DESCRIPTION
should temporarily fix #976 , until `highlight.js` v9.15+ no longer fails on installation (see highlightjs/highlight.js#1984 )

see https://www.npmjs.com/package/highlight.js/v/9.14.2 for latest working version