### PR TITLE
Add option to include modules in the top level toc

### DIFF
--- a/src/lib/converter/components.ts
+++ b/src/lib/converter/components.ts
@@ -6,7 +6,7 @@ import { Type } from '../models/types/abstract';
 import { Context } from './context';
 import { Converter } from './converter';
 
-export {Component};
+export { Component };
 
 export abstract class ConverterComponent extends AbstractComponent<Converter> { }
 

--- a/src/lib/output/components.ts
+++ b/src/lib/output/components.ts
@@ -5,7 +5,7 @@ import { ProjectReflection, DeclarationReflection } from '../models/reflections/
 import { Renderer } from './renderer';
 import { RendererEvent, PageEvent } from './events';
 
-export {Component};
+export { Component };
 
 export abstract class RendererComponent extends AbstractComponent<Renderer> { }
 

--- a/src/lib/output/plugins/TocPlugin.ts
+++ b/src/lib/output/plugins/TocPlugin.ts
@@ -32,25 +32,35 @@ export class TocPlugin extends RendererComponent {
         }
 
         const trail: Reflection[] = [];
-        while (!(model instanceof ProjectReflection) && !model.kindOf(ReflectionKind.SomeModule)) {
+        while (this.shouldBeIncludedInTrail(model)) {
             trail.unshift(model);
             model = model.parent;
         }
 
         const tocRestriction = this.owner.toc;
+        const tocIncludeModules = this.owner.tocIncludeModules;
         page.toc = new NavigationItem();
-        TocPlugin.buildToc(model, trail, page.toc, tocRestriction);
+        TocPlugin.buildToc(model, trail, page.toc, tocRestriction, tocIncludeModules);
+    }
+
+    private shouldBeIncludedInTrail(model: any): boolean {
+        if (model instanceof ProjectReflection) {
+            return false;
+        }
+
+        return !model.kindOf(ReflectionKind.SomeModule) || this.owner.tocIncludeModules;
     }
 
     /**
      * Create a toc navigation item structure.
      *
-     * @param model   The models whose children should be written to the toc.
-     * @param trail   Defines the active trail of expanded toc entries.
-     * @param parent  The parent [[NavigationItem]] the toc should be appended to.
-     * @param restriction  The restricted table of contents.
+     * @param model           The models whose children should be written to the toc.
+     * @param trail           Defines the active trail of expanded toc entries.
+     * @param parent          The parent [[NavigationItem]] the toc should be appended to.
+     * @param restriction     The restricted top level toc entries.
+     * @param includeModules  Include modules in the top level toc.
      */
-    static buildToc(model: Reflection, trail: Reflection[], parent: NavigationItem, restriction?: string[]) {
+    static buildToc(model: Reflection, trail: Reflection[], parent: NavigationItem, restriction?: string[], includeModules?: boolean) {
         const index = trail.indexOf(model);
         const children = model['children'] || [];
 
@@ -67,7 +77,7 @@ export class TocPlugin extends RendererComponent {
                     return;
                 }
 
-                if (child.kindOf(ReflectionKind.SomeModule)) {
+                if (child.kindOf(ReflectionKind.SomeModule) && !includeModules) {
                     return;
                 }
 

--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -110,6 +110,13 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
     })
     toc!: string[];
 
+    @Option({
+        name: 'tocIncludeModules',
+        help: 'Include modules in the top level table of contents.',
+        type: ParameterType.Boolean
+    })
+    tocIncludeModules!: boolean;
+
     /**
      * Create a new Renderer instance.
      *


### PR DESCRIPTION
Together with [`typedoc-plugin-monorepo`](https://www.npmjs.com/package/typedoc-plugin-monorepo) this enables monorepos to generate combined API docs for their packages using "external modules".

[Example](https://deploy-preview-430--feature-hub.netlify.com/@feature-hub/)