### PR TITLE
Fix reference to deprecated handlebars type

### DIFF
--- a/src/lib/output/events.ts
+++ b/src/lib/output/events.ts
@@ -1,3 +1,4 @@
+import { TemplateDelegate } from 'handlebars';
 import * as Path from 'path';
 
 import { Event } from '../utils/events';
@@ -110,7 +111,7 @@ export class PageEvent extends Event {
     /**
      * The template that should be used to render this page.
      */
-    template?: HandlebarsTemplateDelegate;
+    template?: TemplateDelegate;
 
     /**
      * The name of the template that should be used to render this page.

--- a/src/lib/output/utils/resources/templates.ts
+++ b/src/lib/output/utils/resources/templates.ts
@@ -3,10 +3,10 @@ import * as Handlebars from 'handlebars';
 import { readFile } from '../../../utils/fs';
 import { ResourceStack, Resource } from './stack';
 
-export class Template extends Resource {
-    private template?: HandlebarsTemplateDelegate;
+export class Template<T = any> extends Resource {
+    private template?: TemplateDelegate<T>;
 
-    getTemplate(): HandlebarsTemplateDelegate {
+    getTemplate(): TemplateDelegate<T> {
         if (!this.template) {
             const raw = readFile(this.fileName);
             this.template = Handlebars.compile(raw, {

--- a/src/lib/output/utils/resources/templates.ts
+++ b/src/lib/output/utils/resources/templates.ts
@@ -4,9 +4,9 @@ import { readFile } from '../../../utils/fs';
 import { ResourceStack, Resource } from './stack';
 
 export class Template<T = any> extends Resource {
-    private template?: TemplateDelegate<T>;
+    private template?: Handlebars.TemplateDelegate<T>;
 
-    getTemplate(): TemplateDelegate<T> {
+    getTemplate(): Handlebars.TemplateDelegate<T> {
         if (!this.template) {
             const raw = readFile(this.fileName);
             this.template = Handlebars.compile(raw, {


### PR DESCRIPTION
from `handlebars.d.ts`:

```ts
// NOTE: for backward compatibility of this typing
type HandlebarsTemplateDelegate<T = any> = Handlebars.TemplateDelegate<T>;
```

turns out it's not actually backwards compatible because ~they haven't declared it as an ambient global type~ of subtle differences in type acquisition (see below). but anyway, typedoc should use the new namespaced type. I've gone ahead and done that in this PR.

unblocks https://github.com/palantir/documentalist/pull/86
cc @styu 

---

edit: more info

Another way to solve this would be with an `import "handlebars";` statement in any typedoc module which references a global handlebars symbol like `HandlebarsTemplateDelegate`. But adding import statements just for type acquisition side effects is bad.

When handlebars switched to publishing its own types, they did a straight port of `@types/handlebars`. However, the semantics for acquiring types from `node_modules/@types/handlebars` is a little different from `node_modules/handlebars`. TypeScript will automatically pull in all ambient types from `node_modules/@types` and make symbols like `HandlebarsTemplateDelegate` available, but the same is not true for types bundled in a regular npm package.

Related to this (but external to this repo), there's no need for `declare module` statements in [handlebars' types](https://github.com/wycats/handlebars.js/blob/3ce4425056998c1db921d7b6c0662b843acb593b/types/index.d.ts) anymore. The type system will acquire types from the same location as the module system, so `declare module "handlebars"` is unnecessary.