### PR TITLE
Run builds in current Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: node_js
 
 node_js:
-  - 6
+  - 8
   - 10
-
+  - 12
 
 before_install:
  - npm install --global npm@


### PR DESCRIPTION
Node.js 6 "Maintenance LTS" expired in April 2019.

The [currently supported releases](https://nodejs.org/en/about/releases/) are 8, 10 and 12.