### PR TITLE
Ignore tarball, which is the result of running npm pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ yarn-error.log
 /typescript/
 /coverage/
 /dist/
+
+typedoc*.tgz


### PR DESCRIPTION
When making local changes that you want to test with another project, one option is to create a tarball using `npm pack` and installing that in your other project.

This change will ensure you don't accidentally commit that tarball.