### PR TITLE
Fix #1131

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -376,12 +376,6 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
-    "arg": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
-      "dev": true
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -417,12 +411,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -1126,12 +1114,6 @@
         }
       }
     },
-    "make-error": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
-      "dev": true
-    },
     "marked": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
@@ -1757,16 +1739,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
-    "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "spawn-wrap": {
       "version": "2.0.0-beta.0",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0-beta.0.tgz",
@@ -1906,27 +1878,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
-    },
-    "ts-node": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
-      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
-      "dev": true,
-      "requires": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^3.0.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-          "dev": true
-        }
-      }
     },
     "tslib": {
       "version": "1.10.0",
@@ -2235,12 +2186,6 @@
           }
         }
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "mocha": "^6.2.2",
     "mockery": "^2.1.0",
     "nyc": "15.0.0-beta.0",
-    "ts-node": "^8.4.1",
     "tslint": "^5.20.1"
   },
   "files": [
@@ -66,7 +65,8 @@
   "scripts": {
     "pretest": "node scripts/copy_test_files.js",
     "test": "nyc --reporter=html --reporter=text-summary mocha --timeout=10000 dist/test/*.test.js",
-    "test:ts": "mocha --require ts-node/register --watch-extensions ts --timeout=10000 src/test/*.test.ts",
+    "prerebuild_specs": "npm run pretest",
+    "rebuild_specs": "node scripts/rebuild_specs.js",
     "build": "tsc --project .",
     "postbuild": "node scripts/replace_application_version.js",
     "build_and_test": "npm run build && npm run test",

--- a/scripts/rebuild_specs.js
+++ b/scripts/rebuild_specs.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const TypeDoc = require(path.join(__dirname, '..'));
+const TypeDoc = require('..');
 
 const app = new TypeDoc.Application({
     mode: 'Modules',
@@ -18,75 +18,111 @@ const app = new TypeDoc.Application({
     ],
 });
 
-const base = path.join(__dirname, '../src/test/converter');
+// Note that this uses the test files in dist, not in src, this is important since
+// when running the tests we copy the tests to dist and then convert them.
+const base = path.join(__dirname, '../dist/test/converter');
 
-fs.remove(path.join(__dirname, '../src/test/renderer/specs'))
-    .then(() => fs.readdir(base))
-    .then(dirs => {
-        // Get converter directories
-        return Promise.all(dirs.map(dir => {
-            const dirPath = path.join(base, dir);
-            return Promise.all([ dirPath, fs.stat(dirPath) ]);
-        }));
-    }).then(dirs => {
-        // Rebuild converter specs
-        return dirs.map(([ fullPath, isDir ]) => {
-            if (!isDir) return;
+/** @type {[string, () => void, () => void][]} */
+const conversions = [
+    ['specs', () => { }, () => { }],
+    ['specs-without-exported',
+        () => app.options.setValue('excludeNotExported', true),
+        () => app.options.setValue('excludeNotExported', false)
+    ],
+    ['specs-with-lump-categories',
+        () => app.options.setValue('categorizeByGroup', false),
+        () => app.options.setValue('categorizeByGroup', true)
+    ],
+];
 
-            console.log(fullPath);
-            TypeDoc.resetReflectionID();
-            const src = app.expandInputFiles([ fullPath ]);
-            const out = path.join(fullPath, 'specs.json');
-            const result = app.convert(src);
-            const data = JSON.stringify(result.toObject(), null, '  ')
-                .split(TypeDoc.normalizePath(base))
-                .join('%BASE%');
-
-            return fs.writeFile(out, data);
-        })
-    }).then(() => {
-        // Rebuild renderer example
-        const src = path.join(__dirname, '../examples/basic/src');
-        const out = path.join(__dirname, '../src/test/renderer/specs');
-
-        return fs.remove(out)
-            .then(() => app.generateDocs(app.expandInputFiles([src]), out))
-            .then(() => fs.remove(path.join(out, 'assets')))
-            .then(() => out);
-    }).then(out => {
-        // Rewrite GitHub urls
-
-        /**
-         * Avoiding sync methods here is... difficult.
-         * @param {string} base
-         * @param {string} dir
-         * @param {string[]} results
-         * @returns {string[]}
-         */
-        function getFiles(base, dir = '', results = []) {
-            const files = fs.readdirSync(path.join(base, dir));
-            for (const file of files) {
-                const relativeToBase = path.join(dir, file);
-                if (fs.statSync(path.join(base, relativeToBase)).isDirectory()) {
-                    getFiles(base, relativeToBase, results);
-                } else {
-                    results.push(relativeToBase);
-                }
+/**
+ * Rebuilds the converter specs for the provided dirs.
+ * @param {string[]} dirs
+ */
+function rebuildConverterTests(dirs) {
+    return Promise.all(dirs.map(fullPath => {
+        console.log(fullPath);
+        const src = app.expandInputFiles([fullPath]);
+        return Promise.all(conversions.map(([file, before, after]) => {
+            const out = path.join(fullPath, `${file}.json`);
+            if (fs.existsSync(out)) {
+                TypeDoc.resetReflectionID();
+                before();
+                const result = app.convert(src);
+                const data = JSON.stringify(result.toObject(), null, '  ')
+                    .split(TypeDoc.normalizePath(base))
+                    .join('%BASE%');
+                after();
+                return fs.writeFile(out.replace('dist', 'src'), data);
             }
-            return results;
-        }
+        }));
+    }));
+}
 
-        const gitHubRegExp = /https:\/\/github.com\/[A-Za-z0-9\-]+\/typedoc\/blob\/[^\/]*\/examples/g;
-        return getFiles(out).map(file => {
-            const full = path.join(out, file);
-            return fs.readFile(full, { encoding: 'utf-8' })
-                .then(text => fs.writeFile(
-                    full,
-                    text.replace(gitHubRegExp, 'https://github.com/sebastian-lenz/typedoc/blob/master/examples')
-                ));
-        });
-    })
-    .catch(reason => {
-        console.error(reason);
-        process.exit(1);
+async function rebuildRendererTest() {
+    await fs.remove(path.join(__dirname, '../src/test/renderer/specs'));
+    const src = path.join(__dirname, '../examples/basic/src');
+    const out = path.join(__dirname, '../src/test/renderer/specs');
+
+    await fs.remove(out)
+    app.generateDocs(app.expandInputFiles([src]), out)
+    await fs.remove(path.join(out, 'assets'))
+
+    /**
+     * Avoiding sync methods here is... difficult.
+     * @param {string} base
+     * @param {string} dir
+     * @param {string[]} results
+     * @returns {string[]}
+     */
+    function getFiles(base, dir = '', results = []) {
+        const files = fs.readdirSync(path.join(base, dir));
+        for (const file of files) {
+            const relativeToBase = path.join(dir, file);
+            if (fs.statSync(path.join(base, relativeToBase)).isDirectory()) {
+                getFiles(base, relativeToBase, results);
+            } else {
+                results.push(relativeToBase);
+            }
+        }
+        return results;
+    }
+
+    const gitHubRegExp = /https:\/\/github.com\/[A-Za-z0-9\-]+\/typedoc\/blob\/[^\/]*\/examples/g;
+    return getFiles(out).map(file => {
+        const full = path.join(out, file);
+        return fs.readFile(full, { encoding: 'utf-8' })
+            .then(text => fs.writeFile(
+                full,
+                text.replace(gitHubRegExp, 'https://github.com/sebastian-lenz/typedoc/blob/master/examples')
+            ));
     });
+}
+
+async function main(command = 'all', filter = '') {
+    if (!['all', 'converter', 'renderer'].includes(command)) {
+        console.error('Invalid command. Usage: node scripts/rebuild_specs.js <all|converter|renderer> [filter]');
+        throw new Error();
+    }
+
+    if (['all', 'converter'].includes(command)) {
+        const dirs = await Promise.all((await fs.readdir(base)).map(dir => {
+            const dirPath = path.join(base, dir);
+            return Promise.all([dirPath, fs.stat(dirPath)]);
+        }));
+
+        await rebuildConverterTests(dirs.filter(([fullPath, stat]) => {
+            if (!stat.isDirectory()) return false;
+            return fullPath.endsWith(filter);
+        }).map(([path]) => path));
+    }
+
+    if (['all', 'renderer'].includes(command)) {
+        await rebuildRendererTest();
+    }
+}
+
+main(process.argv[2], process.argv[3]).catch(reason => {
+    console.error(reason);
+    process.exit(1);
+});

--- a/src/lib/converter/plugins/SourcePlugin.ts
+++ b/src/lib/converter/plugins/SourcePlugin.ts
@@ -92,6 +92,7 @@ export class SourcePlugin extends ConverterComponent {
         }
         const sourceFile = node.getSourceFile();
         const fileName = sourceFile.fileName;
+        this.basePath.add(fileName);
         const file: SourceFile = this.getSourceFile(fileName, context.project);
 
         let position: ts.LineAndCharacter;

--- a/src/lib/models/types/predicate.ts
+++ b/src/lib/models/types/predicate.ts
@@ -83,7 +83,7 @@ export class PredicateType extends Type {
             ...super.toObject(),
             name: this.name,
             asserts: this.asserts,
-            targetType: this.targetType
+            targetType: this.targetType?.toObject()
         };
     }
 

--- a/src/lib/serialization/serializers/types/predicate.ts
+++ b/src/lib/serialization/serializers/types/predicate.ts
@@ -13,7 +13,7 @@ export class PredicateTypeSerializer extends TypeSerializerComponent<PredicateTy
             ...obj,
             name: type.name,
             asserts: type.asserts,
-            targetType: type.targetType
+            targetType: type.targetType ? this.owner.toObject(type.targetType) : undefined
         };
     }
 }

--- a/src/test/converter.test.ts
+++ b/src/test/converter.test.ts
@@ -89,7 +89,7 @@ describe('Converter', function() {
 
             it('matches specs', function() {
                 const specs = JSON.parse(FS.readFileSync(Path.join(path, 'specs.json')).toString());
-                let data = JSON.stringify(result!.toObject(), null, '  ');
+                let data = JSON.stringify(app.serializer.toObject(result), null, '  ');
                 data = data.split(normalizePath(base)).join('%BASE%');
 
                 compareReflections(JSON.parse(data), specs);

--- a/src/test/converter/array/array.ts
+++ b/src/test/converter/array/array.ts
@@ -1,8 +1,7 @@
 /**
  * A custom array interface.
  */
-export interface Array<T>
-{
+export interface Array<T> {
 }
 
 /**
@@ -14,3 +13,13 @@ export const complex: ((Array<string>[] | number[])[] | string)[][] = [];
  * An exported const of the custom array type.
  */
 export const custom: Array<number> = {};
+
+/**
+ * Class array class item
+ */
+export class Foo {}
+
+/**
+ * Custom list class
+ */
+export class FooList extends Array<Foo> {}

--- a/src/test/converter/array/specs.json
+++ b/src/test/converter/array/specs.json
@@ -27,7 +27,7 @@
           },
           "sources": [
             {
-              "fileName": "array.ts",
+              "fileName": "dist/test/converter/array/array.ts",
               "line": 20,
               "character": 16
             }
@@ -88,7 +88,7 @@
               },
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1215,
                   "character": 10
                 }
@@ -113,7 +113,7 @@
               },
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1385,
                   "character": 17
                 }
@@ -160,7 +160,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.iterable.d.ts",
                   "line": 60,
                   "character": 21
                 }
@@ -205,7 +205,7 @@
                           "flags": {},
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
                               "line": 95,
                               "character": 18
                             }
@@ -223,7 +223,7 @@
                           "flags": {},
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
                               "line": 96,
                               "character": 15
                             }
