### PR TITLE
Support linking to module.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ yarn-error.log
 /typescript/
 /coverage/
 /dist/
+
+typedoc*.tgz

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -257,7 +257,7 @@ export class Application extends ChildableComponent<Application, AbstractCompone
      * @returns  The list of input files with expanded directories.
      */
     public expandInputFiles(inputFiles: string[] = []): string[] {
-        let files: string[] = [];
+        const files: string[] = [];
 
         const exclude = this.exclude ? createMinimatch(this.exclude) : [];
 

--- a/src/lib/converter/context.ts
+++ b/src/lib/converter/context.ts
@@ -227,7 +227,7 @@ export class Context {
             return;
         }
 
-        let isDeclaration = node.isDeclarationFile;
+        const isDeclaration = node.isDeclarationFile;
         if (isDeclaration) {
             const lib = this.converter.getDefaultLib();
             const isLib = node.fileName.substr(-lib.length) === lib;

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -210,7 +210,7 @@ export class Converter extends ChildableComponent<Application, ConverterComponen
     }
 
     private addNodeConverter(converter: ConverterNodeComponent<any>) {
-        for (let supports of converter.supports) {
+        for (const supports of converter.supports) {
             this.nodeConverters[supports] = converter;
         }
     }
@@ -241,7 +241,7 @@ export class Converter extends ChildableComponent<Application, ConverterComponen
     private removeNodeConverter(converter: ConverterNodeComponent<any>) {
         const converters = this.nodeConverters;
         const keys = _.keys(this.nodeConverters);
-        for (let key of keys) {
+        for (const key of keys) {
             if (converters[key] === converter) {
                 delete converters[key];
             }
@@ -333,7 +333,7 @@ export class Converter extends ChildableComponent<Application, ConverterComponen
         if (node) {
             type = type || context.getTypeAtLocation(node);
 
-            for (let converter of this.typeNodeConverters) {
+            for (const converter of this.typeNodeConverters) {
                 if (converter.supportsNode(context, node, type)) {
                     return converter.convertNode(context, node, type);
                 }
@@ -342,7 +342,7 @@ export class Converter extends ChildableComponent<Application, ConverterComponen
 
         // Run all type based type conversions
         if (type) {
-            for (let converter of this.typeTypeConverters) {
+            for (const converter of this.typeTypeConverters) {
                 if (converter.supportsType(context, type)) {
                     return converter.convertType(context, type);
                 }
@@ -420,7 +420,7 @@ export class Converter extends ChildableComponent<Application, ConverterComponen
         this.trigger(Converter.EVENT_RESOLVE_BEGIN, context);
         const project = context.project;
 
-        for (let id in project.reflections) {
+        for (const id in project.reflections) {
             if (!project.reflections.hasOwnProperty(id)) {
                 continue;
             }

--- a/src/lib/converter/factories/comment.ts
+++ b/src/lib/converter/factories/comment.ts
@@ -47,7 +47,7 @@ function isTopmostModuleDeclaration(node: ts.ModuleDeclaration): boolean {
  */
 function getRootModuleDeclaration(node: ts.ModuleDeclaration): ts.Node {
     while (node.parent && node.parent.kind === ts.SyntaxKind.ModuleDeclaration) {
-        let parent = <ts.ModuleDeclaration> node.parent;
+        const parent = <ts.ModuleDeclaration> node.parent;
         if (node.name.pos === parent.name.end + 1) {
             node = parent;
         } else {

--- a/src/lib/converter/nodes/constructor.ts
+++ b/src/lib/converter/nodes/constructor.ts
@@ -30,7 +30,7 @@ export class ConstructorConverter extends ConverterNodeComponent<ts.ConstructorD
 
         if (node.parameters && node.parameters.length) {
             const comment = method ? method.comment : createComment(node);
-            for (let parameter of node.parameters) {
+            for (const parameter of node.parameters) {
                 this.addParameterProperty(context, parameter, comment);
             }
         }

--- a/src/lib/converter/nodes/enum.ts
+++ b/src/lib/converter/nodes/enum.ts
@@ -27,7 +27,7 @@ export class EnumConverter extends ConverterNodeComponent<ts.EnumDeclaration> {
 
         context.withScope(enumeration, () => {
             if (node.members) {
-                for (let member of node.members) {
+                for (const member of node.members) {
                     this.convertMember(context, member);
                 }
             }

--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -208,7 +208,7 @@ export class CommentPlugin extends ConverterComponent {
      * @param context  The context object describing the current state the converter is in.
      */
     private onBeginResolve(context: Context) {
-        for (let id in this.comments) {
+        for (const id in this.comments) {
             if (!this.comments.hasOwnProperty(id)) {
                 continue;
             }
@@ -322,7 +322,7 @@ export class CommentPlugin extends ConverterComponent {
             CommentPlugin.removeReflection(project, reflection, deletedIds);
         });
 
-        for (let key in project.symbolMapping) {
+        for (const key in project.symbolMapping) {
             if (project.symbolMapping.hasOwnProperty(key) && deletedIds.includes(project.symbolMapping[key])) {
                 delete project.symbolMapping[key];
             }
@@ -387,14 +387,14 @@ export class CommentPlugin extends ConverterComponent {
             }
         });
 
-        let id = reflection.id;
+        const id = reflection.id;
         delete project.reflections[id];
 
         // if an array was provided, keep track of the reflections that have been deleted, otherwise clean symbol mappings
         if (deletedIds) {
             deletedIds.push(id);
         } else {
-            for (let key in project.symbolMapping) {
+            for (const key in project.symbolMapping) {
                 if (project.symbolMapping.hasOwnProperty(key) && project.symbolMapping[key] === id) {
                     delete project.symbolMapping[key];
                 }

--- a/src/lib/converter/plugins/DecoratorPlugin.ts
+++ b/src/lib/converter/plugins/DecoratorPlugin.ts
@@ -125,7 +125,7 @@ export class DecoratorPlugin extends ConverterComponent {
      * @param reflection  The reflection that is currently resolved.
      */
     private onBeginResolve(context: Context) {
-        for (let symbolID in this.usages) {
+        for (const symbolID in this.usages) {
             if (!this.usages.hasOwnProperty(symbolID)) {
                 continue;
             }

--- a/src/lib/converter/plugins/DeepCommentPlugin.ts
+++ b/src/lib/converter/plugins/DeepCommentPlugin.ts
@@ -24,7 +24,7 @@ export class DeepCommentPlugin extends ConverterComponent {
     private onBeginResolve(context: Context) {
         const project = context.project;
         let name: string;
-        for (let key in project.reflections) {
+        for (const key in project.reflections) {
             const reflection = project.reflections[key];
             if (!reflection.comment) {
                 findDeepComment(reflection);

--- a/src/lib/converter/plugins/DynamicModulePlugin.ts
+++ b/src/lib/converter/plugins/DynamicModulePlugin.ts
@@ -73,6 +73,10 @@ export class DynamicModulePlugin extends ConverterComponent {
         this.reflections.forEach((reflection) => {
             let name = reflection.name.replace(/"/g, '');
             name = name.substr(0, name.length - Path.extname(name).length);
+            //When working with declaration files, we need to strip the .d as well
+            if(context.converter.includeDeclarations && name.endsWith('.d')){
+                name = name.substr(0, name.length - '.d'.length);
+            }
             reflection.name = '"' + this.basePath.trim(name) + '"';
         });
     }

--- a/src/lib/converter/plugins/DynamicModulePlugin.ts
+++ b/src/lib/converter/plugins/DynamicModulePlugin.ts
@@ -73,8 +73,8 @@ export class DynamicModulePlugin extends ConverterComponent {
         this.reflections.forEach((reflection) => {
             let name = reflection.name.replace(/"/g, '');
             name = name.substr(0, name.length - Path.extname(name).length);
-            //When working with declaration files, we need to strip the .d as well
-            if(context.converter.includeDeclarations && name.endsWith('.d')){
+            // When working with declaration files, we need to strip the .d as well
+            if (context.converter.includeDeclarations && name.endsWith('.d')) {
                 name = name.substr(0, name.length - '.d'.length);
             }
             reflection.name = '"' + this.basePath.trim(name) + '"';

--- a/src/lib/converter/plugins/DynamicModulePlugin.ts
+++ b/src/lib/converter/plugins/DynamicModulePlugin.ts
@@ -73,10 +73,6 @@ export class DynamicModulePlugin extends ConverterComponent {
         this.reflections.forEach((reflection) => {
             let name = reflection.name.replace(/"/g, '');
             name = name.substr(0, name.length - Path.extname(name).length);
-            // When working with declaration files, we need to strip the .d as well
-            if (context.converter.includeDeclarations && name.endsWith('.d')) {
-                name = name.substr(0, name.length - '.d'.length);
-            }
             reflection.name = '"' + this.basePath.trim(name) + '"';
         });
     }

--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -58,10 +58,8 @@ export class Repository {
         this.branch = gitRevision || 'master';
         ShellJS.pushd(path);
 
-        let url: RegExpExecArray | null;
-
         for (let i = 0, c = repoLinks.length; i < c; i++) {
-            url = /(github(?:\.[a-z]+)*\.com)[:\/]([^\/]+)\/(.*)/.exec(repoLinks[i]);
+            const url = /(github(?:\.[a-z]+)*\.com)[:\/]([^\/]+)\/(.*)/.exec(repoLinks[i]);
 
             if (url) {
                 this.gitHubHostname = url[1];

--- a/src/lib/converter/plugins/GroupPlugin.ts
+++ b/src/lib/converter/plugins/GroupPlugin.ts
@@ -103,7 +103,7 @@ export class GroupPlugin extends ConverterComponent {
         function walkDirectory(directory: SourceDirectory) {
             directory.groups = GroupPlugin.getReflectionGroups(directory.getAllReflections());
 
-            for (let key in directory.directories) {
+            for (const key in directory.directories) {
                 if (!directory.directories.hasOwnProperty(key)) {
                     continue;
                 }

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -83,9 +83,9 @@ export class PackagePlugin extends ConverterComponent {
      * @param node  The node that is currently processed if available.
      */
     private onBeginDocument(context: Context, reflection: Reflection, node?: ts.SourceFile) {
-        let packageAndReadmeFound = () => (this.noReadmeFile || this.readmeFile) && this.packageFile;
-        let reachedTopDirectory = dirName => dirName === Path.resolve(Path.join(dirName, '..'));
-        let visitedDirBefore = dirName => this.visited.includes(dirName);
+        const packageAndReadmeFound = () => (this.noReadmeFile || this.readmeFile) && this.packageFile;
+        const reachedTopDirectory = dirName => dirName === Path.resolve(Path.join(dirName, '..'));
+        const visitedDirBefore = dirName => this.visited.includes(dirName);
 
         if (!node) {
             return;

--- a/src/lib/converter/types/alias.ts
+++ b/src/lib/converter/types/alias.ts
@@ -45,7 +45,7 @@ export class AliasConverter extends ConverterTypeComponent implements TypeNodeCo
             return false;
         }
 
-        let common = Math.min(symbolName.length, nodeName.length);
+        const common = Math.min(symbolName.length, nodeName.length);
         symbolName = symbolName.slice(-common);
         nodeName = nodeName.slice(-common);
 

--- a/src/lib/converter/types/reference.ts
+++ b/src/lib/converter/types/reference.ts
@@ -111,7 +111,7 @@ export class ReferenceConverter extends ConverterTypeComponent implements TypeNo
      * @returns A type reflection representing the given type literal.
      */
     private convertLiteral(context: Context, symbol: ts.Symbol, node?: ts.Node): Type | undefined {
-        for (let declaration of symbol.declarations) {
+        for (const declaration of symbol.declarations) {
             if (context.visitStack.includes(declaration)) {
                 if (declaration.kind === ts.SyntaxKind.TypeLiteral ||
                         declaration.kind === ts.SyntaxKind.ObjectLiteralExpression) {

--- a/src/lib/converter/types/this.ts
+++ b/src/lib/converter/types/this.ts
@@ -20,7 +20,7 @@ export class ThisConverter extends ConverterTypeComponent implements TypeNodeCon
      *
      * ```
      * class SomeClass { }
-     * var someValue:SomeClass;
+     * const someValue:SomeClass;
      * ```
      *
      * @param context  The context object describing the current state the converter is in.

--- a/src/lib/models/reflections/abstract.ts
+++ b/src/lib/models/reflections/abstract.ts
@@ -2,6 +2,7 @@ import { SourceReference } from '../sources/file';
 import { Type } from '../types/index';
 import { Comment } from '../comments/comment';
 import { TypeParameterReflection } from './type-parameter';
+import { splitUnquotedString } from './utils';
 
 /**
  * Holds all data models used by TypeDoc.
@@ -479,7 +480,7 @@ export abstract class Reflection {
      * @returns The found child or undefined.
      */
     getChildByName(arg: string | string[]): Reflection | undefined {
-        const names: string[] = Array.isArray(arg) ? arg : arg.split('.');
+        const names: string[] = Array.isArray(arg) ? arg : splitUnquotedString(arg, '.');
         const name = names[0];
         let result: Reflection | undefined;
 
@@ -510,7 +511,7 @@ export abstract class Reflection {
      * @return The found reflection or null.
      */
     findReflectionByName(arg: string | string[]): Reflection | undefined {
-        const names: string[] = Array.isArray(arg) ? arg : arg.split('.');
+        const names: string[] = Array.isArray(arg) ? arg : splitUnquotedString(arg, '.');
 
         const reflection = this.getChildByName(names);
         if (reflection) {

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -197,7 +197,7 @@ export class DeclarationReflection extends ContainerReflection implements Defaul
      * @deprecated Use serializers instead
      */
     toObject(): any {
-        let result = super.toObject();
+        const result = super.toObject();
 
         if (this.type) {
             result.type = this.type.toObject();

--- a/src/lib/models/reflections/index.ts
+++ b/src/lib/models/reflections/index.ts
@@ -2,6 +2,6 @@ export { Reflection, ReflectionKind, ReflectionFlag, TypeParameterContainer, Dec
 export { ContainerReflection } from './container';
 export { DeclarationReflection, DeclarationHierarchy } from './declaration';
 export { ParameterReflection } from './parameter';
-export { ProjectReflection } from './project';
+export { ProjectReflection, splitUnquotedString } from './project';
 export { SignatureReflection } from './signature';
 export { TypeParameterReflection } from './type-parameter';

--- a/src/lib/models/reflections/index.ts
+++ b/src/lib/models/reflections/index.ts
@@ -2,6 +2,7 @@ export { Reflection, ReflectionKind, ReflectionFlag, TypeParameterContainer, Dec
 export { ContainerReflection } from './container';
 export { DeclarationReflection, DeclarationHierarchy } from './declaration';
 export { ParameterReflection } from './parameter';
-export { ProjectReflection, splitUnquotedString } from './project';
+export { ProjectReflection } from './project';
 export { SignatureReflection } from './signature';
 export { TypeParameterReflection } from './type-parameter';
+export { splitUnquotedString } from './utils';

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -109,10 +109,10 @@ export class ProjectReflection extends ContainerReflection {
         return undefined;
     }
 
-    private splitUnquotedString(input: string, delimiter: string): string[]{
-      if(input.startsWith('"') && input.endsWith('"')){
+    private splitUnquotedString(input: string, delimiter: string): string[] {
+      if (input.startsWith('"') && input.endsWith('"')) {
           return [input];
-      } else{
+      } else {
           return input.split(delimiter);
       }
     }

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -85,7 +85,7 @@ export class ProjectReflection extends ContainerReflection {
      * @return The found reflection or undefined.
      */
     findReflectionByName(arg: string | string[]): Reflection | undefined {
-        const names: string[] = Array.isArray(arg) ? arg : arg.split('.');
+        const names: string[] = Array.isArray(arg) ? arg : this.splitUnquotedString(arg, '.');
         const name = names.pop();
 
         search: for (const key in this.reflections) {
@@ -107,5 +107,13 @@ export class ProjectReflection extends ContainerReflection {
         }
 
         return undefined;
+    }
+
+    private splitUnquotedString(input: string, delimiter: string): string[]{
+      if(input.startsWith('"') && input.endsWith('"')){
+          return [input];
+      } else{
+          return input.split(delimiter);
+      }
     }
 }

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -85,7 +85,7 @@ export class ProjectReflection extends ContainerReflection {
      * @return The found reflection or undefined.
      */
     findReflectionByName(arg: string | string[]): Reflection | undefined {
-        const names: string[] = Array.isArray(arg) ? arg : this.splitUnquotedString(arg, '.');
+        const names: string[] = Array.isArray(arg) ? arg : splitUnquotedString(arg, '.');
         const name = names.pop();
 
         search: for (const key in this.reflections) {
@@ -108,12 +108,24 @@ export class ProjectReflection extends ContainerReflection {
 
         return undefined;
     }
+}
 
-    private splitUnquotedString(input: string, delimiter: string): string[] {
-      if (input.startsWith('"') && input.endsWith('"')) {
-          return [input];
-      } else {
-          return input.split(delimiter);
-      }
+function splitUnquotedString(input: string, delimiter: string): string[] {
+    if (input.startsWith(delimiter)) {
+        return splitUnquotedString(input.substring(delimiter.length), delimiter);
+    }
+    if (input.startsWith('"')) {
+        // the part inside the quotes should not be split, the rest should
+        const closingQuoteIndex = input.indexOf('"', 1);
+        if (closingQuoteIndex === input.length - 1) {
+            return [input];
+        } else {
+            const remainder = input.substring(closingQuoteIndex + 1);
+            const result = [input.substring(0, closingQuoteIndex + 1)];
+            result.push.apply(result, this.splitUnquotedString(remainder, delimiter));
+            return result;
+        }
+    } else {
+        return input.split(delimiter);
     }
 }

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -110,7 +110,7 @@ export class ProjectReflection extends ContainerReflection {
     }
 }
 
-function splitUnquotedString(input: string, delimiter: string): string[] {
+export function splitUnquotedString(input: string, delimiter: string): string[] {
     if (input.startsWith(delimiter)) {
         return splitUnquotedString(input.substring(delimiter.length), delimiter);
     }

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -68,7 +68,7 @@ export class ProjectReflection extends ContainerReflection {
      */
     getReflectionsByKind(kind: ReflectionKind): Reflection[] {
         const values: Reflection[] = [];
-        for (let id in this.reflections) {
+        for (const id in this.reflections) {
             const reflection = this.reflections[id];
             if (reflection.kindOf(kind)) {
                 values.push(reflection);
@@ -88,7 +88,7 @@ export class ProjectReflection extends ContainerReflection {
         const names: string[] = Array.isArray(arg) ? arg : arg.split('.');
         const name = names.pop();
 
-        search: for (let key in this.reflections) {
+        search: for (const key in this.reflections) {
             const reflection = this.reflections[key];
             if (reflection.name !== name) {
                 continue;

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -1,6 +1,7 @@
 import { SourceFile, SourceDirectory } from '../sources/index';
 import { Reflection, ReflectionKind } from './abstract';
 import { ContainerReflection } from './container';
+import { splitUnquotedString } from './utils';
 
 /**
  * A reflection that represents the root of the project.
@@ -107,25 +108,5 @@ export class ProjectReflection extends ContainerReflection {
         }
 
         return undefined;
-    }
-}
-
-export function splitUnquotedString(input: string, delimiter: string): string[] {
-    if (input.startsWith(delimiter)) {
-        return splitUnquotedString(input.substring(delimiter.length), delimiter);
-    }
-    if (input.startsWith('"')) {
-        // the part inside the quotes should not be split, the rest should
-        const closingQuoteIndex = input.indexOf('"', 1);
-        if (closingQuoteIndex === input.length - 1) {
-            return [input];
-        } else {
-            const remainder = input.substring(closingQuoteIndex + 1);
-            const result = [input.substring(0, closingQuoteIndex + 1)];
-            result.push.apply(result, this.splitUnquotedString(remainder, delimiter));
-            return result;
-        }
-    } else {
-        return input.split(delimiter);
     }
 }

--- a/src/lib/models/reflections/utils.ts
+++ b/src/lib/models/reflections/utils.ts
@@ -1,0 +1,19 @@
+export function splitUnquotedString(input: string, delimiter: string): string[] {
+    if (input.startsWith(delimiter)) {
+        return splitUnquotedString(input.substring(delimiter.length), delimiter);
+    }
+    if (input.startsWith('"')) {
+        // the part inside the quotes should not be split, the rest should
+        const closingQuoteIndex = input.indexOf('"', 1);
+        if (closingQuoteIndex === input.length - 1) {
+            return [input];
+        } else {
+            const remainder = input.substring(closingQuoteIndex + 1);
+            const result = [input.substring(0, closingQuoteIndex + 1)];
+            result.push.apply(result, this.splitUnquotedString(remainder, delimiter));
+            return result;
+        }
+    } else {
+        return input.split(delimiter);
+    }
+}

--- a/src/lib/models/reflections/utils.ts
+++ b/src/lib/models/reflections/utils.ts
@@ -5,6 +5,10 @@ export function splitUnquotedString(input: string, delimiter: string): string[] 
     if (input.startsWith('"')) {
         // the part inside the quotes should not be split, the rest should
         const closingQuoteIndex = input.indexOf('"', 1);
+        if (closingQuoteIndex === -1) {
+            // Unmatched quotes, just split it
+            return input.split(delimiter);
+        }
         if (closingQuoteIndex === input.length - 1) {
             return [input];
         } else {

--- a/src/lib/models/sources/directory.ts
+++ b/src/lib/models/sources/directory.ts
@@ -65,7 +65,7 @@ export class SourceDirectory {
     toString(indent: string = '') {
         let res = indent + this.name;
 
-        for (let key in this.directories) {
+        for (const key in this.directories) {
             if (!this.directories.hasOwnProperty(key)) {
                 continue;
             }

--- a/src/lib/models/types/abstract.ts
+++ b/src/lib/models/types/abstract.ts
@@ -32,7 +32,7 @@ export abstract class Type {
      * @deprecated Use serializers instead
      */
     toObject(): any {
-        let result: any = {};
+        const result: any = {};
         result.type = this.type;
 
         return result;

--- a/src/test/converter/comment/comment.ts
+++ b/src/test/converter/comment/comment.ts
@@ -4,7 +4,7 @@
  * ## Some Markup
  * **with more markup**
  *
- * A example with decorators that should not parse to tag
+ * An example with decorators that should not parse to tag
  * ```
  * @myDecorator
  * @FactoryDecorator('a', 'b', 'c')

--- a/src/test/converter/comment/specs.json
+++ b/src/test/converter/comment/specs.json
@@ -24,7 +24,7 @@
           },
           "comment": {
             "shortText": "A Comment for a class",
-            "text": "## Some Markup\n**with more markup**\n\nA example with decorators that should not parse to tag\n```\n@myDecorator\n@FactoryDecorator('a', 'b', 'c')\nexport class CommentedClass {\n  myProp: string = 'myProp';\n\n  @PropDecorator() decoratedProp: string;\n\n  constructor(@ParamDecorator public param: string) { }\n\n  myMethod() { }\n}\n```",
+            "text": "## Some Markup\n**with more markup**\n\nAn example with decorators that should not parse to tag\n```\n@myDecorator\n@FactoryDecorator('a', 'b', 'c')\nexport class CommentedClass {\n  myProp: string = 'myProp';\n\n  @PropDecorator() decoratedProp: string;\n\n  constructor(@ParamDecorator public param: string) { }\n\n  myMethod() { }\n}\n```",
             "tags": [
               {
                 "tag": "deprecated",

--- a/src/test/githubplugin.test.ts
+++ b/src/test/githubplugin.test.ts
@@ -3,7 +3,7 @@ import Assert = require('assert');
 
 describe('GitHubRepository', function() {
 
-    describe('contructor', function() {
+    describe('constructor', function() {
         it('must default to github.com hostname', function() {
             let repository = new github.Repository('', '', []);
 

--- a/src/test/project.test.ts
+++ b/src/test/project.test.ts
@@ -24,5 +24,12 @@ describe('Project', function() {
             Assert.strictEqual(result[0], '"foo.d"', 'Wrong split');
             Assert.strictEqual(result[1], 'bar', 'Wrong split');
         });
+
+        it('unmachted quotes', function() {
+          result = splitUnquotedString('"foo.d', '.');
+          Assert.strictEqual(result.length, 2, 'Wrong length');
+          Assert.strictEqual(result[0], '"foo', 'Wrong split');
+          Assert.strictEqual(result[1], 'd', 'Wrong split');
+        });
     });
 });

--- a/src/test/project.test.ts
+++ b/src/test/project.test.ts
@@ -1,0 +1,28 @@
+import { splitUnquotedString } from '..';
+import Assert = require('assert');
+
+describe('Project', function() {
+    describe('splitUnquotedString', () => {
+        let result: string[] | undefined;
+
+        it('unquoted string', function() {
+            result = splitUnquotedString('foo.bar', '.');
+            Assert.strictEqual(result.length, 2, 'Wrong length');
+            Assert.strictEqual(result[0], 'foo', 'Wrong split');
+            Assert.strictEqual(result[1], 'bar', 'Wrong split');
+        });
+
+        it('quoted string', function() {
+            result = splitUnquotedString('"foo.bar"', '.');
+            Assert.strictEqual(result.length, 1, 'Wrong length');
+            Assert.strictEqual(result[0], '"foo.bar"', 'Wrong split');
+        });
+
+        it('quoted start, unquoted end', function() {
+            result = splitUnquotedString('"foo.d".bar', '.');
+            Assert.strictEqual(result.length, 2, 'Wrong length');
+            Assert.strictEqual(result[0], '"foo.d"', 'Wrong split');
+            Assert.strictEqual(result[1], 'bar', 'Wrong split');
+        });
+    });
+});


### PR DESCRIPTION
See my question on https://stackoverflow.com/q/58429798/1076463

Creating a link from `firstmodule.d.ts` file to the module `secondmodule.d.ts` is impossible:

- The name of the second module that you need to use is `"secondmodule.d"`, e.g. `{@link "secondmodule.d"}` (including the quotes)
- However, the name gets split on the `.`, so in the `ProjectReflection#findReflectionByName`, you end up comparing `"secondmodule.d"` with just `d` due to the `const names: string[] = Array.isArray(arg) ? arg : arg.split('.');` line

This proposed change strips the `.d` from the name, allowing you to use `{@link "secondmodule"}`.

Ideally I would also strip the quotes, but that causes a lot of test failures.
My proposed change seems to pass all existing tests, although it affects the json file that gets generated. This sounds like a backwards incompatible change, but no idea how strict the project is on this.

I also haven't quite figured out how to add a test for this :-(

If this PR is not accepted because you don't want to change the outputted json, can you tell me (or answer on SO) how to create that link.