### PR TITLE
Reset the state of the comment plugin on conversion start.

### DIFF
--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -124,6 +124,7 @@ export class CommentPlugin extends ConverterComponent {
      * @param context  The context object describing the current state the converter is in.
      */
     private onBegin(context: Context) {
+        this.hidden = undefined;
         this.comments = {};
     }
 

--- a/src/test/converter/constructor-properties/specs.json
+++ b/src/test/converter/constructor-properties/specs.json
@@ -125,6 +125,7 @@
               "id": 4,
               "name": "x",
               "kind": 1024,
+              "kindString": "Property",
               "flags": {
                 "isConstructorProperty": true,
                 "isPublic": true
@@ -134,7 +135,7 @@
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/constructor-properties/constructor-properties.ts",
+                  "fileName": "constructor-properties.ts",
                   "line": 11,
                   "character": 24
                 }
@@ -148,6 +149,7 @@
               "id": 5,
               "name": "y",
               "kind": 1024,
+              "kindString": "Property",
               "flags": {
                 "isConstructorProperty": true,
                 "isPublic": true
@@ -157,7 +159,7 @@
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/constructor-properties/constructor-properties.ts",
+                  "fileName": "constructor-properties.ts",
                   "line": 11,
                   "character": 41
                 }
@@ -362,7 +364,8 @@
               },
               "inheritedFrom": {
                 "type": "reference",
-                "name": "Vector2.x"
+                "name": "Vector2.x",
+                "id": 4
               }
             },
             {
@@ -390,7 +393,8 @@
               },
               "overwrites": {
                 "type": "reference",
-                "name": "Vector2.y"
+                "name": "Vector2.y",
+                "id": 5
               }
             },
             {

--- a/src/test/converter/decorators/specs.json
+++ b/src/test/converter/decorators/specs.json
@@ -48,7 +48,8 @@
                   "name": "decoratorAtom",
                   "type": {
                     "type": "reference",
-                    "name": "decoratorAtom"
+                    "name": "decoratorAtom",
+                    "id": 5
                   }
                 },
                 {
@@ -68,6 +69,7 @@
                   "id": 4,
                   "name": "decoratedMethod",
                   "kind": 4096,
+                  "kindString": "Call signature",
                   "flags": {},
                   "comment": {
                     "shortText": "A decorated method."
@@ -108,7 +110,15 @@
           "id": 5,
           "name": "decoratorAtom",
           "kind": 64,
+          "kindString": "Function",
           "flags": {},
+          "decorates": [
+            {
+              "type": "reference",
+              "name": "decoratedMethod",
+              "id": 3
+            }
+          ],
           "signatures": [
             {
               "id": 6,
@@ -177,7 +187,7 @@
           ],
           "sources": [
             {
-              "fileName": "%BASE%/decorators/decorators.ts",
+              "fileName": "decorators.ts",
               "line": 21,
               "character": 22
             }

--- a/src/test/converter/destructuring/specs.json
+++ b/src/test/converter/destructuring/specs.json
@@ -18,10 +18,11 @@
           "id": 5,
           "name": "destructArrayA",
           "kind": 32,
+          "kindString": "Variable",
           "flags": {},
           "sources": [
             {
-              "fileName": "%BASE%/destructuring/destructuring.ts",
+              "fileName": "destructuring.ts",
               "line": 10,
               "character": 21
             }
@@ -225,10 +226,11 @@
           "id": 4,
           "name": "destructObjectC",
           "kind": 32,
+          "kindString": "Variable",
           "flags": {},
           "sources": [
             {
-              "fileName": "%BASE%/destructuring/destructuring.ts",
+              "fileName": "destructuring.ts",
               "line": 4,
               "character": 56
             }

--- a/src/test/converter/enum/specs.json
+++ b/src/test/converter/enum/specs.json
@@ -217,6 +217,7 @@
               "id": 4,
               "name": "EnumValue2",
               "kind": 16,
+              "kindString": "Enumeration member",
               "flags": {
                 "isExported": true
               },
@@ -225,7 +226,7 @@
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/enum/enum.ts",
+                  "fileName": "enum.ts",
                   "line": 14,
                   "character": 14
                 }
@@ -236,6 +237,7 @@
               "id": 5,
               "name": "EnumValue3",
               "kind": 16,
+              "kindString": "Enumeration member",
               "flags": {
                 "isExported": true
               },
@@ -244,7 +246,7 @@
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/enum/enum.ts",
+                  "fileName": "enum.ts",
                   "line": 19,
                   "character": 14
                 }

--- a/src/test/converter/events-overloads/specs.json
+++ b/src/test/converter/events-overloads/specs.json
@@ -41,6 +41,7 @@
                   "id": 4,
                   "name": "on",
                   "kind": 8388608,
+                  "kindString": "Event",
                   "flags": {},
                   "comment": {
                     "shortText": "Subscribe for a general event by name."
@@ -50,6 +51,7 @@
                       "id": 5,
                       "name": "event",
                       "kind": 32768,
+                      "kindString": "Parameter",
                       "flags": {},
                       "comment": {
                         "text": "The name of the event to subscribe for."

--- a/src/test/converter/export-assignment/specs.json
+++ b/src/test/converter/export-assignment/specs.json
@@ -35,6 +35,7 @@
                   "id": 4,
                   "name": "x",
                   "kind": 32768,
+                  "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",
@@ -45,6 +46,7 @@
                   "id": 5,
                   "name": "y",
                   "kind": 32768,
+                  "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",

--- a/src/test/converter/export-with-local/specs.json
+++ b/src/test/converter/export-with-local/specs.json
@@ -70,12 +70,14 @@
               "id": 4,
               "name": "add",
               "kind": 4096,
+              "kindString": "Call signature",
               "flags": {},
               "parameters": [
                 {
                   "id": 5,
                   "name": "x",
                   "kind": 32768,
+                  "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",

--- a/src/test/converter/export/specs.json
+++ b/src/test/converter/export/specs.json
@@ -49,12 +49,14 @@
               "id": 4,
               "name": "add",
               "kind": 4096,
+              "kindString": "Call signature",
               "flags": {},
               "parameters": [
                 {
                   "id": 5,
                   "name": "x",
                   "kind": 32768,
+                  "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",

--- a/src/test/converter/function/specs.json
+++ b/src/test/converter/function/specs.json
@@ -176,6 +176,7 @@
           "id": 4,
           "name": "exportedFunction",
           "kind": 64,
+          "kindString": "Function",
           "flags": {
             "isExported": true
           },
@@ -184,6 +185,7 @@
               "id": 5,
               "name": "exportedFunction",
               "kind": 4096,
+              "kindString": "Call signature",
               "flags": {},
               "comment": {
                 "shortText": "This is a simple exported function."
@@ -196,7 +198,7 @@
           ],
           "sources": [
             {
-              "fileName": "%BASE%/function/function.ts",
+              "fileName": "function.ts",
               "line": 10,
               "character": 32
             }

--- a/src/test/converter/generic-class/specs.json
+++ b/src/test/converter/generic-class/specs.json
@@ -90,6 +90,7 @@
               "id": 4,
               "name": "value",
               "kind": 1024,
+              "kindString": "Property",
               "flags": {
                 "isProtected": true
               },
@@ -98,7 +99,7 @@
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/generic-class/generic-class.ts",
+                  "fileName": "generic-class.ts",
                   "line": 9,
                   "character": 19
                 }
@@ -112,6 +113,7 @@
               "id": 5,
               "name": "values",
               "kind": 1024,
+              "kindString": "Property",
               "flags": {
                 "isProtected": true
               },
@@ -120,7 +122,7 @@
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/generic-class/generic-class.ts",
+                  "fileName": "generic-class.ts",
                   "line": 14,
                   "character": 20
                 }
@@ -298,7 +300,8 @@
               },
               "inheritedFrom": {
                 "type": "reference",
-                "name": "GenericClass.value"
+                "name": "GenericClass.value",
+                "id": 4
               }
             },
             {
@@ -328,7 +331,8 @@
               },
               "inheritedFrom": {
                 "type": "reference",
-                "name": "GenericClass.values"
+                "name": "GenericClass.values",
+                "id": 5
               }
             },
             {

--- a/src/test/converter/generic-function/specs.json
+++ b/src/test/converter/generic-function/specs.json
@@ -112,6 +112,7 @@
                   "id": 4,
                   "name": "T",
                   "kind": 131072,
+                  "kindString": "Type parameter",
                   "flags": {},
                   "comment": {
                     "text": "Generic function type parameter."
@@ -127,6 +128,7 @@
                   "id": 5,
                   "name": "value",
                   "kind": 32768,
+                  "kindString": "Parameter",
                   "flags": {},
                   "comment": {
                     "text": "Generic function parameter."

--- a/src/test/converter/getter-setter/specs.json
+++ b/src/test/converter/getter-setter/specs.json
@@ -45,12 +45,14 @@
               "id": 4,
               "name": "name",
               "kind": 262144,
+              "kindString": "Accessor",
               "flags": {},
               "getSignature": [
                 {
                   "id": 5,
                   "name": "__get",
                   "kind": 524288,
+                  "kindString": "Get signature",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",
@@ -86,12 +88,12 @@
               ],
               "sources": [
                 {
-                  "fileName": "%BASE%/getter-setter/getter-setter.ts",
+                  "fileName": "getter-setter.ts",
                   "line": 6,
                   "character": 12
                 },
                 {
-                  "fileName": "%BASE%/getter-setter/getter-setter.ts",
+                  "fileName": "getter-setter.ts",
                   "line": 7,
                   "character": 12
                 }

--- a/src/test/converter/implicit-types/specs.json
+++ b/src/test/converter/implicit-types/specs.json
@@ -27,12 +27,13 @@
               "id": 4,
               "name": "end",
               "kind": 1024,
+              "kindString": "Property",
               "flags": {
                 "isExported": true
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/implicit-types/implicit-types.ts",
+                  "fileName": "implicit-types.ts",
                   "line": 1,
                   "character": 54
                 }
@@ -85,12 +86,13 @@
           "id": 5,
           "name": "_breakpoints",
           "kind": 32,
+          "kindString": "Variable",
           "flags": {
             "isLet": true
           },
           "sources": [
             {
-              "fileName": "%BASE%/implicit-types/implicit-types.ts",
+              "fileName": "implicit-types.ts",
               "line": 3,
               "character": 16
             }

--- a/src/test/converter/interface-empty/specs.json
+++ b/src/test/converter/interface-empty/specs.json
@@ -28,12 +28,13 @@
               "id": 4,
               "name": "name",
               "kind": 1024,
+              "kindString": "Property",
               "flags": {
                 "isPrivate": true
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/interface-empty/interface-empty.ts",
+                  "fileName": "interface-empty.ts",
                   "line": 12,
                   "character": 16
                 }
@@ -47,6 +48,7 @@
               "id": 5,
               "name": "goto",
               "kind": 2048,
+              "kindString": "Method",
               "flags": {
                 "isPublic": true
               },
@@ -65,7 +67,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "%BASE%/interface-empty/interface-empty.ts",
+                  "fileName": "interface-empty.ts",
                   "line": 13,
                   "character": 15
                 }

--- a/src/test/converter/interface-implementation/specs.json
+++ b/src/test/converter/interface-implementation/specs.json
@@ -997,6 +997,7 @@
                   "id": 4,
                   "name": "T",
                   "kind": 131072,
+                  "kindString": "Type parameter",
                   "flags": {}
                 }
               ],
@@ -1005,6 +1006,7 @@
                   "id": 5,
                   "name": "__call",
                   "kind": 4096,
+                  "kindString": "Call signature",
                   "flags": {},
                   "comment": {
                     "shortText": "Function signature of an event listener callback"

--- a/src/test/converter/literal-object-callbacks/specs.json
+++ b/src/test/converter/literal-object-callbacks/specs.json
@@ -18,6 +18,7 @@
           "id": 4,
           "name": "onError",
           "kind": 64,
+          "kindString": "Function",
           "flags": {
             "isLet": true
           },
@@ -26,6 +27,7 @@
               "id": 5,
               "name": "onError",
               "kind": 4096,
+              "kindString": "Call signature",
               "flags": {},
               "type": {
                 "type": "intrinsic",
@@ -35,7 +37,7 @@
           ],
           "sources": [
             {
-              "fileName": "%BASE%/literal-object-callbacks/literal-object-callbacks.ts",
+              "fileName": "literal-object-callbacks.ts",
               "line": 2,
               "character": 11
             }

--- a/src/test/converter/literal-object/specs.json
+++ b/src/test/converter/literal-object/specs.json
@@ -87,12 +87,14 @@
               "id": 4,
               "name": "valueY",
               "kind": 64,
+              "kindString": "Function",
               "flags": {},
               "signatures": [
                 {
                   "id": 5,
                   "name": "valueY",
                   "kind": 4096,
+                  "kindString": "Call signature",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",
@@ -102,7 +104,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "%BASE%/literal-object/literal-object.ts",
+                  "fileName": "literal-object.ts",
                   "line": 6,
                   "character": 10
                 }

--- a/src/test/converter/literal-type/specs.json
+++ b/src/test/converter/literal-type/specs.json
@@ -283,10 +283,11 @@
                   "id": 5,
                   "name": "valueY",
                   "kind": 32,
+                  "kindString": "Variable",
                   "flags": {},
                   "sources": [
                     {
-                      "fileName": "%BASE%/literal-type/literal-type.ts",
+                      "fileName": "literal-type.ts",
                       "line": 3,
                       "character": 10
                     }
@@ -326,10 +327,11 @@
                   "id": 4,
                   "name": "valueZ",
                   "kind": 32,
+                  "kindString": "Variable",
                   "flags": {},
                   "sources": [
                     {
-                      "fileName": "%BASE%/literal-type/literal-type.ts",
+                      "fileName": "literal-type.ts",
                       "line": 2,
                       "character": 10
                     }

--- a/src/test/converter/mixin/specs.json
+++ b/src/test/converter/mixin/specs.json
@@ -51,6 +51,7 @@
               "id": 4,
               "name": "baseMethod",
               "kind": 2048,
+              "kindString": "Method",
               "flags": {
                 "isExported": true
               },
@@ -59,6 +60,7 @@
                   "id": 5,
                   "name": "baseMethod",
                   "kind": 4096,
+                  "kindString": "Call signature",
                   "flags": {},
                   "type": {
                     "type": "intrinsic",
@@ -68,7 +70,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "%BASE%/mixin/mixin.ts",
+                  "fileName": "mixin.ts",
                   "line": 11,
                   "character": 14
                 }
@@ -237,10 +239,12 @@
                     "name": "number"
                   },
                   "overwrites": {
+                    "id": 4,
                     "type": "reference",
                     "name": "Base.baseMethod"
                   },
                   "inheritedFrom": {
+                    "id": 4,
                     "type": "reference",
                     "name": "Base.baseMethod"
                   }
@@ -254,10 +258,12 @@
                 }
               ],
               "overwrites": {
+                "id": 4,
                 "type": "reference",
                 "name": "Base.baseMethod"
               },
               "inheritedFrom": {
+                "id": 4,
                 "type": "reference",
                 "name": "Base.baseMethod"
               }
@@ -583,10 +589,12 @@
                     "name": "number"
                   },
                   "overwrites": {
+                    "id": 4,
                     "type": "reference",
                     "name": "Base.baseMethod"
                   },
                   "inheritedFrom": {
+                    "id": 4,
                     "type": "reference",
                     "name": "Base.baseMethod"
                   }
@@ -600,10 +608,12 @@
                 }
               ],
               "overwrites": {
+                "id": 4,
                 "type": "reference",
                 "name": "Base.baseMethod"
               },
               "inheritedFrom": {
+                "id": 4,
                 "type": "reference",
                 "name": "Base.baseMethod"
               }
@@ -835,10 +845,12 @@
                     "name": "number"
                   },
                   "overwrites": {
+                    "id": 4,
                     "type": "reference",
                     "name": "Base.baseMethod"
                   },
                   "inheritedFrom": {
+                    "id": 4,
                     "type": "reference",
                     "name": "Base.baseMethod"
                   }
@@ -852,10 +864,12 @@
                 }
               ],
               "overwrites": {
+                "id": 4,
                 "type": "reference",
                 "name": "Base.baseMethod"
               },
               "inheritedFrom": {
+                "id": 4,
                 "type": "reference",
                 "name": "Base.baseMethod"
               }

--- a/src/test/converter/promise-object/specs.json
+++ b/src/test/converter/promise-object/specs.json
@@ -64,12 +64,13 @@
           "id": 4,
           "name": "z",
           "kind": 32,
+          "kindString": "Variable",
           "flags": {
             "isLet": true
           },
           "sources": [
             {
-              "fileName": "%BASE%/promise-object/promise-object.ts",
+              "fileName": "promise-object.ts",
               "line": 3,
               "character": 5
             }

--- a/src/test/converter/react/specs.json
+++ b/src/test/converter/react/specs.json
@@ -18,28 +18,9 @@
           "id": 5,
           "name": "Demo",
           "kind": 128,
+          "kindString": "Class",
           "flags": {},
           "children": [
-            {
-              "id": 6,
-              "name": "foo",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {
-                "isPrivate": true
-              },
-              "sources": [
-                {
-                  "fileName": "react.tsx",
-                  "line": 14,
-                  "character": 15
-                }
-              ],
-              "type": {
-                "type": "intrinsic",
-                "name": "number"
-              }
-            },
             {
               "id": 7,
               "name": "constructor",
@@ -88,6 +69,240 @@
               "overwrites": {
                 "type": "reference",
                 "name": "Component.__constructor"
+              }
+            },
+            {
+              "id": 34,
+              "name": "context",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {},
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 142,
+                  "character": 15
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "__type"
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.context"
+              }
+            },
+            {
+              "id": 6,
+              "name": "foo",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isPrivate": true
+              },
+              "sources": [
+                {
+                  "fileName": "react.tsx",
+                  "line": 14,
+                  "character": 15
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            },
+            {
+              "id": 32,
+              "name": "props",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {},
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 140,
+                  "character": 13
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "DemoProps",
+                "id": 2
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.props"
+              }
+            },
+            {
+              "id": 35,
+              "name": "refs",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {},
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 143,
+                  "character": 12
+                }
+              ],
+              "type": {
+                "type": "reflection",
+                "declaration": {
+                  "id": 36,
+                  "name": "__type",
+                  "kind": 65536,
+                  "kindString": "Type literal",
+                  "flags": {},
+                  "indexSignature": [
+                    {
+                      "id": 37,
+                      "name": "__index",
+                      "kind": 8192,
+                      "kindString": "Index signature",
+                      "flags": {},
+                      "parameters": [
+                        {
+                          "id": 38,
+                          "name": "key",
+                          "kind": 32768,
+                          "kindString": "Parameter",
+                          "flags": {},
+                          "type": {
+                            "type": "intrinsic",
+                            "name": "string"
+                          }
+                        }
+                      ],
+                      "type": {
+                        "type": "reference",
+                        "name": "Component",
+                        "typeArguments": [
+                          {
+                            "type": "intrinsic",
+                            "name": "any"
+                          },
+                          {
+                            "type": "intrinsic",
+                            "name": "any"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "sources": [
+                    {
+                      "fileName": "react.d.ts",
+                      "line": 143,
+                      "character": 13
+                    }
+                  ]
+                }
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.refs"
+              }
+            },
+            {
+              "id": 33,
+              "name": "state",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {},
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 141,
+                  "character": 13
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "any"
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.state"
+              }
+            },
+            {
+              "id": 27,
+              "name": "forceUpdate",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {},
+              "signatures": [
+                {
+                  "id": 28,
+                  "name": "forceUpdate",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "parameters": [
+                    {
+                      "id": 29,
+                      "name": "callBack",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 30,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 31,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "type": {
+                                "type": "intrinsic",
+                                "name": "any"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "react.d.ts",
+                              "line": 138,
+                              "character": 30
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Component.forceUpdate"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "react.d.ts",
+                  "line": 138,
+                  "character": 19
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Component.forceUpdate"
               }
             },
             {
@@ -334,225 +549,40 @@
                 "type": "reference",
                 "name": "Component.setState"
               }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Constructors",
+              "kind": 512,
+              "children": [
+                7
+              ]
             },
             {
-              "id": 27,
-              "name": "forceUpdate",
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                34,
+                6,
+                32,
+                35,
+                33
+              ]
+            },
+            {
+              "title": "Methods",
               "kind": 2048,
-              "kindString": "Method",
-              "flags": {},
-              "signatures": [
-                {
-                  "id": 28,
-                  "name": "forceUpdate",
-                  "kind": 4096,
-                  "kindString": "Call signature",
-                  "flags": {},
-                  "parameters": [
-                    {
-                      "id": 29,
-                      "name": "callBack",
-                      "kind": 32768,
-                      "kindString": "Parameter",
-                      "flags": {
-                        "isOptional": true
-                      },
-                      "type": {
-                        "type": "reflection",
-                        "declaration": {
-                          "id": 30,
-                          "name": "__type",
-                          "kind": 65536,
-                          "kindString": "Type literal",
-                          "flags": {},
-                          "signatures": [
-                            {
-                              "id": 31,
-                              "name": "__call",
-                              "kind": 4096,
-                              "kindString": "Call signature",
-                              "flags": {},
-                              "type": {
-                                "type": "intrinsic",
-                                "name": "any"
-                              }
-                            }
-                          ],
-                          "sources": [
-                            {
-                              "fileName": "react.d.ts",
-                              "line": 138,
-                              "character": 30
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  ],
-                  "type": {
-                    "type": "intrinsic",
-                    "name": "void"
-                  },
-                  "inheritedFrom": {
-                    "type": "reference",
-                    "name": "Component.forceUpdate"
-                  }
-                }
-              ],
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 138,
-                  "character": 19
-                }
-              ],
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.forceUpdate"
-              }
-            },
-            {
-              "id": 32,
-              "name": "props",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {},
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 140,
-                  "character": 13
-                }
-              ],
-              "type": {
-                "type": "reference",
-                "name": "DemoProps",
-                "id": 2
-              },
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.props"
-              }
-            },
-            {
-              "id": 33,
-              "name": "state",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {},
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 141,
-                  "character": 13
-                }
-              ],
-              "type": {
-                "type": "intrinsic",
-                "name": "any"
-              },
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.state"
-              }
-            },
-            {
-              "id": 34,
-              "name": "context",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {},
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 142,
-                  "character": 15
-                }
-              ],
-              "type": {
-                "type": "reference",
-                "name": "__type"
-              },
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.context"
-              }
-            },
-            {
-              "id": 35,
-              "name": "refs",
-              "kind": 1024,
-              "kindString": "Property",
-              "flags": {},
-              "sources": [
-                {
-                  "fileName": "react.d.ts",
-                  "line": 143,
-                  "character": 12
-                }
-              ],
-              "type": {
-                "type": "reflection",
-                "declaration": {
-                  "id": 36,
-                  "name": "__type",
-                  "kind": 65536,
-                  "kindString": "Type literal",
-                  "flags": {},
-                  "indexSignature": [
-                    {
-                      "id": 37,
-                      "name": "__index",
-                      "kind": 8192,
-                      "kindString": "Index signature",
-                      "flags": {},
-                      "parameters": [
-                        {
-                          "id": 38,
-                          "name": "key",
-                          "kind": 32768,
-                          "kindString": "Parameter",
-                          "flags": {},
-                          "type": {
-                            "type": "intrinsic",
-                            "name": "string"
-                          }
-                        }
-                      ],
-                      "type": {
-                        "type": "reference",
-                        "name": "Component",
-                        "typeArguments": [
-                          {
-                            "type": "intrinsic",
-                            "name": "any"
-                          },
-                          {
-                            "type": "intrinsic",
-                            "name": "any"
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "sources": [
-                    {
-                      "fileName": "react.d.ts",
-                      "line": 143,
-                      "character": 13
-                    }
-                  ]
-                }
-              },
-              "inheritedFrom": {
-                "type": "reference",
-                "name": "Component.refs"
-              }
+              "children": [
+                27,
+                10,
+                12
+              ]
             }
           ],
           "sources": [
             {
-              "fileName": "%BASE%/react/react.tsx",
+              "fileName": "react.tsx",
               "line": 12,
               "character": 10
             }
@@ -564,7 +594,8 @@
               "typeArguments": [
                 {
                   "type": "reference",
-                  "name": "DemoProps"
+                  "name": "DemoProps",
+                  "id": 2
                 },
                 {
                   "type": "intrinsic",
@@ -585,10 +616,11 @@
               "id": 4,
               "name": "age",
               "kind": 1024,
+              "kindString": "Property",
               "flags": {},
               "sources": [
                 {
-                  "fileName": "%BASE%/react/react.tsx",
+                  "fileName": "react.tsx",
                   "line": 8,
                   "character": 7
                 }

--- a/src/test/converter/this/specs.json
+++ b/src/test/converter/this/specs.json
@@ -41,6 +41,7 @@
                   "id": 4,
                   "name": "chain",
                   "kind": 4096,
+                  "kindString": "Call signature",
                   "flags": {},
                   "comment": {
                     "shortText": "Chain method that returns this."

--- a/src/test/converter/type-operator/specs.json
+++ b/src/test/converter/type-operator/specs.json
@@ -18,6 +18,7 @@
           "id": 5,
           "name": "GenericClass",
           "kind": 128,
+          "kindString": "Class",
           "flags": {
             "isExported": true
           },
@@ -68,9 +69,18 @@
               }
             }
           ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                7
+              ]
+            }
+          ],
           "sources": [
             {
-              "fileName": "%BASE%/type-operator/type-operator.ts",
+              "fileName": "type-operator.ts",
               "line": 13,
               "character": 25
             }
@@ -119,12 +129,13 @@
               "id": 4,
               "name": "b",
               "kind": 1024,
+              "kindString": "Property",
               "flags": {
                 "isExported": true
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/type-operator/type-operator.ts",
+                  "fileName": "type-operator.ts",
                   "line": 10,
                   "character": 5
                 }

--- a/src/test/converter/union-or-intersection/specs.json
+++ b/src/test/converter/union-or-intersection/specs.json
@@ -71,6 +71,7 @@
           "id": 4,
           "name": "SecondType",
           "kind": 256,
+          "kindString": "Interface",
           "flags": {
             "isExported": true
           },
@@ -82,6 +83,7 @@
               "id": 5,
               "name": "secondProperty",
               "kind": 1024,
+              "kindString": "Property",
               "flags": {
                 "isExported": true
               },
@@ -90,7 +92,7 @@
               },
               "sources": [
                 {
-                  "fileName": "%BASE%/union-or-intersection/union-or-intersection.ts",
+                  "fileName": "union-or-intersection.ts",
                   "line": 20,
                   "character": 18
                 }
@@ -101,9 +103,18 @@
               }
             }
           ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                5
+              ]
+            }
+          ],
           "sources": [
             {
-              "fileName": "%BASE%/union-or-intersection/union-or-intersection.ts",
+              "fileName": "union-or-intersection.ts",
               "line": 15,
               "character": 27
             }
@@ -160,7 +171,8 @@
                           },
                           {
                             "type": "reference",
-                            "name": "SecondType"
+                            "name": "SecondType",
+                            "id": 4
                           }
                         ]
                       }
@@ -231,7 +243,8 @@
                   },
                   {
                     "type": "reference",
-                    "name": "SecondType"
+                    "name": "SecondType",
+                    "id": 4
                   }
                 ]
               }