@@ -241,7 +241,7 @@
                           "flags": {},
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
                               "line": 97,
                               "character": 12
                             }
@@ -259,7 +259,7 @@
                           "flags": {},
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
                               "line": 98,
                               "character": 12
                             }
@@ -277,7 +277,7 @@
                           "flags": {},
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
                               "line": 99,
                               "character": 17
                             }
@@ -295,7 +295,7 @@
                           "flags": {},
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
                               "line": 100,
                               "character": 12
                             }
@@ -313,7 +313,7 @@
                           "flags": {},
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
                               "line": 101,
                               "character": 14
                             }
@@ -341,7 +341,7 @@
                       ],
                       "sources": [
                         {
-                          "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                          "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
                           "line": 94,
                           "character": 27
                         }
@@ -356,7 +356,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
                   "line": 94,
                   "character": 24
                 }
@@ -486,12 +486,12 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1237,
                   "character": 10
                 },
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1242,
                   "character": 10
                 }
@@ -577,7 +577,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
                   "line": 64,
                   "character": 14
                 }
@@ -633,7 +633,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.iterable.d.ts",
                   "line": 65,
                   "character": 11
                 }
@@ -734,7 +734,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1310,
                               "character": 21
                             }
@@ -771,7 +771,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1310,
                   "character": 9
                 }
