### PR TITLE
Support negations in directory excludes

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -266,14 +266,19 @@ export class Application extends ChildableComponent<Application, AbstractCompone
         }
 
         const supportedFileRegex = this.options.getCompilerOptions().allowJs ? /\.[tj]sx?$/ : /\.tsx?$/;
-        function add(file: string) {
-            if (isExcluded(file.replace(/\\/g, '/'))) {
+        function add(file: string, entryPoint: boolean) {
+            const fileIsDir = FS.statSync(file).isDirectory();
+            if (fileIsDir && file.slice(-1) !== '/') {
+                file = `${file}/`;
+            }
+
+            if ((!fileIsDir || !entryPoint) && isExcluded(file.replace(/\\/g, '/'))) {
                 return;
             }
 
-            if (FS.statSync(file).isDirectory()) {
+            if (fileIsDir) {
                 FS.readdirSync(file).forEach(next => {
-                    add(Path.join(file, next));
+                    add(Path.join(file, next), false);
                 });
             } else if (supportedFileRegex.test(file)) {
                 files.push(file);
@@ -281,7 +286,7 @@ export class Application extends ChildableComponent<Application, AbstractCompone
         }
 
         inputFiles.forEach(file => {
-            add(Path.resolve(file));
+            add(Path.resolve(file), true);
         });
 
         return files;

--- a/src/test/typedoc.test.ts
+++ b/src/test/typedoc.test.ts
@@ -87,5 +87,15 @@ describe('TypeDoc', function() {
             Assert.strictEqual(expanded.includes(Path.join(inputFiles, 'access', 'access.ts')), false);
             Assert.strictEqual(expanded.includes(inputFiles), false);
         });
+
+        it('supports negations in directory excludes', function() {
+            const inputFiles = Path.join(__dirname, 'converter');
+            application.options.setValue('exclude', [ '**/!(access)/' ]);
+            const expanded = application.expandInputFiles([inputFiles]);
+
+            Assert.strictEqual(expanded.includes(Path.join(inputFiles, 'class', 'class.ts')), false);
+            Assert.strictEqual(expanded.includes(Path.join(inputFiles, 'access', 'access.ts')), true);
+            Assert.strictEqual(expanded.includes(inputFiles), false);
+        });
     });
 });


### PR DESCRIPTION
Currently it's not possible to exclude a directory from the exclude pattern with a glob negation. E.g. if `--exclude '**/!(access)/'` is given, it should match all directories, except `access`. This patch allows doing that by changing the behavior of `add` slightly, if the `file` is a directory:

- Append `/` to allow globs ending with `/` to match directories only
- Don't match the entry-point against the exclude glob, as otherwise a negated glob would prevent further traversing