### PR TITLE
remove content from readme and reference guides on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 [![NPM Version](https://badge.fury.io/js/typedoc.svg)](https://badge.fury.io/js/typedoc)
 [![Chat on Gitter](https://badges.gitter.im/TypeStrong/typedoc.svg)](https://gitter.im/TypeStrong/typedoc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+## Documentation
+Visit our website for more complete documentation and example API documentation:<br>
+[https://typedoc.org](https://typedoc.org).
+
+There you can find an [installation guide](https://typedoc.org/guides/installation/) explaining
+how to use typedoc from the cli, webpack, grunt, or gulp. There are additional guides explaining
+how to extend typedoc using [plugins](https://typedoc.org/guides/plugins/) and
+[themes](https://typedoc.org/guides/themes/).
+
 ## Installation
 
 TypeDoc runs on Node.js and is available as an NPM package. You can install TypeDoc
@@ -35,48 +44,28 @@ generator. So in order to create a documentation for an entire project you simpl
 $ typedoc --out path/to/documentation/ path/to/typescript/project/
 ```
 
-### Important note
-
-Starting with version 0.2, TypeDoc no longer can predict whether files should be treated as modules
-or whether the project should be compiled into one big namespace. You must specify the `mode` argument
-in order to change the behaviour of TypeDoc.
-
 ### Arguments
 
-For a complete list of the command line arguments run `typedoc --help` or read [here](https://typedoc.org/guides/arguments/).
+For a complete list of the command line arguments run `typedoc --help` or visit [our websit](https://typedoc.org/guides/arguments/).
 
 * `--out <path/to/documentation/>`<br>
-  Specifies the location the documentation should be written to.
+  Specifies the location the documentation should be written to. Defaults to `./docs`
 * `--mode <file|modules>`<br>
-  Specifies the output mode the project is used to be compiled with.
+  Specifies the output mode the project is used to be compiled with. Required since verion 0.2.
 * `--options`<br>
-  Specify a js option file that should be loaded. If not specified TypeDoc will look for 'typedoc.js' in the current directory.
+  Specify a json option file that should be loaded. If not specified TypeDoc will look for 'typedoc.json' in the current directory.
 * `--json <path/to/output.json>`<br>
   Specifies the location and file name a json file describing the project is written to. When specified no documentation will be generated.
 * `--ignoreCompilerErrors`<br>
-  Should TypeDoc still generate documentation pages even after the compiler has returned errors?
+  Allows TypeDoc to still generate documentation pages even after the compiler has returned errors
 
 #### Source file handling
 * `--exclude <pattern>`<br>
   Exclude files by the given pattern when a path is provided as source. Supports standard minimatch patterns (see [#170](https://github.com/TypeStrong/typedoc/issues/170))
 * `--includeDeclarations`<br>
   Turn on parsing of .d.ts declaration files.
-* `--externalPattern <pattern>`<br>
-  Define a pattern for files that should be considered being external.
-* `--excludeExternals`<br>
-  Prevent externally resolved TypeScript files from being documented.
-* `--excludeNotExported`<br>
-  Prevent symbols that are not exported from being documented.
-* `--excludePrivate`<br>
-  Prevent private members from being included in the generated documentation.
-* `--excludeProtected`<br>
-  Prevent protected members from being included in the generated documentation.
 
 #### TypeScript compiler
-* `--module <commonjs, amd, system or umd>`<br>
-  Specify module code generation: "commonjs", "amd", "system" or "umd".
-* `--target <ES3, ES5, or ES6>`<br>
-  Specify ECMAScript target version: "ES3" (default), "ES5" or "ES6"
 * `--tsconfig <path/to/tsconfig.json>`<br>
   Specify a typescript config file that should be loaded. If not specified TypeDoc will look for 'tsconfig.json' in the current directory.
 
@@ -88,67 +77,12 @@ For a complete list of the command line arguments run `typedoc --help` or read [
 * `--readme <path/to/readme|none>`<br>
   Path to the readme file that should be displayed on the index page. Pass `none` to disable the index page
   and start the documentation on the globals page.
-* `--plugin`<br>
-  Specify the npm plugins that should be loaded. Omit to load all installed plugins, set to 'none' to load no plugins.
-* `--hideGenerator`<br>
-  Do not print the TypeDoc link at the end of the page.
-* `--gaID`<br>
-  Set the Google Analytics tracking ID and activate tracking code.
-* `--gaSite <site>`<br>
-  Set the site name for Google Analytics. Defaults to `auto`
-* `--entryPoint <fully.qualified.name>`<br>
-  Specifies the fully qualified name of the root symbol. Defaults to global namespace.
-* `--gitRevision <revision|branch>`<br>
-  Use specified revision or branch instead of the last revision for linking to GitHub source files.
-
-#### Content
-* `--includes <path/to/includes>`<br>
-  Specifies the location to look for included documents. One may use <code>[[include:FILENAME]]</code>
-  in comments to include documents from this location.
-
-* `--media <path/to/media>`<br>
-  Specifies the location with media files that should be copied to the output directory. In order to create
-  a link to media files use the pattern <code>media://FILENAME</code> in comments.
 
 #### Miscellaneous
 * `--version`<br>
   Display the version number of TypeDoc.
 * `--help`<br>
   Display all TypeDoc options.
-
-### Webpack
-
-There is a plugin available to run TypeDoc with Webpack created by Microsoft. You can find it on NPM:<br>
-[https://www.npmjs.com/package/typedoc-webpack-plugin](https://www.npmjs.com/package/typedoc-webpack-plugin)
-
-
-### Gulp
-
-There is a plugin available to run TypeDoc with Gulp created by Rogier Schouten. You can find it on NPM:<br>
-[https://www.npmjs.com/package/gulp-typedoc/](https://www.npmjs.com/package/gulp-typedoc/)
-
-
-### Grunt
-
-There is a plugin available to run TypeDoc with Grunt created by Bart van der Schoor. You can find it on NPM:<br>
-[https://www.npmjs.com/package/grunt-typedoc](https://www.npmjs.com/package/grunt-typedoc)
-
-## Plugins
-
-* [External Module Name](https://github.com/christopherthielen/typedoc-plugin-external-module-name) - Set the name of TypeDoc external modules
-* [Sourcefile URL](https://github.com/gdelmas/typedoc-plugin-sourcefile-url) - Set custom source file URL links
-* [Internal/External Module](https://github.com/christopherthielen/typedoc-plugin-internal-external) - Explicitly mark modules as `@internal` or `@external`
-* [Single Line Tags](https://github.com/christopherthielen/typedoc-plugin-single-line-tags) - Process certain `@tags` as single lines
-* [Localization](https://github.com/IgniteUI/typedoc-plugin-localization) - Generate documentation for different languages
-
-A list of all published Typedoc plugins can be found on NPM:<br>
-[https://www.npmjs.com/search?q=keywords:typedocplugin](https://www.npmjs.com/search?q=keywords:typedocplugin)
-
-## Advanced guides and docs
-
-Visit our homepage for advanced guides and an extensive API documentation:<br>
-[https://typedoc.org](https://typedoc.org)
-
 
 ## Contributing
 


### PR DESCRIPTION
This simplifies the project readme to only explain the basics. This also attempts to make it clear that the readme does not contain exhaustive documentation and that users (and contributors) should refer to the website.

Documentation dropped:
- Less important options
- Gulp/grunt/webpack project references
- Plugin list
- Typedoc 0.2 breaking change note