@@ -860,7 +860,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
                   "line": 53,
                   "character": 8
                 }
@@ -985,7 +985,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1337,
                               "character": 35
                             }
@@ -1109,7 +1109,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1343,
                               "character": 22
                             }
@@ -1150,12 +1150,12 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1337,
                   "character": 10
                 },
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1343,
                   "character": 10
                 }
@@ -1291,7 +1291,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
                               "line": 31,
                               "character": 32
                             }
@@ -1415,7 +1415,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
                               "line": 32,
                               "character": 19
                             }
@@ -1459,12 +1459,12 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
                   "line": 31,
                   "character": 8
                 },
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
                   "line": 32,
                   "character": 8
                 }
@@ -1565,7 +1565,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
                               "line": 43,
                               "character": 24
                             }
@@ -1602,7 +1602,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
                   "line": 43,
                   "character": 13
                 }
@@ -1703,7 +1703,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1325,
                               "character": 23
                             }
@@ -1740,7 +1740,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1325,
                   "character": 11
                 }
@@ -1813,7 +1813,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2016.array.include.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2016.array.include.d.ts",
                   "line": 27,
                   "character": 12
                 }
@@ -1886,7 +1886,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1295,
                   "character": 11
                 }
@@ -1944,7 +1944,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1247,
                   "character": 8
                 }
@@ -1990,7 +1990,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.iterable.d.ts",
                   "line": 70,
                   "character": 8
                 }
@@ -2063,7 +2063,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1301,
                   "character": 15
                 }
@@ -2173,7 +2173,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1331,
                               "character": 22
                             }
@@ -2213,7 +2213,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1331,
                   "character": 7
                 }
@@ -2263,7 +2263,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1227,
                   "character": 7
                 }
@@ -2325,7 +2325,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1232,
                   "character": 8
                 }
@@ -2439,7 +2439,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1349,
                               "character": 22
                             }
@@ -2547,7 +2547,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1350,
                               "character": 22
                             }
@@ -2680,7 +2680,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1356,
                               "character": 25
                             }
@@ -2715,17 +2715,17 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1349,
                   "character": 10
                 },
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1350,
                   "character": 10
                 },
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1356,
                   "character": 10
                 }
@@ -2839,7 +2839,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1362,
                               "character": 27
                             }
@@ -2947,7 +2947,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1363,
                               "character": 27
                             }
@@ -3080,7 +3080,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1369,
                               "character": 30
                             }
@@ -3115,17 +3115,17 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1362,
                   "character": 15
                 },
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1363,
                   "character": 15
                 },
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1369,
                   "character": 15
                 }
@@ -3169,7 +3169,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1251,
                   "character": 11
                 }
@@ -3219,7 +3219,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1255,
                   "character": 9
                 }
@@ -3297,7 +3297,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1261,
                   "character": 9
                 }
@@ -3398,7 +3398,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1319,
                               "character": 20
                             }
@@ -3435,7 +3435,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1319,
                   "character": 8
                 }
@@ -3524,7 +3524,7 @@
                           ],
                           "sources": [
                             {
-                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                               "line": 1271,
                               "character": 20
                             }
@@ -3545,7 +3545,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1271,
                   "character": 8
                 }
@@ -3693,12 +3693,12 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1277,
                   "character": 10
                 },
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1284,
                   "character": 10
                 }
@@ -3738,7 +3738,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1223,
                   "character": 18
                 }
@@ -3778,7 +3778,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1219,
                   "character": 12
                 }
@@ -3840,7 +3840,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es5.d.ts",
                   "line": 1289,
                   "character": 11
                 }