--- a/src/test/converter/variable/specs.json
+++ b/src/test/converter/variable/specs.json
@@ -62,12 +62,13 @@
           "id": 4,
           "name": "myVar",
           "kind": 32,
+          "kindString": "Variable",
           "flags": {
             "isExported": true
           },
           "sources": [
             {
-              "fileName": "%BASE%/variable/variable.ts",
+              "fileName": "variable.ts",
               "line": 3,
               "character": 16
             }


### PR DESCRIPTION
In the test suite, a single app is reused for all the converter tests. If the plugins do not appropriately reset their state at the start of a conversion, then one test may affect later tests.

`CommentPlugin` did not reset its `hidden` field. This caused all converter tests after the `comment` test to be messed up. In all subsequent tests, the reflections with `id` 4 and 5 were deleted from `project.reflections`. This prevented plugins that follow `CommentPlugin` from acting on reflections 4 and 5. They were still part of the reflection *tree* however, and were still output, just with incomplete or incorrect values. For instance, `kindString` was not populated by the `GroupPlugin`, and `fileName` was not trimmed by the `SourcePlugin`.

Commit 3716ba7918bce8165e864d40ebf365cded3e3ee1 incorrectly modified all the tests that were failing due to the incorrect code so that they'd conform to the incorrect output. This PR reverses most of that commit.

Closes #828.