### PR TITLE
chore: update typescript dep to 3.6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,9 +194,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.5.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.8.tgz",
-      "integrity": "sha512-sWSjw+bYW/2W+1V3m8tVsm9PKJcxk3NHN7oRqNUfEdofKg0Imbdu1dQbFvLKjZQXEDXRN6IfSMACjJ7Wv4NGCQ==",
+      "version": "12.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
       "dev": true
     },
     "@types/shelljs": {
@@ -1894,9 +1894,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
     },
     "uglify-js": {
       "version": "3.5.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "progress": "^2.0.3",
     "shelljs": "^0.8.3",
     "typedoc-default-themes": "^0.6.0",
-    "typescript": "3.5.x"
+    "typescript": "3.6.x"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
@@ -49,6 +49,7 @@
     "@types/mocha": "^5.2.7",
     "@types/mockery": "^1.4.29",
     "@types/shelljs": "^0.8.5",
+    "@types/node": "^12.7.5",
     "mocha": "^6.2.0",
     "mockery": "^2.1.0",
     "nyc": "^14.1.1",


### PR DESCRIPTION
fixes #1092 
as a side node: needed to add @types/node as an explicit dev dependency, otherwise there is a conflict with IteratorResult (see also https://github.com/microsoft/TypeScript/issues/32333).

All the best,
Thanks
Simon