### PR TITLE
Update marked to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -171,9 +171,9 @@
       "dev": true
     },
     "@types/marked": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.6.3.tgz",
-      "integrity": "sha512-XEPk/AL0lR69XFGYng1R4a+vqDKLyeQSzgBZtAxHKpauaCx8eNSYCc6pBtYhx2rNyH15d1+vfeSjepcd3s1RLA==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.6.5.tgz",
+      "integrity": "sha512-6kBKf64aVfx93UJrcyEZ+OBM5nGv4RLsI6sR1Ar34bpgvGVRoyTgpxn4ZmtxOM5aDTAaaznYuYUH8bUX3Nk3YA==",
       "dev": true
     },
     "@types/minimatch": {
@@ -1112,9 +1112,9 @@
       }
     },
     "marked": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
-      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
     },
     "mem": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "handlebars": "^4.1.2",
     "highlight.js": "^9.13.1",
     "lodash": "^4.17.11",
-    "marked": "^0.6.2",
+    "marked": "^0.7.0",
     "minimatch": "^3.0.0",
     "progress": "^2.0.3",
     "shelljs": "^0.8.3",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/fs-extra": "^5.0.5",
     "@types/lodash": "^4.14.123",
-    "@types/marked": "^0.6.0",
+    "@types/marked": "^0.6.5",
     "@types/mocha": "^5.2.6",
     "@types/mockery": "^1.4.29",
     "@types/shelljs": "^0.8.3",


### PR DESCRIPTION
Marked 0.7.0 was recently released (https://github.com/markedjs/marked/releases/tag/v0.7.0)

I use https://github.com/palantir/documentalist and was just chasing down the dependencies that pull in the older versions of marked