### PR TITLE
Allow TraverseCallback to bail out early

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,14 @@
     "documentation",
     "generator",
     "gruntplugin"
-  ]
+  ],
+  "nyc": {
+    "extension": [
+      ".ts",
+      ".tsx"
+    ],
+    "exclude": [
+      "**/*.d.ts"
+    ]
+  }
 }

--- a/src/lib/models/reflections/container.ts
+++ b/src/lib/models/reflections/container.ts
@@ -39,7 +39,7 @@ export class ContainerReflection extends Reflection {
      * @param callback  The callback function that should be applied for each child reflection.
      */
     traverse(callback: TraverseCallback) {
-        for (const child of toArray(this.children).slice()) {
+        for (const child of toArray(this.children)) {
             if (callback(child, TraverseProperty.Children) === false) {
                 return;
             }

--- a/src/lib/models/reflections/container.ts
+++ b/src/lib/models/reflections/container.ts
@@ -2,6 +2,7 @@ import { Reflection, ReflectionKind, TraverseCallback, TraverseProperty } from '
 import { ReflectionCategory } from '../ReflectionCategory';
 import { ReflectionGroup } from '../ReflectionGroup';
 import { DeclarationReflection } from './declaration';
+import { toArray } from 'lodash';
 
 export class ContainerReflection extends Reflection {
     /**
@@ -38,10 +39,10 @@ export class ContainerReflection extends Reflection {
      * @param callback  The callback function that should be applied for each child reflection.
      */
     traverse(callback: TraverseCallback) {
-        if (this.children) {
-            this.children.slice().forEach((child: DeclarationReflection) => {
-                callback(child, TraverseProperty.Children);
-            });
+        for (const child of toArray(this.children).slice()) {
+            if (callback(child, TraverseProperty.Children) === false) {
+                return;
+            }
         }
     }
 

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -153,7 +153,7 @@ export class DeclarationReflection extends ContainerReflection implements Defaul
      * @param callback  The callback function that should be applied for each child reflection.
      */
     traverse(callback: TraverseCallback) {
-        for (const parameter of toArray(this.typeParameters).slice()) {
+        for (const parameter of toArray(this.typeParameters)) {
             if (callback(parameter, TraverseProperty.TypeParameter) === false) {
                 return;
             }
@@ -165,7 +165,7 @@ export class DeclarationReflection extends ContainerReflection implements Defaul
             }
         }
 
-        for (const signature of toArray(this.signatures).slice()) {
+        for (const signature of toArray(this.signatures)) {
             if (callback(signature, TraverseProperty.Signatures) === false) {
                 return;
             }

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -3,6 +3,7 @@ import { Type, ReflectionType } from '../types/index';
 import { ContainerReflection } from './container';
 import { SignatureReflection } from './signature';
 import { TypeParameterReflection } from './type-parameter';
+import { toArray } from 'lodash';
 
 /**
  * Stores hierarchical type data.
@@ -152,28 +153,40 @@ export class DeclarationReflection extends ContainerReflection implements Defaul
      * @param callback  The callback function that should be applied for each child reflection.
      */
     traverse(callback: TraverseCallback) {
-        if (this.typeParameters) {
-            this.typeParameters.slice().forEach((parameter) => callback(parameter, TraverseProperty.TypeParameter));
+        for (const parameter of toArray(this.typeParameters).slice()) {
+            if (callback(parameter, TraverseProperty.TypeParameter) === false) {
+                return;
+            }
         }
 
         if (this.type instanceof ReflectionType) {
-            callback(this.type.declaration, TraverseProperty.TypeLiteral);
+            if (callback(this.type.declaration, TraverseProperty.TypeLiteral) === false) {
+                return;
+            }
         }
 
-        if (this.signatures) {
-            this.signatures.slice().forEach((signature) => callback(signature, TraverseProperty.Signatures));
+        for (const signature of toArray(this.signatures).slice()) {
+            if (callback(signature, TraverseProperty.Signatures) === false) {
+                return;
+            }
         }
 
         if (this.indexSignature) {
-            callback(this.indexSignature, TraverseProperty.IndexSignature);
+            if (callback(this.indexSignature, TraverseProperty.IndexSignature) === false) {
+                return;
+            }
         }
 
         if (this.getSignature) {
-            callback(this.getSignature, TraverseProperty.GetSignature);
+            if (callback(this.getSignature, TraverseProperty.GetSignature) === false) {
+                return;
+            }
         }
 
         if (this.setSignature) {
-            callback(this.setSignature, TraverseProperty.SetSignature);
+            if (callback(this.setSignature, TraverseProperty.SetSignature) === false) {
+                return;
+            }
         }
 
         super.traverse(callback);

--- a/src/lib/models/reflections/parameter.ts
+++ b/src/lib/models/reflections/parameter.ts
@@ -19,7 +19,9 @@ export class ParameterReflection extends Reflection implements DefaultValueConta
      */
     traverse(callback: TraverseCallback) {
         if (this.type instanceof ReflectionType) {
-            callback(this.type.declaration, TraverseProperty.TypeLiteral);
+            if (callback(this.type.declaration, TraverseProperty.TypeLiteral) === false) {
+                return;
+            }
         }
 
         super.traverse(callback);

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -79,21 +79,12 @@ export class ProjectReflection extends ContainerReflection {
     }
 
     /**
-     * @param name  The name to look for. Might contain a hierarchy.
-     */
-    findReflectionByName(name: string): Reflection;
-
-    /**
-     * @param names  The name hierarchy to look for.
-     */
-    findReflectionByName(names: string[]): Reflection;
-
-    /**
      * Try to find a reflection by its name.
      *
+     * @param names The name hierarchy to look for, if a string, the name will be split on "."
      * @return The found reflection or undefined.
      */
-    findReflectionByName(arg: any): Reflection | undefined {
+    findReflectionByName(arg: string | string[]): Reflection | undefined {
         const names: string[] = Array.isArray(arg) ? arg : arg.split('.');
         const name = names.pop();
 

--- a/src/lib/models/reflections/signature.ts
+++ b/src/lib/models/reflections/signature.ts
@@ -63,13 +63,13 @@ export class SignatureReflection extends Reflection implements TypeContainer, Ty
             }
         }
 
-        for (const parameter of toArray(this.typeParameters).slice()) {
+        for (const parameter of toArray(this.typeParameters)) {
             if (callback(parameter, TraverseProperty.TypeParameter) === false) {
                 return;
             }
         }
 
-        for (const parameter of toArray(this.parameters).slice()) {
+        for (const parameter of toArray(this.parameters)) {
             if (callback(parameter, TraverseProperty.Parameters) === false) {
                 return;
             }

--- a/src/lib/models/reflections/signature.ts
+++ b/src/lib/models/reflections/signature.ts
@@ -3,6 +3,7 @@ import { Reflection, TypeContainer, TypeParameterContainer, TraverseProperty, Tr
 import { ContainerReflection } from './container';
 import { ParameterReflection } from './parameter';
 import { TypeParameterReflection } from './type-parameter';
+import { toArray } from 'lodash';
 
 export class SignatureReflection extends Reflection implements TypeContainer, TypeParameterContainer {
     parent?: ContainerReflection;
@@ -57,15 +58,21 @@ export class SignatureReflection extends Reflection implements TypeContainer, Ty
      */
     traverse(callback: TraverseCallback) {
         if (this.type instanceof ReflectionType) {
-            callback(this.type.declaration, TraverseProperty.TypeLiteral);
+            if (callback(this.type.declaration, TraverseProperty.TypeLiteral) === false) {
+                return;
+            }
         }
 
-        if (this.typeParameters) {
-            this.typeParameters.slice().forEach((parameter) => callback(parameter, TraverseProperty.TypeParameter));
+        for (const parameter of toArray(this.typeParameters).slice()) {
+            if (callback(parameter, TraverseProperty.TypeParameter) === false) {
+                return;
+            }
         }
 
-        if (this.parameters) {
-            this.parameters.slice().forEach((parameter) => callback(parameter, TraverseProperty.Parameters));
+        for (const parameter of toArray(this.parameters).slice()) {
+            if (callback(parameter, TraverseProperty.Parameters) === false) {
+                return;
+            }
         }
 
         super.traverse(callback);


### PR DESCRIPTION
It is used in `getChildByName` when searching for a reflection by name, which led to *always* searching all children, which is especially problematic for any deeply nested structures.

Improves convert time by 25% on the monaco.d.ts file in #975