### PR TITLE
Updated lodash to 4.17.15 (to avoid prototype pollution)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1044,9 +1044,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "fs-extra": "^7.0.1",
     "handlebars": "^4.1.2",
     "highlight.js": "^9.13.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "marked": "^0.7.0",
     "minimatch": "^3.0.0",
     "progress": "^2.0.3",


### PR DESCRIPTION
Actually only needs to be updated above 4.17.12 to avoid this potential issue, but may as well go to 4.17.15.