### PR TITLE
Add links to README.md headings

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -37,3 +37,11 @@ $ examples --out path/to/documentation/ path/to/example/project/
 ### Только кириллица
 
 > Only Cyrillic text
+
+## Repeated Heading
+
+This is used to check the generated id. First instance.
+
+## Repeated Heading
+
+This is used to check the generated id. Second instance.

--- a/src/lib/output/plugins/MarkedPlugin.ts
+++ b/src/lib/output/plugins/MarkedPlugin.ts
@@ -9,6 +9,18 @@ import { RendererEvent, MarkdownEvent } from '../events';
 import { Option } from '../../utils/component';
 import { ParameterHint } from '../../utils/options/declaration';
 
+const customMarkedRenderer = new Marked.Renderer();
+
+customMarkedRenderer.heading = (text, level, _, slugger) => {
+  const slug = slugger.slug(text);
+
+  return `
+<a href="#${slug}" id="${slug}" style="color: inherit; text-decoration: none;">
+  <h${level}>${text}</h${level}>
+</a>
+`;
+};
+
 /**
  * A plugin that exposes the markdown, compact and relativeURL helper to handlebars.
  *
@@ -87,7 +99,8 @@ export class MarkedPlugin extends ContextAwareRendererComponent {
         Handlebars.registerHelper('relativeURL', (url: string) => url ? this.getRelativeUrl(url) : url);
 
         Marked.setOptions({
-            highlight: (text: any, lang: any) => this.getHighlighted(text, lang)
+            highlight: (text: any, lang: any) => this.getHighlighted(text, lang),
+            renderer: customMarkedRenderer
         });
     }
 

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -64,32 +64,56 @@
 	<div class="row">
 		<div class="col-8 col-content">
 			<div class="tsd-panel tsd-typography">
-				<h1 id="example">Example</h1>
+				<a href="#example" id="example" style="color: inherit; text-decoration: none;">
+					<h1>Example</h1>
+				</a>
 				<blockquote>
 					<p>Example Documentation</p>
 				</blockquote>
-				<h2 id="installation">Installation</h2>
+				<a href="#installation" id="installation" style="color: inherit; text-decoration: none;">
+					<h2>Installation</h2>
+				</a>
 				<p>Example install</p>
 				<pre><code class="language-bash">$ npm install examples --save-dev</code></pre>
 				<p>Example executable: <code>examples</code>. </p>
-				<h2 id="usage">Usage</h2>
-				<h3 id="shell">Shell</h3>
+				<a href="#usage" id="usage" style="color: inherit; text-decoration: none;">
+					<h2>Usage</h2>
+				</a>
+				<a href="#shell" id="shell" style="color: inherit; text-decoration: none;">
+					<h3>Shell</h3>
+				</a>
 				<p>Example usage.</p>
 				<pre><code class="language-bash">$ examples --out path/to/documentation/ path/to/example/project/</code></pre>
-				<h3 id="arguments">Arguments</h3>
+				<a href="#arguments" id="arguments" style="color: inherit; text-decoration: none;">
+					<h3>Arguments</h3>
+				</a>
 				<ul>
 					<li><code>--example &lt;project&gt;</code><br>
 					Example explanation.</li>
 				</ul>
-				<h2 id="example-with-cyrillic">Example with Cyrillic</h2>
-				<h3 id="пример-api">Пример API</h3>
+				<a href="#example-with-cyrillic" id="example-with-cyrillic" style="color: inherit; text-decoration: none;">
+					<h2>Example with Cyrillic</h2>
+				</a>
+				<a href="#пример-api" id="пример-api" style="color: inherit; text-decoration: none;">
+					<h3>Пример API</h3>
+				</a>
 				<blockquote>
 					<p>Combined Latin and Cyrillic text</p>
 				</blockquote>
-				<h3 id="только-кириллица">Только кириллица</h3>
+				<a href="#только-кириллица" id="только-кириллица" style="color: inherit; text-decoration: none;">
+					<h3>Только кириллица</h3>
+				</a>
 				<blockquote>
 					<p>Only Cyrillic text</p>
 				</blockquote>
+				<a href="#repeated-heading" id="repeated-heading" style="color: inherit; text-decoration: none;">
+					<h2>Repeated Heading</h2>
+				</a>
+				<p>This is used to check the generated id. First instance.</p>
+				<a href="#repeated-heading-1" id="repeated-heading-1" style="color: inherit; text-decoration: none;">
+					<h2>Repeated Heading</h2>
+				</a>
+				<p>This is used to check the generated id. Second instance.</p>
 			</div>
 		</div>
 		<div class="col-4 col-menu menu-sticky-wrap menu-highlight">


### PR DESCRIPTION
Hi 🙂 

This would add links without underline or special colour to the files parsed by `marked`, fixing (partially?) this issue: https://github.com/TypeStrong/typedoc/issues/972

Was thinking that it may be nice to also add links in the headings in the generated API pages, e.g. `Properties`, `Functions`, etc. , and in each of the elements titles (e.g. `methodA`). The last ones are already anchors although they are still using the `name` attribute, for example:

```
<a name="method-a" class="tsd-anchor"></a>
<h3>methodA</h3>
```

However, I think that would involve updating this repository: https://github.com/TypeStrong/typedoc-default-themes with a different approach, and not sure if this issue was referring to that also.

Many thanks for the library and happy to update any code from comments