### PR TITLE
Add emitDeclarationOnly to ignored tsconfig options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ To compile the TypeDoc source, run `npm run build`. This will start the TypeScri
 
 #### Testing
 
-TypeDoc includes an extensive set of tests that describe its output. To validate any changes you have made, build the project and then run `npm test`. Alternatively, to rebuild with your changes and then immediately test, run `npm run build`.
+TypeDoc includes an extensive set of tests that describe its output. To validate any changes you have made, build the project and then run `npm test`. Alternatively, to rebuild with your changes and then immediately test, run `npm run build_and_test`.
 
 If you have changed the TypeDoc output, it will cause tests to fail. Once you have validated that the introduced changes were intended, run `node scripts/rebuild_specs` to update the spec files for the new output.
 

--- a/src/lib/utils/options/sources/typescript.ts
+++ b/src/lib/utils/options/sources/typescript.ts
@@ -19,7 +19,7 @@ export class TypeScriptSource extends OptionsComponent {
      * A list of all TypeScript parameters that should be ignored.
      */
     static IGNORED: string[] = [
-        'out', 'version', 'help',
+        'out', 'version', 'help', 'emitDeclarationOnly',
         'watch', 'declaration', 'declarationDir', 'declarationMap', 'mapRoot',
         'sourceMap', 'inlineSources', 'removeComments'
     ];


### PR DESCRIPTION
As mentioned by @brainkim and confirmed by @aciccarello in [issue 811](https://github.com/TypeStrong/typedoc/issues/811), specifying the `emitDeclarationOnly` option in your tsconfig file causes typedoc to fail.

This PR fixes the problem by adding `emitDeclarationOnly` to the list of ignored tsconfig options.

**Bonus**: Fixed an incorrect command specified in the `Contributors` file.