### PR TITLE
Prevent unnecessary outer directory searches

### DIFF
--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -86,7 +86,7 @@ export class PackagePlugin extends ConverterComponent {
         if (!node) {
             return;
         }
-        if (this.readmeFile && this.packageFile) {
+        if ((this.noReadmeFile || this.readmeFile) && this.packageFile) {
             return;
         }
 
@@ -95,6 +95,14 @@ export class PackagePlugin extends ConverterComponent {
         do {
             dirName = parentDir;
             if (this.visited.includes(dirName)) {
+                break;
+            }
+
+            if ((this.noReadmeFile || this.readmeFile) && this.packageFile) {
+                break;
+            }
+
+            if ((this.noReadmeFile || this.readmeFile) && this.packageFile) {
                 break;
             }
 


### PR DESCRIPTION
Fixes #645 and supersedes PR #772 

Figured I'd have a crack at getting this fix in. I ran into this particular bug trying to run typedoc on a project on my phone (shout out to Termux while I'm here, amazing Android terminal).

I've cherry-picked two relevant commits from the branch for #772, with a few adjustments:
- I dropped the changes to the specs, as they seemed unrelated to the failing test harnesses and to getting this working again. I figured I'd look further if the tests wouldn't pass, but on my computer and my phone the tests seem to pass now.
- I fixed a bug in the refactored `reachedTopDirectory` function where it seemed that the check was accidentally inversed.
- Fixed the merge issues via the cherry-picking process.

If there's any further issues with this PR, I'm happy to follow up and to try and fix them.