### PR TITLE
Move unexported @types packages to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,12 +141,14 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/fs-extra": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
       "integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -155,26 +157,24 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
       }
     },
-    "@types/highlight.js": {
-      "version": "9.12.3",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ=="
-    },
     "@types/lodash": {
       "version": "4.14.123",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
+      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
+      "dev": true
     },
     "@types/marked": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.6.3.tgz",
-      "integrity": "sha512-XEPk/AL0lR69XFGYng1R4a+vqDKLyeQSzgBZtAxHKpauaCx8eNSYCc6pBtYhx2rNyH15d1+vfeSjepcd3s1RLA=="
+      "integrity": "sha512-XEPk/AL0lR69XFGYng1R4a+vqDKLyeQSzgBZtAxHKpauaCx8eNSYCc6pBtYhx2rNyH15d1+vfeSjepcd3s1RLA==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -196,12 +196,14 @@
     "@types/node": {
       "version": "10.5.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.8.tgz",
-      "integrity": "sha512-sWSjw+bYW/2W+1V3m8tVsm9PKJcxk3NHN7oRqNUfEdofKg0Imbdu1dQbFvLKjZQXEDXRN6IfSMACjJ7Wv4NGCQ=="
+      "integrity": "sha512-sWSjw+bYW/2W+1V3m8tVsm9PKJcxk3NHN7oRqNUfEdofKg0Imbdu1dQbFvLKjZQXEDXRN6IfSMACjJ7Wv4NGCQ==",
+      "dev": true
     },
     "@types/shelljs": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.3.tgz",
       "integrity": "sha512-miY41hqc5SkRlsZDod3heDa4OS9xv8G77EMBQuSpqq86HBn66l7F+f8y9YKm+1PIuwC8QEZVwN8YxOOG7Y67fA==",
+      "dev": true,
       "requires": {
         "@types/glob": "*",
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -30,12 +30,7 @@
     "node": ">= 6.0.0"
   },
   "dependencies": {
-    "@types/fs-extra": "^5.0.5",
-    "@types/highlight.js": "^9.12.3",
-    "@types/lodash": "^4.14.123",
-    "@types/marked": "^0.6.0",
     "@types/minimatch": "3.0.3",
-    "@types/shelljs": "^0.8.3",
     "fs-extra": "^7.0.1",
     "handlebars": "^4.1.2",
     "highlight.js": "^9.13.1",
@@ -48,8 +43,12 @@
     "typescript": "3.4.x"
   },
   "devDependencies": {
+    "@types/fs-extra": "^5.0.5",
+    "@types/lodash": "^4.14.123",
+    "@types/marked": "^0.6.0",
     "@types/mocha": "^5.2.6",
     "@types/mockery": "^1.4.29",
+    "@types/shelljs": "^0.8.3",
     "mocha": "^6.1.4",
     "mockery": "^2.1.0",
     "nyc": "^14.0.0",


### PR DESCRIPTION
I went through the generated declaration files for the build and moved any imported types which were not referenced from `dependencies` to `devDependencies`.

`@types/minimatch` is still included in `dependencies` because it is used in `./dist/lib/utils/paths.d.ts`, the other `@types` packages are used internally but their types are not reexported.

If you want to validate the changes you can search for `from '[^.]` with "Files to include" set to `./typestrong-typedoc/dist/**/*.d.ts` (or equivalent for how you opened the project) in VSCode. It gives 43 results of re-exports from TypeScript, 2 re-exports from `handlebars` (which now has its own type declarations) and 1 from `minimatch`

Closes #1010
Closes #986