@@ -3887,7 +3887,7 @@
               ],
               "sources": [
                 {
-                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+                  "fileName": "node_modules/typescript/lib/lib.es2015.iterable.d.ts",
                   "line": 75,
                   "character": 10
                 }
@@ -3947,7 +3947,7 @@
           ],
           "sources": [
             {
-              "fileName": "array.ts",
+              "fileName": "dist/test/converter/array/array.ts",
               "line": 25,
               "character": 20
             }
@@ -3988,7 +3988,7 @@
           ],
           "sources": [
             {
-              "fileName": "array.ts",
+              "fileName": "dist/test/converter/array/array.ts",
               "line": 4,
               "character": 22
             }
@@ -4008,7 +4008,7 @@
           },
           "sources": [
             {
-              "fileName": "array.ts",
+              "fileName": "dist/test/converter/array/array.ts",
               "line": 10,
               "character": 20
             }
@@ -4073,7 +4073,7 @@
           },
           "sources": [
             {
-              "fileName": "array.ts",
+              "fileName": "dist/test/converter/array/array.ts",
               "line": 15,
               "character": 19
             }
@@ -4118,7 +4118,7 @@
       ],
       "sources": [
         {
-          "fileName": "array.ts",
+          "fileName": "dist/test/converter/array/array.ts",
           "line": 1,
           "character": 0
         }

--- a/src/test/converter/array/specs.json
+++ b/src/test/converter/array/specs.json
@@ -15,6 +15,3958 @@
       "originalName": "%BASE%/array/array.ts",
       "children": [
         {
+          "id": 4,
+          "name": "Foo",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "Class array class item"
+          },
+          "sources": [
+            {
+              "fileName": "array.ts",
+              "line": 20,
+              "character": 16
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "name": "FooList",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "comment": {
+            "shortText": "Custom list class"
+          },
+          "indexSignature": [
+            {
+              "id": 169,
+              "name": "__index",
+              "kind": 8192,
+              "kindString": "Index signature",
+              "flags": {},
+              "comment": {
+                "shortText": "Custom list class"
+              },
+              "parameters": [
+                {
+                  "id": 170,
+                  "name": "n",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "Foo",
+                "id": 4
+              }
+            }
+          ],
+          "children": [
+            {
+              "id": 6,
+              "name": "length",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true
+              },
+              "comment": {
+                "shortText": "Gets or sets the length of the array. This is a number one higher than the highest element defined in an array."
+              },
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1215,
+                  "character": 10
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              },
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.length"
+              }
+            },
+            {
+              "id": 171,
+              "name": "Array",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isStatic": true,
+                "isExported": true
+              },
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1385,
+                  "character": 17
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "ArrayConstructor"
+              }
+            },
+            {
+              "id": 210,
+              "name": "__@iterator",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 211,
+                  "name": "__@iterator",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Iterator"
+                  },
+                  "type": {
+                    "type": "reference",
+                    "name": "IterableIterator",
+                    "typeArguments": [
+                      {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    ]
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.[Symbol.iterator]"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+                  "line": 60,
+                  "character": 21
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.[Symbol.iterator]"
+              }
+            },
+            {
+              "id": 218,
+              "name": "__@unscopables",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 219,
+                  "name": "__@unscopables",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns an object whose properties have the value 'true'\nwhen they will be absent when used in a 'with' statement."
+                  },
+                  "type": {
+                    "type": "reflection",
+                    "declaration": {
+                      "id": 220,
+                      "name": "__type",
+                      "kind": 65536,
+                      "kindString": "Type literal",
+                      "flags": {},
+                      "children": [
+                        {
+                          "id": 221,
+                          "name": "copyWithin",
+                          "kind": 32,
+                          "kindString": "Variable",
+                          "flags": {},
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "line": 95,
+                              "character": 18
+                            }
+                          ],
+                          "type": {
+                            "type": "intrinsic",
+                            "name": "boolean"
+                          }
+                        },
+                        {
+                          "id": 222,
+                          "name": "entries",
+                          "kind": 32,
+                          "kindString": "Variable",
+                          "flags": {},
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "line": 96,
+                              "character": 15
+                            }
+                          ],
+                          "type": {
+                            "type": "intrinsic",
+                            "name": "boolean"
+                          }
+                        },
+                        {
+                          "id": 223,
+                          "name": "fill",
+                          "kind": 32,
+                          "kindString": "Variable",
+                          "flags": {},
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "line": 97,
+                              "character": 12
+                            }
+                          ],
+                          "type": {
+                            "type": "intrinsic",
+                            "name": "boolean"
+                          }
+                        },
+                        {
+                          "id": 224,
+                          "name": "find",
+                          "kind": 32,
+                          "kindString": "Variable",
+                          "flags": {},
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "line": 98,
+                              "character": 12
+                            }
+                          ],
+                          "type": {
+                            "type": "intrinsic",
+                            "name": "boolean"
+                          }
+                        },
+                        {
+                          "id": 225,
+                          "name": "findIndex",
+                          "kind": 32,
+                          "kindString": "Variable",
+                          "flags": {},
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "line": 99,
+                              "character": 17
+                            }
+                          ],
+                          "type": {
+                            "type": "intrinsic",
+                            "name": "boolean"
+                          }
+                        },
+                        {
+                          "id": 226,
+                          "name": "keys",
+                          "kind": 32,
+                          "kindString": "Variable",
+                          "flags": {},
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "line": 100,
+                              "character": 12
+                            }
+                          ],
+                          "type": {
+                            "type": "intrinsic",
+                            "name": "boolean"
+                          }
+                        },
+                        {
+                          "id": 227,
+                          "name": "values",
+                          "kind": 32,
+                          "kindString": "Variable",
+                          "flags": {},
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                              "line": 101,
+                              "character": 14
+                            }
+                          ],
+                          "type": {
+                            "type": "intrinsic",
+                            "name": "boolean"
+                          }
+                        }
+                      ],
+                      "groups": [
+                        {
+                          "title": "Variables",
+                          "kind": 32,
+                          "children": [
+                            221,
+                            222,
+                            223,
+                            224,
+                            225,
+                            226,
+                            227
+                          ]
+                        }
+                      ],
+                      "sources": [
+                        {
+                          "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                          "line": 94,
+                          "character": 27
+                        }
+                      ]
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.[Symbol.unscopables]"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+                  "line": 94,
+                  "character": 24
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.[Symbol.unscopables]"
+              }
+            },
+            {
+              "id": 16,
+              "name": "concat",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 17,
+                  "name": "concat",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Combines two or more arrays."
+                  },
+                  "parameters": [
+                    {
+                      "id": 18,
+                      "name": "items",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isRest": true
+                      },
+                      "comment": {
+                        "text": "Additional items to add to the end of array1.\n"
+                      },
+                      "type": {
+                        "type": "array",
+                        "elementType": {
+                          "type": "reference",
+                          "name": "ConcatArray",
+                          "typeArguments": [
+                            {
+                              "type": "reference",
+                              "name": "Foo",
+                              "id": 4
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "reference",
+                      "name": "Foo",
+                      "id": 4
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.concat"
+                  }
+                },
+                {
+                  "id": 19,
+                  "name": "concat",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Combines two or more arrays."
+                  },
+                  "parameters": [
+                    {
+                      "id": 20,
+                      "name": "items",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isRest": true
+                      },
+                      "comment": {
+                        "text": "Additional items to add to the end of array1.\n"
+                      },
+                      "type": {
+                        "type": "array",
+                        "elementType": {
+                          "type": "union",
+                          "types": [
+                            {
+                              "type": "unknown",
+                              "name": "T"
+                            },
+                            {
+                              "type": "reference",
+                              "name": "ConcatArray",
+                              "typeArguments": [
+                                {
+                                  "type": "unknown",
+                                  "name": "T"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "reference",
+                      "name": "Foo",
+                      "id": 4
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.concat"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1237,
+                  "character": 10
+                },
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1242,
+                  "character": 10
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.concat"
+              }
+            },
+            {
+              "id": 205,
+              "name": "copyWithin",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 206,
+                  "name": "copyWithin",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns the this object after copying a section of the array identified by start and end\nto the same array starting at position target"
+                  },
+                  "parameters": [
+                    {
+                      "id": 207,
+                      "name": "target",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "If target is negative, it is treated as length+target where length is the\nlength of the array."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 208,
+                      "name": "start",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "If start is negative, it is treated as length+start. If end is negative, it\nis treated as length+end."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 209,
+                      "name": "end",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "If not specified, length of the this object is used as its default value.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "this"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.copyWithin"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "line": 64,
+                  "character": 14
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.copyWithin"
+              }
+            },
+            {
+              "id": 212,
+              "name": "entries",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 213,
+                  "name": "entries",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns an iterable of key, value pairs for every entry in the array"
+                  },
+                  "type": {
+                    "type": "reference",
+                    "name": "IterableIterator",
+                    "typeArguments": [
+                      {
+                        "type": "tuple",
+                        "elements": [
+                          {
+                            "type": "intrinsic",
+                            "name": "number"
+                          },
+                          {
+                            "type": "reference",
+                            "name": "Foo",
+                            "id": 4
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.entries"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+                  "line": 65,
+                  "character": 11
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.entries"
+              }
+            },
+            {
+              "id": 58,
+              "name": "every",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 59,
+                  "name": "every",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Determines whether all the members of an array satisfy the specified test."
+                  },
+                  "parameters": [
+                    {
+                      "id": 60,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to three arguments. The every method calls\nthe callbackfn function for each element in the array until the callbackfn returns a value\nwhich is coercible to the Boolean value false, or until the end of the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 61,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 62,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 63,
+                                  "name": "value",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 64,
+                                  "name": "index",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 65,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "intrinsic",
+                                "name": "unknown"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1310,
+                              "character": 21
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 66,
+                      "name": "thisArg",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "An object to which the this keyword can refer in the callbackfn function.\nIf thisArg is omitted, undefined is used as the this value.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "boolean"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.every"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1310,
+                  "character": 9
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.every"
+              }
+            },
+            {
+              "id": 200,
+              "name": "fill",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 201,
+                  "name": "fill",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns the this object after filling the section identified by start and end with value"
+                  },
+                  "parameters": [
+                    {
+                      "id": 202,
+                      "name": "value",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "value to fill array section with"
+                      },
+                      "type": {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    },
+                    {
+                      "id": 203,
+                      "name": "start",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "index to start filling the array at. If start is negative, it is treated as\nlength+start where length is the length of the array."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 204,
+                      "name": "end",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "index to stop filling the array at. If end is negative, it is treated as\nlength+end.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "this"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.fill"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "line": 53,
+                  "character": 8
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.fill"
+              }
+            },
+            {
+              "id": 95,
+              "name": "filter",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 96,
+                  "name": "filter",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns the elements of an array that meet the condition specified in a callback function."
+                  },
+                  "typeParameter": [
+                    {
+                      "id": 97,
+                      "name": "S",
+                      "kind": 131072,
+                      "kindString": "Type parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    }
+                  ],
+                  "parameters": [
+                    {
+                      "id": 98,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 99,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 100,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 101,
+                                  "name": "value",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 102,
+                                  "name": "index",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 103,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "predicate",
+                                "name": "value",
+                                "asserts": false,
+                                "targetType": {
+                                  "type": "typeParameter",
+                                  "name": "S",
+                                  "constraint": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1337,
+                              "character": 35
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 104,
+                      "name": "thisArg",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "typeParameter",
+                      "name": "S",
+                      "constraint": {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.filter"
+                  }
+                },
+                {
+                  "id": 105,
+                  "name": "filter",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns the elements of an array that meet the condition specified in a callback function."
+                  },
+                  "parameters": [
+                    {
+                      "id": 106,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 107,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 108,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 109,
+                                  "name": "value",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 110,
+                                  "name": "index",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 111,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "intrinsic",
+                                "name": "unknown"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1343,
+                              "character": 22
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 112,
+                      "name": "thisArg",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "reference",
+                      "name": "Foo",
+                      "id": 4
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.filter"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1337,
+                  "character": 10
+                },
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1343,
+                  "character": 10
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.filter"
+              }
+            },
+            {
+              "id": 172,
+              "name": "find",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 173,
+                  "name": "find",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns the value of the first element in the array where predicate is true, and undefined\notherwise."
+                  },
+                  "typeParameter": [
+                    {
+                      "id": 174,
+                      "name": "S",
+                      "kind": 131072,
+                      "kindString": "Type parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    }
+                  ],
+                  "parameters": [
+                    {
+                      "id": 175,
+                      "name": "predicate",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "find calls predicate once for each element of the array, in ascending\norder, until it finds one where predicate returns true. If such an element is found, find\nimmediately returns that element value. Otherwise, find returns undefined."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 176,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 177,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 178,
+                                  "name": "this",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "void"
+                                  }
+                                },
+                                {
+                                  "id": 179,
+                                  "name": "value",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 180,
+                                  "name": "index",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 181,
+                                  "name": "obj",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "predicate",
+                                "name": "value",
+                                "asserts": false,
+                                "targetType": {
+                                  "type": "typeParameter",
+                                  "name": "S",
+                                  "constraint": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                              "line": 31,
+                              "character": 32
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 182,
+                      "name": "thisArg",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "If provided, it will be used as the this value for each invocation of\npredicate. If it is not provided, undefined is used instead.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "union",
+                    "types": [
+                      {
+                        "type": "typeParameter",
+                        "name": "S",
+                        "constraint": {
+                          "type": "reference",
+                          "name": "Foo",
+                          "id": 4
+                        }
+                      },
+                      {
+                        "type": "intrinsic",
+                        "name": "undefined"
+                      }
+                    ]
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.find"
+                  }
+                },
+                {
+                  "id": 183,
+                  "name": "find",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "parameters": [
+                    {
+                      "id": 184,
+                      "name": "predicate",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 185,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 186,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 187,
+                                  "name": "value",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 188,
+                                  "name": "index",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 189,
+                                  "name": "obj",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "intrinsic",
+                                "name": "unknown"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                              "line": 32,
+                              "character": 19
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 190,
+                      "name": "thisArg",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "union",
+                    "types": [
+                      {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      },
+                      {
+                        "type": "intrinsic",
+                        "name": "undefined"
+                      }
+                    ]
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.find"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "line": 31,
+                  "character": 8
+                },
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "line": 32,
+                  "character": 8
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.find"
+              }
+            },
+            {
+              "id": 191,
+              "name": "findIndex",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 192,
+                  "name": "findIndex",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns the index of the first element in the array where predicate is true, and -1\notherwise."
+                  },
+                  "parameters": [
+                    {
+                      "id": 193,
+                      "name": "predicate",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "find calls predicate once for each element of the array, in ascending\norder, until it finds one where predicate returns true. If such an element is found,\nfindIndex immediately returns that element index. Otherwise, findIndex returns -1."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 194,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 195,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 196,
+                                  "name": "value",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 197,
+                                  "name": "index",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 198,
+                                  "name": "obj",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "intrinsic",
+                                "name": "unknown"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                              "line": 43,
+                              "character": 24
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 199,
+                      "name": "thisArg",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "If provided, it will be used as the this value for each invocation of\npredicate. If it is not provided, undefined is used instead.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.findIndex"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.core.d.ts",
+                  "line": 43,
+                  "character": 13
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.findIndex"
+              }
+            },
+            {
+              "id": 76,
+              "name": "forEach",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 77,
+                  "name": "forEach",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Performs the specified action for each element in an array."
+                  },
+                  "parameters": [
+                    {
+                      "id": 78,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 79,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 80,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 81,
+                                  "name": "value",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 82,
+                                  "name": "index",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 83,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "intrinsic",
+                                "name": "void"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1325,
+                              "character": 23
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 84,
+                      "name": "thisArg",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "void"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.forEach"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1325,
+                  "character": 11
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.forEach"
+              }
+            },
+            {
+              "id": 228,
+              "name": "includes",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 229,
+                  "name": "includes",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Determines whether an array includes a certain element, returning true or false as appropriate."
+                  },
+                  "parameters": [
+                    {
+                      "id": 230,
+                      "name": "searchElement",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The element to search for."
+                      },
+                      "type": {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    },
+                    {
+                      "id": 231,
+                      "name": "fromIndex",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "The position in this array at which to begin searching for searchElement.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "boolean"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.includes"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2016.array.include.d.ts",
+                  "line": 27,
+                  "character": 12
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.includes"
+              }
+            },
+            {
+              "id": 50,
+              "name": "indexOf",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 51,
+                  "name": "indexOf",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns the index of the first occurrence of a value in an array."
+                  },
+                  "parameters": [
+                    {
+                      "id": 52,
+                      "name": "searchElement",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The value to locate in the array."
+                      },
+                      "type": {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    },
+                    {
+                      "id": 53,
+                      "name": "fromIndex",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.indexOf"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1295,
+                  "character": 11
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.indexOf"
+              }
+            },
+            {
+              "id": 21,
+              "name": "join",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 22,
+                  "name": "join",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Adds all the elements of an array separated by the specified separator string."
+                  },
+                  "parameters": [
+                    {
+                      "id": 23,
+                      "name": "separator",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "string"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "string"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.join"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1247,
+                  "character": 8
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.join"
+              }
+            },
+            {
+              "id": 214,
+              "name": "keys",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 215,
+                  "name": "keys",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns an iterable of keys in the array"
+                  },
+                  "type": {
+                    "type": "reference",
+                    "name": "IterableIterator",
+                    "typeArguments": [
+                      {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    ]
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.keys"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+                  "line": 70,
+                  "character": 8
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.keys"
+              }
+            },
+            {
+              "id": 54,
+              "name": "lastIndexOf",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 55,
+                  "name": "lastIndexOf",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns the index of the last occurrence of a specified value in an array."
+                  },
+                  "parameters": [
+                    {
+                      "id": 56,
+                      "name": "searchElement",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The value to locate in the array."
+                      },
+                      "type": {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    },
+                    {
+                      "id": 57,
+                      "name": "fromIndex",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.lastIndexOf"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1301,
+                  "character": 15
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.lastIndexOf"
+              }
+            },
+            {
+              "id": 85,
+              "name": "map",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 86,
+                  "name": "map",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Calls a defined callback function on each element of an array, and returns an array that contains the results."
+                  },
+                  "typeParameter": [
+                    {
+                      "id": 87,
+                      "name": "U",
+                      "kind": 131072,
+                      "kindString": "Type parameter",
+                      "flags": {}
+                    }
+                  ],
+                  "parameters": [
+                    {
+                      "id": 88,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 89,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 90,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 91,
+                                  "name": "value",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 92,
+                                  "name": "index",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 93,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "typeParameter",
+                                "name": "U"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1331,
+                              "character": 22
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 94,
+                      "name": "thisArg",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "typeParameter",
+                      "name": "U"
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.map"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1331,
+                  "character": 7
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.map"
+              }
+            },
+            {
+              "id": 11,
+              "name": "pop",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 12,
+                  "name": "pop",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Removes the last element from an array and returns it."
+                  },
+                  "type": {
+                    "type": "union",
+                    "types": [
+                      {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      },
+                      {
+                        "type": "intrinsic",
+                        "name": "undefined"
+                      }
+                    ]
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.pop"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1227,
+                  "character": 7
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.pop"
+              }
+            },
+            {
+              "id": 13,
+              "name": "push",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 14,
+                  "name": "push",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Appends new elements to an array, and returns the new length of the array."
+                  },
+                  "parameters": [
+                    {
+                      "id": 15,
+                      "name": "items",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isRest": true
+                      },
+                      "comment": {
+                        "text": "New elements of the Array.\n"
+                      },
+                      "type": {
+                        "type": "array",
+                        "elementType": {
+                          "type": "reference",
+                          "name": "Foo",
+                          "id": 4
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.push"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1232,
+                  "character": 8
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.push"
+              }
+            },
+            {
+              "id": 113,
+              "name": "reduce",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 114,
+                  "name": "reduce",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
+                  },
+                  "parameters": [
+                    {
+                      "id": 115,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 116,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 117,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 118,
+                                  "name": "previousValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 119,
+                                  "name": "currentValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 120,
+                                  "name": "currentIndex",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 121,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "reference",
+                                "name": "Foo",
+                                "id": 4
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1349,
+                              "character": 22
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "reference",
+                    "name": "Foo",
+                    "id": 4
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.reduce"
+                  }
+                },
+                {
+                  "id": 122,
+                  "name": "reduce",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "parameters": [
+                    {
+                      "id": 123,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 124,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 125,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 126,
+                                  "name": "previousValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 127,
+                                  "name": "currentValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 128,
+                                  "name": "currentIndex",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 129,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "reference",
+                                "name": "Foo",
+                                "id": 4
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1350,
+                              "character": 22
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 130,
+                      "name": "initialValue",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "reference",
+                    "name": "Foo",
+                    "id": 4
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.reduce"
+                  }
+                },
+                {
+                  "id": 131,
+                  "name": "reduce",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
+                  },
+                  "typeParameter": [
+                    {
+                      "id": 132,
+                      "name": "U",
+                      "kind": 131072,
+                      "kindString": "Type parameter",
+                      "flags": {}
+                    }
+                  ],
+                  "parameters": [
+                    {
+                      "id": 133,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 134,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 135,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 136,
+                                  "name": "previousValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "typeParameter",
+                                    "name": "U"
+                                  }
+                                },
+                                {
+                                  "id": 137,
+                                  "name": "currentValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 138,
+                                  "name": "currentIndex",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 139,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "typeParameter",
+                                "name": "U"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1356,
+                              "character": 25
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 140,
+                      "name": "initialValue",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.\n"
+                      },
+                      "type": {
+                        "type": "typeParameter",
+                        "name": "U"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "typeParameter",
+                    "name": "U"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.reduce"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1349,
+                  "character": 10
+                },
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1350,
+                  "character": 10
+                },
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1356,
+                  "character": 10
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.reduce"
+              }
+            },
+            {
+              "id": 141,
+              "name": "reduceRight",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 142,
+                  "name": "reduceRight",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
+                  },
+                  "parameters": [
+                    {
+                      "id": 143,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 144,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 145,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 146,
+                                  "name": "previousValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 147,
+                                  "name": "currentValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 148,
+                                  "name": "currentIndex",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 149,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "reference",
+                                "name": "Foo",
+                                "id": 4
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1362,
+                              "character": 27
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "reference",
+                    "name": "Foo",
+                    "id": 4
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.reduceRight"
+                  }
+                },
+                {
+                  "id": 150,
+                  "name": "reduceRight",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "parameters": [
+                    {
+                      "id": 151,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 152,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 153,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 154,
+                                  "name": "previousValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 155,
+                                  "name": "currentValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 156,
+                                  "name": "currentIndex",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 157,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "reference",
+                                "name": "Foo",
+                                "id": 4
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1363,
+                              "character": 27
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 158,
+                      "name": "initialValue",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "type": {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "reference",
+                    "name": "Foo",
+                    "id": 4
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.reduceRight"
+                  }
+                },
+                {
+                  "id": 159,
+                  "name": "reduceRight",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
+                  },
+                  "typeParameter": [
+                    {
+                      "id": 160,
+                      "name": "U",
+                      "kind": 131072,
+                      "kindString": "Type parameter",
+                      "flags": {}
+                    }
+                  ],
+                  "parameters": [
+                    {
+                      "id": 161,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 162,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 163,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 164,
+                                  "name": "previousValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "typeParameter",
+                                    "name": "U"
+                                  }
+                                },
+                                {
+                                  "id": 165,
+                                  "name": "currentValue",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 166,
+                                  "name": "currentIndex",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 167,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "typeParameter",
+                                "name": "U"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1369,
+                              "character": 30
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 168,
+                      "name": "initialValue",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.\n"
+                      },
+                      "type": {
+                        "type": "typeParameter",
+                        "name": "U"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "typeParameter",
+                    "name": "U"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.reduceRight"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1362,
+                  "character": 15
+                },
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1363,
+                  "character": 15
+                },
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1369,
+                  "character": 15
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.reduceRight"
+              }
+            },
+            {
+              "id": 24,
+              "name": "reverse",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 25,
+                  "name": "reverse",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Reverses the elements in an Array."
+                  },
+                  "type": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "reference",
+                      "name": "Foo",
+                      "id": 4
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.reverse"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1251,
+                  "character": 11
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.reverse"
+              }
+            },
+            {
+              "id": 26,
+              "name": "shift",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 27,
+                  "name": "shift",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Removes the first element from an array and returns it."
+                  },
+                  "type": {
+                    "type": "union",
+                    "types": [
+                      {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      },
+                      {
+                        "type": "intrinsic",
+                        "name": "undefined"
+                      }
+                    ]
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.shift"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1255,
+                  "character": 9
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.shift"
+              }
+            },
+            {
+              "id": 28,
+              "name": "slice",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 29,
+                  "name": "slice",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns a section of an array."
+                  },
+                  "parameters": [
+                    {
+                      "id": 30,
+                      "name": "start",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "The beginning of the specified portion of the array."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 31,
+                      "name": "end",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "The end of the specified portion of the array. This is exclusive of the element at the index 'end'.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "reference",
+                      "name": "Foo",
+                      "id": 4
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.slice"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1261,
+                  "character": 9
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.slice"
+              }
+            },
+            {
+              "id": 67,
+              "name": "some",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 68,
+                  "name": "some",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Determines whether the specified callback function returns true for any element of an array."
+                  },
+                  "parameters": [
+                    {
+                      "id": 69,
+                      "name": "callbackfn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "A function that accepts up to three arguments. The some method calls\nthe callbackfn function for each element in the array until the callbackfn returns a value\nwhich is coercible to the Boolean value true, or until the end of the array."
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 70,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 71,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 72,
+                                  "name": "value",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 73,
+                                  "name": "index",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "intrinsic",
+                                    "name": "number"
+                                  }
+                                },
+                                {
+                                  "id": 74,
+                                  "name": "array",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "array",
+                                    "elementType": {
+                                      "type": "reference",
+                                      "name": "Foo",
+                                      "id": 4
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "intrinsic",
+                                "name": "unknown"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1319,
+                              "character": 20
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": 75,
+                      "name": "thisArg",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "An object to which the this keyword can refer in the callbackfn function.\nIf thisArg is omitted, undefined is used as the this value.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "boolean"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.some"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1319,
+                  "character": 8
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.some"
+              }
+            },
+            {
+              "id": 32,
+              "name": "sort",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 33,
+                  "name": "sort",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Sorts an array."
+                  },
+                  "parameters": [
+                    {
+                      "id": 34,
+                      "name": "compareFn",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "Function used to determine the order of the elements. It is expected to return\na negative value if first argument is less than second argument, zero if they're equal and a positive\nvalue otherwise. If omitted, the elements are sorted in ascending, ASCII character order.\n```ts\n[11,2,22,1].sort((a, b) => a - b)\n```\n"
+                      },
+                      "type": {
+                        "type": "reflection",
+                        "declaration": {
+                          "id": 35,
+                          "name": "__type",
+                          "kind": 65536,
+                          "kindString": "Type literal",
+                          "flags": {},
+                          "signatures": [
+                            {
+                              "id": 36,
+                              "name": "__call",
+                              "kind": 4096,
+                              "kindString": "Call signature",
+                              "flags": {},
+                              "parameters": [
+                                {
+                                  "id": 37,
+                                  "name": "a",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                },
+                                {
+                                  "id": 38,
+                                  "name": "b",
+                                  "kind": 32768,
+                                  "kindString": "Parameter",
+                                  "flags": {},
+                                  "type": {
+                                    "type": "reference",
+                                    "name": "Foo",
+                                    "id": 4
+                                  }
+                                }
+                              ],
+                              "type": {
+                                "type": "intrinsic",
+                                "name": "number"
+                              }
+                            }
+                          ],
+                          "sources": [
+                            {
+                              "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                              "line": 1271,
+                              "character": 20
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "this"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.sort"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1271,
+                  "character": 8
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.sort"
+              }
+            },
+            {
+              "id": 39,
+              "name": "splice",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 40,
+                  "name": "splice",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements."
+                  },
+                  "parameters": [
+                    {
+                      "id": 41,
+                      "name": "start",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The zero-based location in the array from which to start removing elements."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 42,
+                      "name": "deleteCount",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isOptional": true
+                      },
+                      "comment": {
+                        "text": "The number of elements to remove.\n"
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "reference",
+                      "name": "Foo",
+                      "id": 4
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.splice"
+                  }
+                },
+                {
+                  "id": 43,
+                  "name": "splice",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements."
+                  },
+                  "parameters": [
+                    {
+                      "id": 44,
+                      "name": "start",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The zero-based location in the array from which to start removing elements."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 45,
+                      "name": "deleteCount",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {},
+                      "comment": {
+                        "text": "The number of elements to remove."
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "number"
+                      }
+                    },
+                    {
+                      "id": 46,
+                      "name": "items",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isRest": true
+                      },
+                      "comment": {
+                        "text": "Elements to insert into the array in place of the deleted elements.\n"
+                      },
+                      "type": {
+                        "type": "array",
+                        "elementType": {
+                          "type": "reference",
+                          "name": "Foo",
+                          "id": 4
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "reference",
+                      "name": "Foo",
+                      "id": 4
+                    }
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.splice"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1277,
+                  "character": 10
+                },
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1284,
+                  "character": 10
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.splice"
+              }
+            },
+            {
+              "id": 9,
+              "name": "toLocaleString",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 10,
+                  "name": "toLocaleString",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns a string representation of an array. The elements are converted to string using their toLocalString methods."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "string"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.toLocaleString"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1223,
+                  "character": 18
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.toLocaleString"
+              }
+            },
+            {
+              "id": 7,
+              "name": "toString",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 8,
+                  "name": "toString",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns a string representation of an array."
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "string"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.toString"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1219,
+                  "character": 12
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.toString"
+              }
+            },
+            {
+              "id": 47,
+              "name": "unshift",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 48,
+                  "name": "unshift",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Inserts new elements at the start of an array."
+                  },
+                  "parameters": [
+                    {
+                      "id": 49,
+                      "name": "items",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isRest": true
+                      },
+                      "comment": {
+                        "text": "Elements to insert at the start of the Array.\n"
+                      },
+                      "type": {
+                        "type": "array",
+                        "elementType": {
+                          "type": "reference",
+                          "name": "Foo",
+                          "id": 4
+                        }
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.unshift"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es5.d.ts",
+                  "line": 1289,
+                  "character": 11
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.unshift"
+              }
+            },
+            {
+              "id": 216,
+              "name": "values",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 217,
+                  "name": "values",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {},
+                  "comment": {
+                    "shortText": "Returns an iterable of values in the array"
+                  },
+                  "type": {
+                    "type": "reference",
+                    "name": "IterableIterator",
+                    "typeArguments": [
+                      {
+                        "type": "reference",
+                        "name": "Foo",
+                        "id": 4
+                      }
+                    ]
+                  },
+                  "inheritedFrom": {
+                    "type": "reference",
+                    "name": "Array.values"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "C:/Users/Gerrit/Documents/GitHub/typestrong-typedoc/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+                  "line": 75,
+                  "character": 10
+                }
+              ],
+              "inheritedFrom": {
+                "type": "reference",
+                "name": "Array.values"
+              }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                6,
+                171
+              ]
+            },
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                210,
+                218,
+                16,
+                205,
+                212,
+                58,
+                200,
+                95,
+                172,
+                191,
+                76,
+                228,
+                50,
+                21,
+                214,
+                54,
+                85,
+                11,
+                13,
+                113,
+                141,
+                24,
+                26,
+                28,
+                67,
+                32,
+                39,
+                9,
+                7,
+                47,
+                216
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "array.ts",
+              "line": 25,
+              "character": 20
+            }
+          ],
+          "extendedTypes": [
+            {
+              "type": "reference",
+              "name": "Array",
+              "typeArguments": [
+                {
+                  "type": "reference",
+                  "name": "Foo",
+                  "id": 4
+                }
+              ]
+            }
+          ]
+        },
+        {
           "id": 2,
           "name": "Array",
           "kind": 256,
@@ -43,7 +3995,7 @@
           ]
         },
         {
-          "id": 4,
+          "id": 232,
           "name": "complex",
           "kind": 32,
           "kindString": "Variable",
@@ -57,7 +4009,7 @@
           "sources": [
             {
               "fileName": "array.ts",
-              "line": 11,
+              "line": 10,
               "character": 20
             }
           ],
@@ -108,7 +4060,7 @@
           "defaultValue": " []"
         },
         {
-          "id": 5,
+          "id": 233,
           "name": "custom",
           "kind": 32,
           "kindString": "Variable",
@@ -122,7 +4074,7 @@
           "sources": [
             {
               "fileName": "array.ts",
-              "line": 16,
+              "line": 15,
               "character": 19
             }
           ],
@@ -141,6 +4093,14 @@
       ],
       "groups": [
         {
+          "title": "Classes",
+          "kind": 128,
+          "children": [
+            4,
+            5
+          ]
+        },
+        {
           "title": "Interfaces",
           "kind": 256,
           "children": [
@@ -151,8 +4111,8 @@
           "title": "Variables",
           "kind": 32,
           "children": [
-            4,
-            5
+            232,
+            233
           ]
         }
       ],


### PR DESCRIPTION
I forgot to call the serializer on the target type, and instead tried to just output the object, which doesn't work if the target of a type predicate is a type reference which has a `.parent` property.