### PR TITLE
fix: the bug with the negated/commented exclude patterns

### DIFF
--- a/src/lib/utils/paths.ts
+++ b/src/lib/utils/paths.ts
@@ -3,26 +3,30 @@ import { Minimatch, IMinimatch } from 'minimatch';
 
 const unix = Path.sep === '/';
 
+function normalize(pattern: string) {
+    if (pattern.startsWith('!')) {
+        return pattern[0] + normalize(pattern.substr(1));
+    }
+
+    if (unix) { pattern = pattern.replace(/[\\]/g, '/').replace(/^\w:/, ''); }
+
+    // pattern paths not starting with '**' are resolved even if it is an
+    // absolute path, to ensure correct format for the current OS
+    if (pattern.substr(0, 2) !== '**') {
+        pattern = Path.resolve(pattern);
+    }
+
+    // On Windows we transform `\` to `/` to unify the way paths are intepreted
+    if (!unix) { pattern = pattern.replace(/[\\]/g, '/'); }
+
+    return pattern;
+}
+
 /**
  * Convert array of glob patterns to array of minimatch instances.
  *
  * Handle a few Windows-Unix path gotchas.
  */
 export function createMinimatch(patterns: string[]): IMinimatch[] {
-    return patterns.map((pattern: string): IMinimatch => {
-        // Ensure correct pathing on unix, by transforming `\` to `/` and removing any `X:/` from the path
-        if (unix) { pattern = pattern.replace(/[\\]/g, '/').replace(/^\w:/, ''); }
-
-        // pattern paths not starting with '**' are resolved even if it is an
-        // absolute path, to ensure correct format for the current OS
-        if (pattern.substr(0, 2) !== '**') {
-            pattern = Path.resolve(pattern);
-        }
-
-        // On Windows we transform `\` to `/` to unify the way paths are intepreted
-        if (!unix) { pattern = pattern.replace(/[\\]/g, '/'); }
-
-        // Unify the path slashes before creating the minimatch, for more reliable matching
-        return new Minimatch(pattern, { dot: true });
-    });
+    return patterns.map(pattern => new Minimatch(normalize(pattern), { dot: true }));
 }

--- a/src/lib/utils/paths.ts
+++ b/src/lib/utils/paths.ts
@@ -4,7 +4,7 @@ import { Minimatch, IMinimatch } from 'minimatch';
 const unix = Path.sep === '/';
 
 function normalize(pattern: string) {
-    if (pattern.startsWith('!')) {
+    if (pattern.startsWith('!') || pattern.startsWith('#')) {
         return pattern[0] + normalize(pattern.substr(1));
     }
 

--- a/src/test/utils.paths.test.ts
+++ b/src/test/utils.paths.test.ts
@@ -58,5 +58,13 @@ describe('Paths', () => {
       Assert(mm.match(absolutePath('/some/path/.dot/dir')), 'Didn\'t match .dot path');
       Assert(mm.match(absolutePath('/some/path/normal/dir')), 'Didn\'t match normal path');
     });
+
+    it('Minimatch matches negated expressions', () => {
+      const paths = ['!./some/path', '!!./some/path'];
+      const mms = createMinimatch(paths);
+
+      Assert(!mms[0].match(Path.resolve('some/path')), "Didn't match a negated expression");
+      Assert(mms[1].match(Path.resolve('some/path')), "Didn't match a doubly negated expression");
+    });
   });
 });

--- a/src/test/utils.paths.test.ts
+++ b/src/test/utils.paths.test.ts
@@ -66,5 +66,11 @@ describe('Paths', () => {
       Assert(!mms[0].match(Path.resolve('some/path')), "Didn't match a negated expression");
       Assert(mms[1].match(Path.resolve('some/path')), "Didn't match a doubly negated expression");
     });
+
+    it('Minimatch does not match commented expressions', () => {
+      const [mm] = createMinimatch(['#/some/path']);
+
+      Assert(!mm.match('#/some/path'), "Didn't match a commented expression");
+    });
   });
 });

--- a/src/test/utils.paths.test.ts
+++ b/src/test/utils.paths.test.ts
@@ -63,14 +63,14 @@ describe('Paths', () => {
       const paths = ['!./some/path', '!!./some/path'];
       const mms = createMinimatch(paths);
 
-      Assert(!mms[0].match(Path.resolve('some/path')), "Didn't match a negated expression");
+      Assert(!mms[0].match(Path.resolve('some/path')), 'Matched a negated expression');
       Assert(mms[1].match(Path.resolve('some/path')), "Didn't match a doubly negated expression");
     });
 
     it('Minimatch does not match commented expressions', () => {
       const [mm] = createMinimatch(['#/some/path']);
 
-      Assert(!mm.match('#/some/path'), "Didn't match a commented expression");
+      Assert(!mm.match('#/some/path'), 'Matched a commented expression');
     });
   });
 });


### PR DESCRIPTION
As from the [Minimatch documentation](https://github.com/isaacs/minimatch#comparisons-to-other-fnmatchglob-implementations), it should be possible to use `!` at the beginning of the pattern to negate that. Same works for `#` which can deactivate the whole pattern.

The fix adds the following possibilities for the exclude patterns:
- Patterns starting with `!` (e.g. `!src/**/api.ts`, `!/home/user/src/**/api.ts`) should exclude everything except the glob following after that.
- Patterns starting with `#` (e.g. `#src/**/api.ts`) should do nothing.
- Patterns starting with multiple `!` will be negated multiple times [accordingly](https://github.com/isaacs/minimatch#comparisons-to-other-fnmatchglob-implementations).

Fixes #1024.