### PR TITLE
feat: Support for export declarations

### DIFF
--- a/examples/basic/src/mod.ts
+++ b/examples/basic/src/mod.ts
@@ -1,0 +1,6 @@
+export const a = 1;
+
+/**
+ * Will not be included in mod2
+ */
+export default function() {}

--- a/examples/basic/src/mod2.ts
+++ b/examples/basic/src/mod2.ts
@@ -1,0 +1,6 @@
+export * from './mod';
+
+/**
+ * Will be exported from mod2, unlike the default function in mod
+ */
+export default function () {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc",
-  "version": "0.16.0-5",
+  "version": "0.16.0-6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc",
-  "version": "0.16.0-3",
+  "version": "0.16.0-4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc",
-  "version": "0.16.0-4",
+  "version": "0.16.0-5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc",
-  "version": "0.15.6",
+  "version": "0.16.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1932,9 +1932,9 @@
       }
     },
     "typedoc-default-themes": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.3.tgz",
-      "integrity": "sha512-rouf0TcIA4M2nOQFfC7Zp4NEwoYiEX4vX/ZtudJWU9IHA29MPC+PPgSXYLPESkUo7FuB//GxigO3mk9Qe1xp3Q==",
+      "version": "0.7.0-0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.7.0-0.tgz",
+      "integrity": "sha512-Be+69lZmcZxLH/sSi6rb7TLbc+Sb/tENooCs+IOy0qv1ppJipGlZhTIWoY5t6DJsOXlvDL9zY6gEBXq/pC24Iw==",
       "requires": {
         "backbone": "^1.4.0",
         "jquery": "^3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -766,9 +766,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.0.tgz",
+      "integrity": "sha512-PaZ6G6nYzfJ0Hd1WIhOpsnUPWh1R0Pg//r4wEYOtzG65c2V8RJQ/++yYlVmuoQ7EMXcb4eri5+FB2XH1Lwed9g==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -1948,9 +1948,9 @@
       "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw=="
     },
     "uglify-js": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
-      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+      "integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
       "optional": true,
       "requires": {
         "commander": "~2.20.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc",
-  "version": "0.16.0-0",
+  "version": "0.16.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1932,9 +1932,9 @@
       }
     },
     "typedoc-default-themes": {
-      "version": "0.7.0-0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.7.0-0.tgz",
-      "integrity": "sha512-Be+69lZmcZxLH/sSi6rb7TLbc+Sb/tENooCs+IOy0qv1ppJipGlZhTIWoY5t6DJsOXlvDL9zY6gEBXq/pC24Iw==",
+      "version": "0.7.0-2",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.7.0-2.tgz",
+      "integrity": "sha512-L/f3mKgOImj2A4i9fb9kzU+Hb0cYXkN9Qn9QpM0BZ/704kEwRSijntRWhRaBt+pcXIwidxTYEVdUYNzGGsa67g==",
       "requires": {
         "backbone": "^1.4.0",
         "jquery": "^3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc",
-  "version": "0.16.0-2",
+  "version": "0.16.0-3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc",
-  "version": "0.16.0-1",
+  "version": "0.16.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc",
   "description": "Create api documentation for TypeScript projects.",
-  "version": "0.16.0-0",
+  "version": "0.16.0-1",
   "homepage": "https://typedoc.org",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -39,7 +39,7 @@
     "minimatch": "^3.0.0",
     "progress": "^2.0.3",
     "shelljs": "^0.8.3",
-    "typedoc-default-themes": "0.7.0-0",
+    "typedoc-default-themes": "0.7.0-2",
     "typescript": "3.7.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc",
   "description": "Create api documentation for TypeScript projects.",
-  "version": "0.16.0-4",
+  "version": "0.16.0-5",
   "homepage": "https://typedoc.org",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc",
   "description": "Create api documentation for TypeScript projects.",
-  "version": "0.16.0-5",
+  "version": "0.16.0-6",
   "homepage": "https://typedoc.org",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc",
   "description": "Create api documentation for TypeScript projects.",
-  "version": "0.16.0-1",
+  "version": "0.16.0-2",
   "homepage": "https://typedoc.org",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc",
   "description": "Create api documentation for TypeScript projects.",
-  "version": "0.16.0-3",
+  "version": "0.16.0-4",
   "homepage": "https://typedoc.org",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc",
   "description": "Create api documentation for TypeScript projects.",
-  "version": "0.15.6",
+  "version": "0.16.0-0",
   "homepage": "https://typedoc.org",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -39,7 +39,7 @@
     "minimatch": "^3.0.0",
     "progress": "^2.0.3",
     "shelljs": "^0.8.3",
-    "typedoc-default-themes": "^0.6.3",
+    "typedoc-default-themes": "0.7.0-0",
     "typescript": "3.7.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc",
   "description": "Create api documentation for TypeScript projects.",
-  "version": "0.16.0-2",
+  "version": "0.16.0-3",
   "homepage": "https://typedoc.org",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@types/minimatch": "3.0.3",
     "fs-extra": "^8.1.0",
-    "handlebars": "^4.5.3",
+    "handlebars": "^4.7.0",
     "highlight.js": "^9.17.1",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/scripts/rebuild_specs.js
+++ b/scripts/rebuild_specs.js
@@ -17,7 +17,8 @@ const app = new TypeDoc.Application({
         "lib.es2015.iterable.d.ts",
         "lib.es2015.collection.d.ts"
     ],
-    name: 'typedoc'
+    name: 'typedoc',
+    excludeExternals: true
 });
 
 // Note that this uses the test files in dist, not in src, this is important since
@@ -27,6 +28,10 @@ const base = path.join(__dirname, '../dist/test/converter');
 /** @type {[string, () => void, () => void][]} */
 const conversions = [
     ['specs', () => { }, () => { }],
+    ['specs.d',
+        () => app.options.setValue('includeDeclarations', true),
+        () => app.options.setValue('includeDeclarations', false)
+    ],
     ['specs-without-exported',
         () => app.options.setValue('excludeNotExported', true),
         () => app.options.setValue('excludeNotExported', false)
@@ -73,7 +78,9 @@ async function rebuildRendererTest() {
     const out = path.join(__dirname, '../src/test/renderer/specs');
 
     await fs.remove(out)
+    app.options.setValue('excludeExternals', false);
     app.generateDocs(app.expandInputFiles([src]), out)
+    app.options.setValue('excludeExternals', true);
     await fs.remove(path.join(out, 'assets'))
 
     /**

--- a/src/lib/converter/context.ts
+++ b/src/lib/converter/context.ts
@@ -400,7 +400,7 @@ export class Context {
 }
 
 function isNamedNode(node: ts.Node): node is ts.Node & { name: ts.Identifier | ts.ComputedPropertyName } {
-    return node.hasOwnProperty('name') && (
+    return node['name'] && (
         ts.isIdentifier(node['name']) ||
         ts.isComputedPropertyName(node['name'])
     );

--- a/src/lib/converter/context.ts
+++ b/src/lib/converter/context.ts
@@ -151,6 +151,14 @@ export class Context {
         return nodeType;
     }
 
+    getSymbolAtLocation(node: ts.Node): ts.Symbol | undefined {
+        let symbol = this.checker.getSymbolAtLocation(node);
+        if (!symbol && isNamedNode(node)) {
+            symbol = this.checker.getSymbolAtLocation(node.name);
+        }
+        return symbol;
+    }
+
     /**
      * Return the current logger instance.
      *
@@ -389,4 +397,11 @@ export class Context {
 
         return typeParameters;
     }
+}
+
+function isNamedNode(node: ts.Node): node is ts.Node & { name: ts.Identifier | ts.ComputedPropertyName } {
+    return node.hasOwnProperty('name') && (
+        ts.isIdentifier(node['name']) ||
+        ts.isComputedPropertyName(node['name'])
+    );
 }

--- a/src/lib/converter/convert-expression.ts
+++ b/src/lib/converter/convert-expression.ts
@@ -26,8 +26,9 @@ export function convertExpression(expression: ts.Expression): string {
             return 'true';
         case ts.SyntaxKind.FalseKeyword:
             return 'false';
+        case ts.SyntaxKind.NullKeyword:
+            return 'null';
         default:
-            const source = expression.getSourceFile();
-            return source.text.substring(expression.pos, expression.end);
+            return expression.getText(expression.getSourceFile());
     }
 }

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -285,6 +285,16 @@ export class Converter extends ChildableComponent<Application, ConverterComponen
         const errors = this.compile(context);
         const project = this.resolve(context);
 
+        const dangling = project.getDanglingReferences();
+        if (dangling.length) {
+            this.owner.logger.warn([
+                'Some names refer to reflections that do not exist.',
+                'This can be caused by exporting a reflection only under a different name than it is declared',
+                'or by a plugin removing reflections. The names that cannot be resolved are:',
+                ...dangling
+            ].join('\n'));
+        }
+
         this.trigger(Converter.EVENT_END, context);
 
         return {

--- a/src/lib/converter/factories/declaration.ts
+++ b/src/lib/converter/factories/declaration.ts
@@ -75,7 +75,15 @@ export function createDeclaration(context: Context, node: ts.Declaration, kind: 
         isExported = true;
     } else if (container.kindOf([ReflectionKind.Module, ReflectionKind.ExternalModule])) {
         const symbol = context.getSymbolAtLocation(node);
-        isExported = !!symbol?.parent?.exports?.get(symbol.escapedName);
+        if (!symbol) {
+            isExported = false;
+        } else {
+            let parentNode = node.parent;
+            while (![ts.SyntaxKind.SourceFile, ts.SyntaxKind.ModuleDeclaration].includes(parentNode.kind)) {
+                parentNode = parentNode.parent;
+            }
+            isExported = !!context.getSymbolAtLocation(parentNode)?.exports?.get(symbol.escapedName);
+        }
     } else {
         isExported = container.flags.isExported;
     }

--- a/src/lib/converter/factories/declaration.ts
+++ b/src/lib/converter/factories/declaration.ts
@@ -82,7 +82,14 @@ export function createDeclaration(context: Context, node: ts.Declaration, kind: 
             while (![ts.SyntaxKind.SourceFile, ts.SyntaxKind.ModuleDeclaration].includes(parentNode.kind)) {
                 parentNode = parentNode.parent;
             }
-            isExported = !!context.getSymbolAtLocation(parentNode)?.exports?.get(symbol.escapedName);
+            const parentSymbol = context.getSymbolAtLocation(parentNode);
+            if (!parentSymbol) {
+                // This is a file with no imports/exports, so everything is
+                // global and therefore exported.
+                isExported = true;
+            } else {
+                isExported = !!parentSymbol.exports?.get(symbol.escapedName);
+            }
         }
     } else {
         isExported = container.flags.isExported;

--- a/src/lib/converter/factories/declaration.ts
+++ b/src/lib/converter/factories/declaration.ts
@@ -73,6 +73,9 @@ export function createDeclaration(context: Context, node: ts.Declaration, kind: 
     let isExported: boolean;
     if (kind === ReflectionKind.ExternalModule || kind === ReflectionKind.Global) {
         isExported = true;
+    } else if (container.kind === ReflectionKind.Global) {
+        // In file mode, everything is exported.
+        isExported = true;
     } else if (container.kindOf([ReflectionKind.Module, ReflectionKind.ExternalModule])) {
         const symbol = context.getSymbolAtLocation(node);
         if (!symbol) {

--- a/src/lib/converter/factories/parameter.ts
+++ b/src/lib/converter/factories/parameter.ts
@@ -23,6 +23,7 @@ export function createParameter(context: Context, node: ts.ParameterDeclaration)
     }
 
     const parameter = new ParameterReflection(node.symbol.name, ReflectionKind.Parameter, signature);
+    parameter.flags.setFlag(ReflectionFlag.Exported, context.scope.flags.isExported);
     context.registerReflection(parameter, node);
     context.withScope(parameter, () => {
         if (ts.isArrayBindingPattern(node.name) || ts.isObjectBindingPattern(node.name)) {

--- a/src/lib/converter/factories/reference.ts
+++ b/src/lib/converter/factories/reference.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 
-import { ReferenceType, ReferenceReflection, ContainerReflection } from '../../models';
+import { ReferenceType, ReferenceReflection, ContainerReflection, ReflectionFlag } from '../../models';
 import { Context } from '../context';
 import { ReferenceState } from '../../models/reflections/reference';
 import { Converter } from '../converter';
@@ -35,6 +35,7 @@ export function createReferenceReflection(context: Context, source: ts.Symbol, t
     }
 
     const reflection = new ReferenceReflection(source.name, [ReferenceState.Unresolved, context.getSymbolID(target)!], context.scope);
+    reflection.flags.setFlag(ReflectionFlag.Exported, true); // References are exported by necessity
     if (!context.scope.children) {
         context.scope.children = [];
     }

--- a/src/lib/converter/factories/reference.ts
+++ b/src/lib/converter/factories/reference.ts
@@ -3,6 +3,7 @@ import * as ts from 'typescript';
 import { ReferenceType, ReferenceReflection, ContainerReflection } from '../../models';
 import { Context } from '../context';
 import { ReferenceState } from '../../models/reflections/reference';
+import { Converter } from '../converter';
 
 /**
  * Create a new reference type pointing to the given symbol.
@@ -39,6 +40,7 @@ export function createReferenceReflection(context: Context, source: ts.Symbol, t
     }
     context.scope.children.push(reflection);
     context.registerReflection(reflection, undefined, source);
+    context.trigger(Converter.EVENT_CREATE_DECLARATION, reflection);
 
     return reflection;
 }

--- a/src/lib/converter/factories/reference.ts
+++ b/src/lib/converter/factories/reference.ts
@@ -1,7 +1,8 @@
 import * as ts from 'typescript';
 
-import { ReferenceType } from '../../models/types/index';
+import { ReferenceType, ReferenceReflection, ContainerReflection } from '../../models';
 import { Context } from '../context';
+import { ReferenceState } from '../../models/reflections/reference';
 
 /**
  * Create a new reference type pointing to the given symbol.
@@ -25,4 +26,19 @@ export function createReferenceType(context: Context, symbol: ts.Symbol | undefi
     }
 
     return new ReferenceType(name, id);
+}
+
+export function createReferenceReflection(context: Context, source: ts.Symbol, target: ts.Symbol): ReferenceReflection {
+    if (!(context.scope instanceof ContainerReflection)) {
+        throw new Error('Cannot add reference to a non-container');
+    }
+
+    const reflection = new ReferenceReflection(source.name, [ReferenceState.Unresolved, context.getSymbolID(target)!], context.scope);
+    if (!context.scope.children) {
+        context.scope.children = [];
+    }
+    context.scope.children.push(reflection);
+    context.registerReflection(reflection, undefined, source);
+
+    return reflection;
 }

--- a/src/lib/converter/factories/signature.ts
+++ b/src/lib/converter/factories/signature.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 
-import { ReflectionKind, SignatureReflection, ContainerReflection, DeclarationReflection, Type } from '../../models/index';
+import { ReflectionKind, SignatureReflection, ContainerReflection, DeclarationReflection, Type, ReflectionFlag } from '../../models/index';
 import { Context } from '../context';
 import { Converter } from '../converter';
 import { createParameter } from './parameter';
@@ -22,6 +22,7 @@ export function createSignature(context: Context, node: ts.SignatureDeclaration,
     }
 
     const signature = new SignatureReflection(name, kind, container);
+    signature.flags.setFlag(ReflectionFlag.Exported, container.flags.isExported);
     context.registerReflection(signature, node);
     context.withScope(signature, node.typeParameters, true, () => {
         node.parameters.forEach((parameter: ts.ParameterDeclaration) => {

--- a/src/lib/converter/factories/type-parameter.ts
+++ b/src/lib/converter/factories/type-parameter.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 
-import { TypeParameterContainer, TypeParameterReflection, TypeParameterType } from '../../models/index';
+import { TypeParameterContainer, TypeParameterReflection, TypeParameterType, ReflectionFlag } from '../../models/index';
 import { Context } from '../context';
 import { Converter } from '../converter';
 
@@ -23,6 +23,7 @@ export function createTypeParameter(context: Context, node: ts.TypeParameterDecl
 
     const reflection = <TypeParameterContainer> context.scope;
     const typeParameterReflection = new TypeParameterReflection(typeParameter, reflection);
+    typeParameterReflection.flags.setFlag(ReflectionFlag.Exported, reflection.flags.isExported);
 
     if (!reflection.typeParameters) {
         reflection.typeParameters = [];

--- a/src/lib/converter/nodes/export.ts
+++ b/src/lib/converter/nodes/export.ts
@@ -74,7 +74,7 @@ export class ExportDeclarationConverter extends ConverterNodeComponent<ts.Export
                     const original = (target.flags & ts.SymbolFlags.Alias) ? context.checker.getAliasedSymbol(target) : target;
                     // If the original declaration is in this file, export {} was used with something
                     // defined in this file and we don't need to create a reference unless the name is different.
-                    if (original.valueDeclaration.getSourceFile() === specifier.getSourceFile() && !specifier.propertyName) {
+                    if (!node.moduleSpecifier && !specifier.propertyName) {
                         return;
                     }
 

--- a/src/lib/converter/nodes/export.ts
+++ b/src/lib/converter/nodes/export.ts
@@ -1,9 +1,11 @@
 import * as ts from 'typescript';
 
-import { Reflection, ReflectionFlag, DeclarationReflection } from '../../models/index';
+import { Reflection, ReflectionFlag, DeclarationReflection, ContainerReflection } from '../../models/index';
 import { Context } from '../context';
 import { Component, ConverterNodeComponent } from '../components';
+import { createReferenceReflection } from '../factories/reference';
 
+// TODO: With 9c3114d this converter should no longer be necessary. Verify and remove.
 @Component({name: 'node:export'})
 export class ExportConverter extends ConverterNodeComponent<ts.ExportAssignment> {
     /**
@@ -48,6 +50,50 @@ export class ExportConverter extends ConverterNodeComponent<ts.ExportAssignment>
             }
 
             reflection.traverse(markAsExported);
+        }
+
+        return context.scope;
+    }
+}
+
+@Component({ name: 'node:export-declaration' })
+export class ExportDeclarationConverter extends ConverterNodeComponent<ts.ExportDeclaration> {
+    supports = [ts.SyntaxKind.ExportDeclaration];
+
+    convert(context: Context, node: ts.ExportDeclaration): Reflection | undefined {
+        const scope = context.scope;
+        if (!(scope instanceof ContainerReflection)) {
+            throw new Error('Expected to be within a container');
+        }
+
+        if (node.exportClause) { // export { a, a as b }
+            node.exportClause.elements.forEach(specifier => {
+                const source = context.getSymbolAtLocation(specifier.name);
+                const target = context.getSymbolAtLocation(specifier.propertyName ?? specifier.name);
+                if (source && target) {
+                    const original = (target.flags & ts.SymbolFlags.Alias) ? context.checker.getAliasedSymbol(target) : target;
+                    // If the original declaration is in this file, export {} was used with something
+                    // defined in this file and we don't need to create a reference unless the name is different.
+                    if (original.valueDeclaration.getSourceFile() === specifier.getSourceFile() && !specifier.propertyName) {
+                        return;
+                    }
+
+                    createReferenceReflection(context, source, original);
+                }
+            });
+        } else if (node.moduleSpecifier) { // export * from ...
+            const thisModule = context.getSymbolAtLocation(node.getSourceFile())!;
+            const sourceFileSymbol = context.getSymbolAtLocation(node.moduleSpecifier);
+            sourceFileSymbol?.exports?.forEach((symbol, key) => {
+                // Default exports are not re-exported with export * from
+                if (key === 'default' as ts.__String) {
+                    return;
+                }
+                const source = context.checker.tryGetMemberInModuleExports(key.toString().replace(/^__/, '_'), thisModule);
+                if (source) {
+                    createReferenceReflection(context, source, symbol);
+                }
+            });
         }
 
         return context.scope;

--- a/src/lib/converter/types/binding-object.ts
+++ b/src/lib/converter/types/binding-object.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 
-import { Type, ReflectionKind, DeclarationReflection, ReflectionType } from '../../models/index';
+import { Type, ReflectionKind, DeclarationReflection, ReflectionType, ReflectionFlag } from '../../models/index';
 import { Component, ConverterTypeComponent, TypeNodeConverter } from '../components';
 import { Context } from '../context';
 import { Converter } from '../converter';
@@ -23,6 +23,7 @@ export class BindingObjectConverter extends ConverterTypeComponent implements Ty
      */
     convertNode(context: Context, node: ts.BindingPattern): Type {
         const declaration = new DeclarationReflection('__type', ReflectionKind.TypeLiteral, context.scope);
+        declaration.flags.setFlag(ReflectionFlag.Exported, context.scope.flags.isExported);
 
         context.registerReflection(declaration);
         context.trigger(Converter.EVENT_CREATE_DECLARATION, declaration, node);

--- a/src/lib/converter/types/reference.ts
+++ b/src/lib/converter/types/reference.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 
 import { Type, IntrinsicType, ReflectionType } from '../../models/types/index';
-import { ReflectionKind, DeclarationReflection } from '../../models/reflections/index';
+import { ReflectionKind, DeclarationReflection, ReflectionFlag } from '../../models/reflections/index';
 import { createReferenceType } from '../factories/index';
 import { Component, ConverterTypeComponent, TypeNodeConverter } from '../components';
 import { Context } from '../context';
@@ -115,16 +115,15 @@ export class ReferenceConverter extends ConverterTypeComponent implements TypeNo
             if (context.visitStack.includes(declaration)) {
                 if (declaration.kind === ts.SyntaxKind.TypeLiteral ||
                         declaration.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-                    // TODO: Check if this type assertion is safe and document.
-                    return createReferenceType(context, declaration.parent.symbol!);
+                    return createReferenceType(context, declaration.parent.symbol);
                 } else {
-                    // TODO: Check if this type assertion is safe and document.
-                    return createReferenceType(context, declaration.symbol!);
+                    return createReferenceType(context, declaration.symbol);
                 }
             }
         }
 
         const declaration = new DeclarationReflection('__type', ReflectionKind.TypeLiteral, context.scope);
+        declaration.flags.setFlag(ReflectionFlag.Exported, context.scope.flags.isExported);
 
         context.registerReflection(declaration, undefined, symbol);
         context.trigger(Converter.EVENT_CREATE_DECLARATION, declaration, node);

--- a/src/lib/models/reflections/abstract.ts
+++ b/src/lib/models/reflections/abstract.ts
@@ -3,6 +3,7 @@ import { Type } from '../types/index';
 import { Comment } from '../comments/comment';
 import { TypeParameterReflection } from './type-parameter';
 import { splitUnquotedString } from './utils';
+import { ProjectReflection } from './project';
 
 /**
  * Holds all data models used by TypeDoc.
@@ -35,29 +36,30 @@ export function resetReflectionID() {
  */
 export enum ReflectionKind {
     Global = 0,
-    ExternalModule = 1,
-    Module = 2,
-    Enum = 4,
-    EnumMember = 16,
-    Variable = 32,
-    Function = 64,
-    Class = 128,
-    Interface = 256,
-    Constructor = 512,
-    Property = 1024,
-    Method = 2048,
-    CallSignature = 4096,
-    IndexSignature = 8192,
-    ConstructorSignature = 16384,
-    Parameter = 32768,
-    TypeLiteral = 65536,
-    TypeParameter = 131072,
-    Accessor = 262144,
-    GetSignature = 524288,
-    SetSignature = 1048576,
-    ObjectLiteral = 2097152,
-    TypeAlias = 4194304,
-    Event = 8388608,
+    ExternalModule = 1 << 0,
+    Module = 1 << 1,
+    Enum = 1 << 2,
+    EnumMember = 1 << 4,
+    Variable = 1 << 5,
+    Function = 1 << 6,
+    Class = 1 << 7,
+    Interface = 1 << 8,
+    Constructor = 1 << 9,
+    Property = 1 << 10,
+    Method = 1 << 11,
+    CallSignature = 1 << 12,
+    IndexSignature = 1 << 13,
+    ConstructorSignature = 1 << 14,
+    Parameter = 1 << 15,
+    TypeLiteral = 1 << 16,
+    TypeParameter = 1 << 17,
+    Accessor = 1 << 18,
+    GetSignature = 1 << 19,
+    SetSignature = 1 << 20,
+    ObjectLiteral = 1 << 21,
+    TypeAlias = 1 << 22,
+    Event = 1 << 23,
+    Reference = 1 << 24,
 
     ClassOrInterface = Class | Interface,
     VariableOrProperty = Variable | Property,
@@ -319,7 +321,7 @@ export abstract class Reflection {
     /**
      * The symbol name of this reflection.
      */
-    name = '';
+    name: string;
 
     /**
      * The original name of the TypeScript declaration.
@@ -513,7 +515,7 @@ export abstract class Reflection {
     /**
      * Return whether this reflection is the root / project reflection.
      */
-    isProject(): boolean { // this is ProjectReflection
+    isProject(): this is ProjectReflection {
         return false;
     }
 

--- a/src/lib/models/reflections/abstract.ts
+++ b/src/lib/models/reflections/abstract.ts
@@ -139,7 +139,18 @@ export class ReflectionFlags extends Array<string> {
     }
 
     /**
-     * Is this member exported?
+     * True if the reflection is exported from its containing declaration. Note that if a file
+     * has no imports or exports, then TS assumes that the file is in a global scope and *all*
+     * declarations are exported.
+     * ```ts
+     * // a.ts
+     * namespace A { // isExported = false
+     *   export const b = 1 // isExported = true, even though the container is false.
+     * }
+     * export const b = 2 // isExported = true
+     * // b.ts
+     * const c = 1 // isExported = true, no imports/exports
+     * ```
      */
     get isExported(): boolean {
         return this.hasFlag(ReflectionFlag.Exported);

--- a/src/lib/models/reflections/index.ts
+++ b/src/lib/models/reflections/index.ts
@@ -3,6 +3,7 @@ export { ContainerReflection } from './container';
 export { DeclarationReflection, DeclarationHierarchy } from './declaration';
 export { ParameterReflection } from './parameter';
 export { ProjectReflection } from './project';
+export { ReferenceReflection } from './reference';
 export { SignatureReflection } from './signature';
 export { TypeParameterReflection } from './type-parameter';
 export { splitUnquotedString } from './utils';

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -57,7 +57,7 @@ export class ProjectReflection extends ContainerReflection {
     /**
      * Return whether this reflection is the root / project reflection.
      */
-    isProject(): boolean {
+    isProject(): this is ProjectReflection {
         return true;
     }
 

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -2,6 +2,7 @@ import { SourceFile, SourceDirectory } from '../sources/index';
 import { Reflection, ReflectionKind } from './abstract';
 import { ContainerReflection } from './container';
 import { splitUnquotedString } from './utils';
+import { ReferenceReflection } from './reference';
 
 /**
  * A reflection that represents the root of the project.
@@ -108,5 +109,22 @@ export class ProjectReflection extends ContainerReflection {
         }
 
         return undefined;
+    }
+
+    /**
+     * When excludeNotExported is set, if a symbol is exported only under a different name
+     * there will be a reference which points to the symbol, but the symbol will not be converted
+     * and the rename will point to nothing. Warn the user if this happens.
+     */
+    getDanglingReferences() {
+        const dangling = new Set<string>();
+        for (const ref of Object.values(this.reflections)) {
+            if (ref instanceof ReferenceReflection) {
+                if (!ref.tryGetTargetReflection()) {
+                    dangling.add(ref.name);
+                }
+            }
+        }
+        return [...dangling];
     }
 }

--- a/src/lib/models/reflections/reference.ts
+++ b/src/lib/models/reflections/reference.ts
@@ -1,0 +1,100 @@
+import { Reflection, ReflectionKind, ReflectionFlag } from './abstract';
+import { ProjectReflection } from './project';
+import { DeclarationReflection } from './declaration';
+
+export enum ReferenceState {
+    Unresolved,
+    Resolved
+}
+
+/**
+ * Describes a reflection which does not exist at this location, but is referenced. Used for imported reflections.
+ *
+ * ```ts
+ * // a.ts
+ * export const a = 1;
+ * // b.ts
+ * import { a } from './a';
+ * // Here to avoid extra work we create a reference to the original reflection in module a instead
+ * // of copying the reflection.
+ * export { a };
+ * ```
+ */
+export class ReferenceReflection extends DeclarationReflection {
+    private _state: [ReferenceState.Unresolved, number] | [ReferenceState.Resolved, number];
+    private _project?: ProjectReflection;
+
+    /**
+     * Creates a reference reflection. Should only be used within the factory function.
+     * @param name
+     * @param state
+     * @param parent
+     *
+     * @internal
+     */
+    constructor(name: string, state: ReferenceReflection['_state'], parent?: Reflection) {
+        super(name, ReflectionKind.Reference, parent);
+        // References are only created for re-exported items, so they must be exported.
+        this.flags.setFlag(ReflectionFlag.Exported, true);
+        this._state = state;
+    }
+
+    /**
+     * Gets the reflection that is referenced. This may be another reference reflection.
+     * To fully resolve any references, use [[getTargetReflectionDeep]].
+     */
+    getTargetReflection(): Reflection {
+        this._ensureProject();
+        this._ensureResolved();
+
+        return this._project!.reflections[this._state[1]];
+    }
+
+    /**
+     * Gets the reflection that is referenced, this will fully resolve references.
+     * To only resolve one reference, use [[getTargetReflection]].
+     */
+    getTargetReflectionDeep(): Reflection {
+        let result = this.getTargetReflection();
+        while (result instanceof ReferenceReflection) {
+            result = result.getTargetReflection();
+        }
+        return result;
+    }
+
+    /**
+     * Get a raw object representation of this reflection.
+     * @deprecated use serializers instead.
+     */
+    toObject() {
+        return {
+            ...super.toObject(),
+            target: this.getTargetReflection().id
+        };
+    }
+
+    private _ensureResolved() {
+        if (this._state[0] === ReferenceState.Unresolved) {
+            const target = this._project!.symbolMapping[this._state[1]];
+            if (!target) {
+                console.log({ ...this, parent: null, _project: null }, this._project!.symbolMapping);
+                throw new Error(`Tried to reference reflection for ${this.name} that does not exist.`);
+            }
+            this._state = [ReferenceState.Resolved, target];
+        }
+    }
+
+    private _ensureProject() {
+        if (this._project) { return; }
+
+        let project = this.parent;
+        while (project && !project.isProject()) {
+            project = project.parent;
+        }
+        this._project = project;
+
+        if (!this._project) {
+            throw new Error('Reference reflection has no project and is unable to resolve.');
+        }
+    }
+}

--- a/src/lib/models/reflections/reference.ts
+++ b/src/lib/models/reflections/reference.ts
@@ -67,7 +67,7 @@ export class ReferenceReflection extends DeclarationReflection {
      */
     getTargetReflection(): Reflection {
         this._ensureProject();
-        this._ensureResolved();
+        this._ensureResolved(true);
 
         return this._project!.reflections[this._state[1]];
     }
@@ -91,16 +91,18 @@ export class ReferenceReflection extends DeclarationReflection {
     toObject() {
         return {
             ...super.toObject(),
-            target: this.getTargetReflection().id
+            target: this.tryGetTargetReflection()?.id ?? -1
         };
     }
 
-    private _ensureResolved() {
+    private _ensureResolved(throwIfFail: boolean) {
         if (this._state[0] === ReferenceState.Unresolved) {
             const target = this._project!.symbolMapping[this._state[1]];
             if (!target) {
-                console.log({ ...this, parent: null, _project: null }, this._project!.symbolMapping);
-                throw new Error(`Tried to reference reflection for ${this.name} that does not exist.`);
+                if (throwIfFail) {
+                    throw new Error(`Tried to reference reflection for ${this.name} that does not exist.`);
+                }
+                return;
             }
             this._state = [ReferenceState.Resolved, target];
         }

--- a/src/lib/models/reflections/reference.ts
+++ b/src/lib/models/reflections/reference.ts
@@ -40,6 +40,13 @@ export class ReferenceReflection extends DeclarationReflection {
     }
 
     /**
+     * Helper to check if this reflection is a reference for themes.
+     */
+    get isReference() {
+        return true;
+    }
+
+    /**
      * Tries to get the reflection that is referenced. This may be another reference reflection.
      * To fully resolve any references, use [[tryGetTargetReflectionDeep]].
      */

--- a/src/lib/models/reflections/reference.ts
+++ b/src/lib/models/reflections/reference.ts
@@ -40,6 +40,28 @@ export class ReferenceReflection extends DeclarationReflection {
     }
 
     /**
+     * Tries to get the reflection that is referenced. This may be another reference reflection.
+     * To fully resolve any references, use [[tryGetTargetReflectionDeep]].
+     */
+    tryGetTargetReflection(): Reflection | undefined {
+        this._ensureProject();
+        this._ensureResolved(false);
+        return this._state[0] === ReferenceState.Resolved ? this._project!.reflections[this._state[1]] : undefined;
+    }
+
+    /**
+     * Tries to get the reflection that is referenced, this will fully resolve references.
+     * To only resolve one reference, use [[tryGetTargetReflection]].
+     */
+    tryGetTargetReflectionDeep(): Reflection | undefined {
+        let result = this.tryGetTargetReflection();
+        while (result instanceof ReferenceReflection) {
+            result = result.tryGetTargetReflection();
+        }
+        return result;
+    }
+
+    /**
      * Gets the reflection that is referenced. This may be another reference reflection.
      * To fully resolve any references, use [[getTargetReflectionDeep]].
      */

--- a/src/lib/output/plugins/MarkedPlugin.ts
+++ b/src/lib/output/plugins/MarkedPlugin.ts
@@ -139,7 +139,7 @@ export class MarkedPlugin extends ContextAwareRendererComponent {
                     const contents = FS.readFileSync(path, 'utf-8');
                     if (path.substr(-4).toLocaleLowerCase() === '.hbs') {
                         const template = Handlebars.compile(contents);
-                        return template(context);
+                        return template(context, { allowProtoMethodsByDefault: true, allowProtoPropertiesByDefault: true });
                     } else {
                         return contents;
                     }

--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -163,7 +163,7 @@ export class Renderer extends ChildableComponent<Application, RendererComponent>
 
         // Theme must be set as this is only called in render, and render ensures theme is set.
         page.template = page.template || this.theme!.resources.templates.getResource(page.templateName)!.getTemplate();
-        page.contents = page.template(page);
+        page.contents = page.template(page, { allowProtoMethodsByDefault: true, allowProtoPropertiesByDefault: true });
 
         this.trigger(PageEvent.END, page);
         if (page.isDefaultPrevented) {

--- a/src/lib/output/utils/resources/templates.ts
+++ b/src/lib/output/utils/resources/templates.ts
@@ -17,9 +17,9 @@ export class Template<T = any> extends Resource {
         return this.template;
     }
 
-    render(context: any, options?: any): string {
+    render(context: any, options?: Handlebars.RuntimeOptions): string {
         const template = this.getTemplate();
-        return template(context, options);
+        return template(context, { ...options, allowProtoMethodsByDefault: true, allowProtoPropertiesByDefault: true });
     }
 }
 

--- a/src/lib/serialization/serializers/reflections/index.ts
+++ b/src/lib/serialization/serializers/reflections/index.ts
@@ -3,5 +3,6 @@ export * from './container';
 export * from './declaration';
 export * from './parameter';
 export * from './project';
+export * from './reference';
 export * from './signature';
 export * from './type-parameter';

--- a/src/lib/serialization/serializers/reflections/reference.ts
+++ b/src/lib/serialization/serializers/reflections/reference.ts
@@ -1,0 +1,18 @@
+import { Component } from '../../../utils/component';
+import { ReferenceReflection } from '../../../models';
+
+import { ReflectionSerializerComponent } from '../../components';
+
+@Component({ name: 'serializer:reference-reflection' })
+export class ReferenceReflectionSerializer extends ReflectionSerializerComponent<ReferenceReflection> {
+    supports(t: unknown) {
+        return t instanceof ReferenceReflection;
+    }
+
+    toObject(ref: ReferenceReflection, obj?: any): any {
+        return {
+            ...obj,
+            target: ref.getTargetReflection().id
+        };
+    }
+}

--- a/src/lib/serialization/serializers/reflections/reference.ts
+++ b/src/lib/serialization/serializers/reflections/reference.ts
@@ -12,7 +12,7 @@ export class ReferenceReflectionSerializer extends ReflectionSerializerComponent
     toObject(ref: ReferenceReflection, obj?: any): any {
         return {
             ...obj,
-            target: ref.getTargetReflection().id
+            target: ref.tryGetTargetReflection()?.id ?? -1
         };
     }
 }

--- a/src/test/converter.test.ts
+++ b/src/test/converter.test.ts
@@ -69,7 +69,8 @@ describe('Converter', function() {
             module: 'CommonJS',
             experimentalDecorators: true,
             jsx: 'react',
-            name: 'typedoc'
+            name: 'typedoc',
+            ignoreCompilerErrors: true
         });
     });
 
@@ -114,7 +115,8 @@ describe('Converter with categorizeByGroup=false', function() {
             experimentalDecorators: true,
             categorizeByGroup: false,
             jsx: 'react',
-            name: 'typedoc'
+            name: 'typedoc',
+            ignoreCompilerErrors: true
         });
     });
 
@@ -169,7 +171,8 @@ describe('Converter with excludeNotExported=true', function() {
             experimentalDecorators: true,
             excludeNotExported: true,
             jsx: 'react',
-            name: 'typedoc'
+            name: 'typedoc',
+            ignoreCompilerErrors: true
         });
     });
 

--- a/src/test/converter.test.ts
+++ b/src/test/converter.test.ts
@@ -67,4 +67,3 @@ describe('Converter', function() {
         });
     });
 });
-

--- a/src/test/converter.test.ts
+++ b/src/test/converter.test.ts
@@ -1,78 +1,37 @@
 import { Application, resetReflectionID, normalizePath, ProjectReflection } from '..';
 import * as FS from 'fs';
 import * as Path from 'path';
-import Assert = require('assert');
-
-function compareReflections(fixture, spec, path?: string) {
-    path = (path ? path + '/' : '') + spec.name;
-    Assert.deepEqual(fixture, spec);
-
-    for (let key in spec) {
-        if (!spec.hasOwnProperty(key)) {
-            continue;
-        }
-        Assert(fixture.hasOwnProperty(key), path + ': Missing property "' + key + '"');
-    }
-
-    for (let key in fixture) {
-        if (!fixture.hasOwnProperty(key) || typeof fixture[key] === 'undefined') {
-            continue;
-        }
-        Assert(spec.hasOwnProperty(key), path + ': Unknown property "' + key + '"');
-
-        const a = fixture[key];
-        const b = spec[key];
-        Assert(a instanceof Object === b instanceof Object, path + ': Property "' + key + '" type mismatch');
-
-        if (a instanceof Object) {
-            switch (key) {
-                case 'signatures':
-                case 'typeParameters':
-                case 'children':
-                    compareChildren(a, b, path);
-                    break;
-                case 'indexSignature':
-                case 'getSignature':
-                case 'setSignature':
-                    compareReflections(a, b, path);
-                    break;
-                default:
-                    Assert.deepEqual(a, b, path + ': Property "' + key + '" value mismatch');
-            }
-        } else {
-            Assert(a === b, path + ': Property "' + key + '" value mismatch');
-        }
-    }
-}
-
-function compareChildren(fixture, spec, path) {
-    const a = fixture.map(function(child) { return child.id; });
-    const b = spec.map(function(child) { return child.id; });
-
-    Assert(a.length === b.length, path + ': Number of children differs');
-    Assert(a.every(function(u, i) { return u === b[i]; }), path + ': Children are different');
-
-    fixture.forEach(function(a, index) {
-        compareReflections(a, spec[index], path);
-    });
-}
+import { deepStrictEqual as equal, ok } from 'assert';
 
 describe('Converter', function() {
     const base = Path.join(__dirname, 'converter');
-    let app: Application;
-
-    before('constructs', function() {
-        app = new Application({
-            mode:   'Modules',
-            logger: 'none',
-            target: 'ES5',
-            module: 'CommonJS',
-            experimentalDecorators: true,
-            jsx: 'react',
-            name: 'typedoc',
-            ignoreCompilerErrors: true
-        });
+    const app = new Application({
+        mode:   'Modules',
+        logger: 'none',
+        target: 'ES5',
+        module: 'CommonJS',
+        experimentalDecorators: true,
+        jsx: 'react',
+        name: 'typedoc',
+        ignoreCompilerErrors: true,
+        excludeExternals: true
     });
+
+    const checks: [string, () => void, () => void][] = [
+        ['specs', () => { }, () => { }],
+        ['specs.d',
+            () => app.options.setValue('includeDeclarations', true),
+            () => app.options.setValue('includeDeclarations', false)
+        ],
+        ['specs-without-exported',
+            () => app.options.setValue('excludeNotExported', true),
+            () => app.options.setValue('excludeNotExported', false)
+        ],
+        ['specs-with-lump-categories',
+            () => app.options.setValue('categorizeByGroup', false),
+            () => app.options.setValue('categorizeByGroup', true)
+        ]
+    ];
 
     FS.readdirSync(base).forEach(function (directory) {
         const path = Path.join(base, directory);
@@ -81,133 +40,31 @@ describe('Converter', function() {
         }
 
         describe(directory, function() {
-            let result: ProjectReflection | undefined;
+            for (const [file, before, after] of checks) {
+                const specsFile = Path.join(path, `${file}.json`);
+                if (!FS.existsSync(specsFile)) {
+                    continue;
+                }
 
-            it('converts fixtures', function() {
-                resetReflectionID();
-                result = app.convert(app.expandInputFiles([path]));
-                Assert(result instanceof ProjectReflection, 'No reflection returned');
-            });
+                let result: ProjectReflection | undefined;
 
-            it('matches specs', function() {
-                const specs = JSON.parse(FS.readFileSync(Path.join(path, 'specs.json')).toString());
-                let data = JSON.stringify(app.serializer.toObject(result), null, '  ');
-                data = data.split(normalizePath(base)).join('%BASE%');
+                it(`[${file}] converts fixtures`, function() {
+                    before();
+                    resetReflectionID();
+                    result = app.convert(app.expandInputFiles([path]));
+                    after();
+                    ok(result instanceof ProjectReflection, 'No reflection returned');
+                });
 
-                compareReflections(JSON.parse(data), specs);
-            });
+                it(`[${file}] matches specs`, function() {
+                    const specs = JSON.parse(FS.readFileSync(specsFile, 'utf-8'));
+                    let data = JSON.stringify(app.serializer.toObject(result), null, '  ');
+                    data = data.split(normalizePath(base)).join('%BASE%');
+
+                    equal(JSON.parse(data), specs);
+                });
+            }
         });
     });
 });
 
-describe('Converter with categorizeByGroup=false', function() {
-    const base = Path.join(__dirname, 'converter');
-    const categoryDir = Path.join(base, 'category');
-    const classDir = Path.join(base, 'class');
-    let app: Application;
-
-    before('constructs', function() {
-        app = new Application({
-            mode: 'Modules',
-            logger: 'none',
-            target: 'ES5',
-            module: 'CommonJS',
-            experimentalDecorators: true,
-            categorizeByGroup: false,
-            jsx: 'react',
-            name: 'typedoc',
-            ignoreCompilerErrors: true
-        });
-    });
-
-    let result: ProjectReflection | undefined;
-
-    describe('category', () => {
-        it('converts fixtures', function() {
-            resetReflectionID();
-            result = app.convert(app.expandInputFiles([categoryDir]));
-            Assert(result instanceof ProjectReflection, 'No reflection returned');
-        });
-
-        it('matches specs', function() {
-            const specs = JSON.parse(FS.readFileSync(Path.join(categoryDir, 'specs-with-lump-categories.json')).toString());
-            let data = JSON.stringify(result!.toObject(), null, '  ');
-            data = data.split(normalizePath(base)).join('%BASE%');
-
-            compareReflections(JSON.parse(data), specs);
-        });
-    });
-
-    // verify that no categories are used when not specified during lump categorization
-    describe('class', () => {
-        it('converts fixtures', function() {
-            resetReflectionID();
-            result = app.convert(app.expandInputFiles([classDir]));
-            Assert(result instanceof ProjectReflection, 'No reflection returned');
-        });
-
-        it('matches specs', function() {
-            const specs = JSON.parse(FS.readFileSync(Path.join(classDir, 'specs.json')).toString());
-            let data = JSON.stringify(result!.toObject(), null, '  ');
-            data = data.split(normalizePath(base)).join('%BASE%');
-
-            compareReflections(JSON.parse(data), specs);
-        });
-    });
-});
-
-describe('Converter with excludeNotExported=true', function() {
-    const base = Path.join(__dirname, 'converter');
-    const exportWithLocalDir = Path.join(base, 'export-with-local');
-    const classDir = Path.join(base, 'class');
-    let app: Application;
-
-    before('constructs', function() {
-        app = new Application({
-            mode: 'Modules',
-            logger: 'none',
-            target: 'ES5',
-            module: 'CommonJS',
-            experimentalDecorators: true,
-            excludeNotExported: true,
-            jsx: 'react',
-            name: 'typedoc',
-            ignoreCompilerErrors: true
-        });
-    });
-
-    let result: ProjectReflection | undefined;
-
-    describe('export-with-local', () => {
-        it('converts fixtures', function() {
-            resetReflectionID();
-            result = app.convert(app.expandInputFiles([exportWithLocalDir]));
-            Assert(result instanceof ProjectReflection, 'No reflection returned');
-        });
-
-        it('matches specs', function() {
-            const specs = JSON.parse(FS.readFileSync(Path.join(exportWithLocalDir, 'specs-without-exported.json')).toString());
-            let data = JSON.stringify(result!.toObject(), null, '  ');
-            data = data.split(normalizePath(base)).join('%BASE%');
-
-            compareReflections(JSON.parse(data), specs);
-        });
-    });
-
-    describe('class', () => {
-        it('converts fixtures', function() {
-            resetReflectionID();
-            result = app.convert(app.expandInputFiles([classDir]));
-            Assert(result instanceof ProjectReflection, 'No reflection returned');
-        });
-
-        it('matches specs', function() {
-            const specs = JSON.parse(FS.readFileSync(Path.join(classDir, 'specs-without-exported.json')).toString());
-            let data = JSON.stringify(result!.toObject(), null, '  ');
-            data = data.split(normalizePath(base)).join('%BASE%');
-
-            compareReflections(JSON.parse(data), specs);
-        });
-    });
-
-});

--- a/src/test/converter/access/specs.json
+++ b/src/test/converter/access/specs.json
@@ -91,7 +91,8 @@
                   "kind": 4096,
                   "kindString": "Call signature",
                   "flags": {
-                    "isPrivate": true
+                    "isPrivate": true,
+                    "isExported": true
                   },
                   "comment": {
                     "shortText": "A function that is made private via comment."
@@ -126,7 +127,8 @@
                   "kind": 4096,
                   "kindString": "Call signature",
                   "flags": {
-                    "isProtected": true
+                    "isProtected": true,
+                    "isExported": true
                   },
                   "comment": {
                     "shortText": "A function that is made protected via comment."
@@ -240,7 +242,8 @@
               "kind": 4096,
               "kindString": "Call signature",
               "flags": {
-                "isPrivate": true
+                "isPrivate": true,
+                "isExported": true
               },
               "comment": {
                 "shortText": "A function that is made private via comment."
@@ -275,7 +278,8 @@
               "kind": 4096,
               "kindString": "Call signature",
               "flags": {
-                "isProtected": true
+                "isProtected": true,
+                "isExported": true
               },
               "comment": {
                 "shortText": "A function that is made protected via comment."

--- a/src/test/converter/alias/specs.json
+++ b/src/test/converter/alias/specs.json
@@ -31,7 +31,9 @@
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "type": {
                 "type": "array",
                 "elementType": {
@@ -45,7 +47,9 @@
               "name": "R",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {}
+              "flags": {
+                "isExported": true
+              }
             }
           ],
           "sources": [
@@ -64,14 +68,18 @@
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
-                "flags": {},
+                "flags": {
+                  "isExported": true
+                },
                 "children": [
                   {
                     "id": 26,
                     "name": "0",
                     "kind": 32,
                     "kindString": "Variable",
-                    "flags": {},
+                    "flags": {
+                      "isExported": true
+                    },
                     "sources": [
                       {
                         "fileName": "alias.ts",
@@ -89,7 +97,9 @@
                     "name": "1",
                     "kind": 32,
                     "kindString": "Variable",
-                    "flags": {},
+                    "flags": {
+                      "isExported": true
+                    },
                     "sources": [
                       {
                         "fileName": "alias.ts",
@@ -127,7 +137,9 @@
                             "name": "__type",
                             "kind": 65536,
                             "kindString": "Type literal",
-                            "flags": {},
+                            "flags": {
+                              "isExported": true
+                            },
                             "sources": [
                               {
                                 "fileName": "alias.ts",
@@ -212,7 +224,9 @@
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {}
+              "flags": {
+                "isExported": true
+              }
             }
           ],
           "sources": [
@@ -259,7 +273,9 @@
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "type": {
                 "type": "array",
                 "elementType": {
@@ -285,14 +301,18 @@
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
-                "flags": {},
+                "flags": {
+                  "isExported": true
+                },
                 "signatures": [
                   {
                     "id": 16,
                     "name": "__call",
                     "kind": 4096,
                     "kindString": "Call signature",
-                    "flags": {},
+                    "flags": {
+                      "isExported": true
+                    },
                     "parameters": [
                       {
                         "id": 17,
@@ -300,6 +320,7 @@
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {
+                          "isExported": true,
                           "isRest": true
                         },
                         "type": {
@@ -337,21 +358,27 @@
                 "name": "__type",
                 "kind": 65536,
                 "kindString": "Type literal",
-                "flags": {},
+                "flags": {
+                  "isExported": true
+                },
                 "signatures": [
                   {
                     "id": 19,
                     "name": "__call",
                     "kind": 4096,
                     "kindString": "Call signature",
-                    "flags": {},
+                    "flags": {
+                      "isExported": true
+                    },
                     "parameters": [
                       {
                         "id": 20,
                         "name": "a",
                         "kind": 32768,
                         "kindString": "Parameter",
-                        "flags": {},
+                        "flags": {
+                          "isExported": true
+                        },
                         "type": {
                           "type": "intrinsic",
                           "name": "any"
@@ -363,6 +390,7 @@
                         "kind": 32768,
                         "kindString": "Parameter",
                         "flags": {
+                          "isExported": true,
                           "isRest": true
                         },
                         "type": {
@@ -413,7 +441,9 @@
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {}
+              "flags": {
+                "isExported": true
+              }
             }
           ],
           "sources": [
@@ -466,7 +496,9 @@
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {}
+              "flags": {
+                "isExported": true
+              }
             }
           ],
           "sources": [
@@ -483,21 +515,27 @@
               "name": "__type",
               "kind": 65536,
               "kindString": "Type literal",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "signatures": [
                 {
                   "id": 5,
                   "name": "__call",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 6,
                       "name": "a",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "typeParameter",
                         "name": "T"
@@ -508,7 +546,9 @@
                       "name": "b",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "typeParameter",
                         "name": "T"

--- a/src/test/converter/array/specs.json
+++ b/src/test/converter/array/specs.json
@@ -4057,7 +4057,7 @@
               }
             }
           },
-          "defaultValue": " []"
+          "defaultValue": "[]"
         },
         {
           "id": 233,

--- a/src/test/converter/array/specs.json
+++ b/src/test/converter/array/specs.json
@@ -50,7 +50,9 @@
               "name": "__index",
               "kind": 8192,
               "kindString": "Index signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "Custom list class"
               },
@@ -60,7 +62,9 @@
                   "name": "n",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"
@@ -137,7 +141,9 @@
                   "name": "[Symbol.iterator]",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Iterator"
                   },
@@ -184,7 +190,9 @@
                   "name": "[Symbol.unscopables]",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns an object whose properties have the value 'true'\nwhen they will be absent when used in a 'with' statement."
                   },
@@ -195,14 +203,18 @@
                       "name": "__type",
                       "kind": 65536,
                       "kindString": "Type literal",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "children": [
                         {
                           "id": 221,
                           "name": "copyWithin",
                           "kind": 32,
                           "kindString": "Variable",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "sources": [
                             {
                               "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
@@ -220,7 +232,9 @@
                           "name": "entries",
                           "kind": 32,
                           "kindString": "Variable",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "sources": [
                             {
                               "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
@@ -238,7 +252,9 @@
                           "name": "fill",
                           "kind": 32,
                           "kindString": "Variable",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "sources": [
                             {
                               "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
@@ -256,7 +272,9 @@
                           "name": "find",
                           "kind": 32,
                           "kindString": "Variable",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "sources": [
                             {
                               "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
@@ -274,7 +292,9 @@
                           "name": "findIndex",
                           "kind": 32,
                           "kindString": "Variable",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "sources": [
                             {
                               "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
@@ -292,7 +312,9 @@
                           "name": "keys",
                           "kind": 32,
                           "kindString": "Variable",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "sources": [
                             {
                               "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
@@ -310,7 +332,9 @@
                           "name": "values",
                           "kind": 32,
                           "kindString": "Variable",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "sources": [
                             {
                               "fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
@@ -380,7 +404,9 @@
                   "name": "concat",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Combines two or more arrays."
                   },
@@ -391,6 +417,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isRest": true
                       },
                       "comment": {
@@ -430,7 +457,9 @@
                   "name": "concat",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Combines two or more arrays."
                   },
@@ -441,6 +470,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isRest": true
                       },
                       "comment": {
@@ -515,7 +545,9 @@
                   "name": "copyWithin",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns the this object after copying a section of the array identified by start and end\nto the same array starting at position target"
                   },
@@ -525,7 +557,9 @@
                       "name": "target",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "If target is negative, it is treated as length+target where length is the\nlength of the array."
                       },
@@ -539,7 +573,9 @@
                       "name": "start",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "If start is negative, it is treated as length+start. If end is negative, it\nis treated as length+end."
                       },
@@ -554,6 +590,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -601,7 +638,9 @@
                   "name": "entries",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns an iterable of key, value pairs for every entry in the array"
                   },
@@ -657,7 +696,9 @@
                   "name": "every",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Determines whether all the members of an array satisfy the specified test."
                   },
@@ -667,7 +708,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to three arguments. The every method calls\nthe callbackfn function for each element in the array until the callbackfn returns a value\nwhich is coercible to the Boolean value false, or until the end of the array."
                       },
@@ -678,21 +721,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 62,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 63,
                                   "name": "value",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -704,7 +753,9 @@
                                   "name": "index",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -715,7 +766,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -748,6 +801,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -795,7 +849,9 @@
                   "name": "fill",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns the this object after filling the section identified by start and end with value"
                   },
@@ -805,7 +861,9 @@
                       "name": "value",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "value to fill array section with"
                       },
@@ -821,6 +879,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -837,6 +896,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -884,7 +944,9 @@
                   "name": "filter",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns the elements of an array that meet the condition specified in a callback function."
                   },
@@ -894,7 +956,9 @@
                       "name": "S",
                       "kind": 131072,
                       "kindString": "Type parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reference",
                         "name": "Foo",
@@ -908,7 +972,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array."
                       },
@@ -919,21 +985,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 100,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 101,
                                   "name": "value",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -945,7 +1017,9 @@
                                   "name": "index",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -956,7 +1030,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -999,6 +1075,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -1032,7 +1109,9 @@
                   "name": "filter",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns the elements of an array that meet the condition specified in a callback function."
                   },
@@ -1042,7 +1121,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array."
                       },
@@ -1053,21 +1134,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 108,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 109,
                                   "name": "value",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -1079,7 +1166,9 @@
                                   "name": "index",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -1090,7 +1179,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -1123,6 +1214,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -1179,7 +1271,9 @@
                   "name": "find",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns the value of the first element in the array where predicate is true, and undefined\notherwise."
                   },
@@ -1189,7 +1283,9 @@
                       "name": "S",
                       "kind": 131072,
                       "kindString": "Type parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reference",
                         "name": "Foo",
@@ -1203,7 +1299,9 @@
                       "name": "predicate",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "find calls predicate once for each element of the array, in ascending\norder, until it finds one where predicate returns true. If such an element is found, find\nimmediately returns that element value. Otherwise, find returns undefined."
                       },
@@ -1214,21 +1312,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 177,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 178,
                                   "name": "this",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "void"
@@ -1239,7 +1343,9 @@
                                   "name": "value",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -1251,7 +1357,9 @@
                                   "name": "index",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -1262,7 +1370,9 @@
                                   "name": "obj",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -1305,6 +1415,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -1344,14 +1455,18 @@
                   "name": "find",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 184,
                       "name": "predicate",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reflection",
                         "declaration": {
@@ -1359,21 +1474,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 186,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 187,
                                   "name": "value",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -1385,7 +1506,9 @@
                                   "name": "index",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -1396,7 +1519,9 @@
                                   "name": "obj",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -1429,6 +1554,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "type": {
@@ -1488,7 +1614,9 @@
                   "name": "findIndex",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns the index of the first element in the array where predicate is true, and -1\notherwise."
                   },
@@ -1498,7 +1626,9 @@
                       "name": "predicate",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "find calls predicate once for each element of the array, in ascending\norder, until it finds one where predicate returns true. If such an element is found,\nfindIndex immediately returns that element index. Otherwise, findIndex returns -1."
                       },
@@ -1509,21 +1639,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 195,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 196,
                                   "name": "value",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -1535,7 +1671,9 @@
                                   "name": "index",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -1546,7 +1684,9 @@
                                   "name": "obj",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -1579,6 +1719,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -1626,7 +1767,9 @@
                   "name": "forEach",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Performs the specified action for each element in an array."
                   },
@@ -1636,7 +1779,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array."
                       },
@@ -1647,21 +1792,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 80,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 81,
                                   "name": "value",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -1673,7 +1824,9 @@
                                   "name": "index",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -1684,7 +1837,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -1717,6 +1872,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -1764,7 +1920,9 @@
                   "name": "includes",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Determines whether an array includes a certain element, returning true or false as appropriate."
                   },
@@ -1774,7 +1932,9 @@
                       "name": "searchElement",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "The element to search for."
                       },
@@ -1790,6 +1950,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -1837,7 +1998,9 @@
                   "name": "indexOf",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns the index of the first occurrence of a value in an array."
                   },
@@ -1847,7 +2010,9 @@
                       "name": "searchElement",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "The value to locate in the array."
                       },
@@ -1863,6 +2028,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -1910,7 +2076,9 @@
                   "name": "join",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Adds all the elements of an array separated by the specified separator string."
                   },
@@ -1921,6 +2089,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -1968,7 +2137,9 @@
                   "name": "keys",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns an iterable of keys in the array"
                   },
@@ -2014,7 +2185,9 @@
                   "name": "lastIndexOf",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns the index of the last occurrence of a specified value in an array."
                   },
@@ -2024,7 +2197,9 @@
                       "name": "searchElement",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "The value to locate in the array."
                       },
@@ -2040,6 +2215,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -2087,7 +2263,9 @@
                   "name": "map",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Calls a defined callback function on each element of an array, and returns an array that contains the results."
                   },
@@ -2097,7 +2275,9 @@
                       "name": "U",
                       "kind": 131072,
                       "kindString": "Type parameter",
-                      "flags": {}
+                      "flags": {
+                        "isExported": true
+                      }
                     }
                   ],
                   "parameters": [
@@ -2106,7 +2286,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array."
                       },
@@ -2117,21 +2299,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 90,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 91,
                                   "name": "value",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2143,7 +2331,9 @@
                                   "name": "index",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -2154,7 +2344,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -2187,6 +2379,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -2237,7 +2430,9 @@
                   "name": "pop",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Removes the last element from an array and returns it."
                   },
@@ -2287,7 +2482,9 @@
                   "name": "push",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Appends new elements to an array, and returns the new length of the array."
                   },
@@ -2298,6 +2495,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isRest": true
                       },
                       "comment": {
@@ -2349,7 +2547,9 @@
                   "name": "reduce",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
                   },
@@ -2359,7 +2559,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array."
                       },
@@ -2370,21 +2572,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 117,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 118,
                                   "name": "previousValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2396,7 +2604,9 @@
                                   "name": "currentValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2408,7 +2618,9 @@
                                   "name": "currentIndex",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -2419,7 +2631,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -2463,14 +2677,18 @@
                   "name": "reduce",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 123,
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reflection",
                         "declaration": {
@@ -2478,21 +2696,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 125,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 126,
                                   "name": "previousValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2504,7 +2728,9 @@
                                   "name": "currentValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2516,7 +2742,9 @@
                                   "name": "currentIndex",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -2527,7 +2755,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -2560,7 +2790,9 @@
                       "name": "initialValue",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reference",
                         "name": "Foo",
@@ -2583,7 +2815,9 @@
                   "name": "reduce",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
                   },
@@ -2593,7 +2827,9 @@
                       "name": "U",
                       "kind": 131072,
                       "kindString": "Type parameter",
-                      "flags": {}
+                      "flags": {
+                        "isExported": true
+                      }
                     }
                   ],
                   "parameters": [
@@ -2602,7 +2838,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array."
                       },
@@ -2613,21 +2851,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 135,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 136,
                                   "name": "previousValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "typeParameter",
                                     "name": "U"
@@ -2638,7 +2882,9 @@
                                   "name": "currentValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2650,7 +2896,9 @@
                                   "name": "currentIndex",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -2661,7 +2909,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -2693,7 +2943,9 @@
                       "name": "initialValue",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.\n"
                       },
@@ -2749,7 +3001,9 @@
                   "name": "reduceRight",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
                   },
@@ -2759,7 +3013,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array."
                       },
@@ -2770,21 +3026,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 145,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 146,
                                   "name": "previousValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2796,7 +3058,9 @@
                                   "name": "currentValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2808,7 +3072,9 @@
                                   "name": "currentIndex",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -2819,7 +3085,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -2863,14 +3131,18 @@
                   "name": "reduceRight",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 151,
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reflection",
                         "declaration": {
@@ -2878,21 +3150,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 153,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 154,
                                   "name": "previousValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2904,7 +3182,9 @@
                                   "name": "currentValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -2916,7 +3196,9 @@
                                   "name": "currentIndex",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -2927,7 +3209,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -2960,7 +3244,9 @@
                       "name": "initialValue",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reference",
                         "name": "Foo",
@@ -2983,7 +3269,9 @@
                   "name": "reduceRight",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
                   },
@@ -2993,7 +3281,9 @@
                       "name": "U",
                       "kind": 131072,
                       "kindString": "Type parameter",
-                      "flags": {}
+                      "flags": {
+                        "isExported": true
+                      }
                     }
                   ],
                   "parameters": [
@@ -3002,7 +3292,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array."
                       },
@@ -3013,21 +3305,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 163,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 164,
                                   "name": "previousValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "typeParameter",
                                     "name": "U"
@@ -3038,7 +3336,9 @@
                                   "name": "currentValue",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -3050,7 +3350,9 @@
                                   "name": "currentIndex",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -3061,7 +3363,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -3093,7 +3397,9 @@
                       "name": "initialValue",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.\n"
                       },
@@ -3149,7 +3455,9 @@
                   "name": "reverse",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Reverses the elements in an Array."
                   },
@@ -3193,7 +3501,9 @@
                   "name": "shift",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Removes the first element from an array and returns it."
                   },
@@ -3243,7 +3553,9 @@
                   "name": "slice",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns a section of an array."
                   },
@@ -3254,6 +3566,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -3270,6 +3583,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -3321,7 +3635,9 @@
                   "name": "some",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Determines whether the specified callback function returns true for any element of an array."
                   },
@@ -3331,7 +3647,9 @@
                       "name": "callbackfn",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "A function that accepts up to three arguments. The some method calls\nthe callbackfn function for each element in the array until the callbackfn returns a value\nwhich is coercible to the Boolean value true, or until the end of the array."
                       },
@@ -3342,21 +3660,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 71,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 72,
                                   "name": "value",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -3368,7 +3692,9 @@
                                   "name": "index",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "intrinsic",
                                     "name": "number"
@@ -3379,7 +3705,9 @@
                                   "name": "array",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "array",
                                     "elementType": {
@@ -3412,6 +3740,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -3459,7 +3788,9 @@
                   "name": "sort",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Sorts an array."
                   },
@@ -3470,6 +3801,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -3482,21 +3814,27 @@
                           "name": "__type",
                           "kind": 65536,
                           "kindString": "Type literal",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "signatures": [
                             {
                               "id": 36,
                               "name": "__call",
                               "kind": 4096,
                               "kindString": "Call signature",
-                              "flags": {},
+                              "flags": {
+                                "isExported": true
+                              },
                               "parameters": [
                                 {
                                   "id": 37,
                                   "name": "a",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -3508,7 +3846,9 @@
                                   "name": "b",
                                   "kind": 32768,
                                   "kindString": "Parameter",
-                                  "flags": {},
+                                  "flags": {
+                                    "isExported": true
+                                  },
                                   "type": {
                                     "type": "reference",
                                     "name": "Foo",
@@ -3569,7 +3909,9 @@
                   "name": "splice",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements."
                   },
@@ -3579,7 +3921,9 @@
                       "name": "start",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "The zero-based location in the array from which to start removing elements."
                       },
@@ -3594,6 +3938,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isOptional": true
                       },
                       "comment": {
@@ -3623,7 +3968,9 @@
                   "name": "splice",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements."
                   },
@@ -3633,7 +3980,9 @@
                       "name": "start",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "The zero-based location in the array from which to start removing elements."
                       },
@@ -3647,7 +3996,9 @@
                       "name": "deleteCount",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "text": "The number of elements to remove."
                       },
@@ -3662,6 +4013,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isRest": true
                       },
                       "comment": {
@@ -3722,7 +4074,9 @@
                   "name": "toLocaleString",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns a string representation of an array. The elements are converted to string using their toLocalString methods."
                   },
@@ -3762,7 +4116,9 @@
                   "name": "toString",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns a string representation of an array."
                   },
@@ -3802,7 +4158,9 @@
                   "name": "unshift",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Inserts new elements at the start of an array."
                   },
@@ -3813,6 +4171,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isRest": true
                       },
                       "comment": {
@@ -3864,7 +4223,9 @@
                   "name": "values",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Returns an iterable of values in the array"
                   },
@@ -3983,7 +4344,9 @@
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {}
+              "flags": {
+                "isExported": true
+              }
             }
           ],
           "sources": [

--- a/src/test/converter/category/specs-with-lump-categories.json
+++ b/src/test/converter/category/specs-with-lump-categories.json
@@ -145,7 +145,9 @@
                   "name": "myAbstractMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "void"
@@ -241,7 +243,9 @@
                   "name": "myAbstractMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "void"
@@ -334,7 +338,9 @@
                   "name": "new TestClass",
                   "kind": 16384,
                   "kindString": "Constructor signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Constructor short text."
                   },
@@ -444,7 +450,9 @@
                   "name": "privateMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "privateMethod short text."
                   },
@@ -477,7 +485,9 @@
                   "name": "protectedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "protectedMethod short text."
                   },
@@ -510,7 +520,9 @@
                   "name": "publicMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "publicMethod short text."
                   },
@@ -543,7 +555,9 @@
                   "name": "staticMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMethod short text."
                   },
@@ -651,7 +665,9 @@
                   "name": "new TestSubClass",
                   "kind": 16384,
                   "kindString": "Constructor signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Constructor short text."
                   },
@@ -661,7 +677,9 @@
                       "name": "p1",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Constructor param"
                       },
@@ -675,7 +693,9 @@
                       "name": "p2",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Private string property"
                       },
@@ -689,7 +709,9 @@
                       "name": "p3",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Public number property"
                       },
@@ -703,7 +725,9 @@
                       "name": "p4",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Public implicit any property\n"
                       },
@@ -886,7 +910,9 @@
                   "name": "mergedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "mergedMethod short text."
                   },
@@ -919,7 +945,9 @@
                   "name": "protectedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "protectedMethod short text."
                   },
@@ -962,7 +990,9 @@
                   "name": "publicMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "publicMethod short text."
                   },
@@ -1005,7 +1035,9 @@
                   "name": "staticMergedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMergedMethod short text."
                   },
@@ -1038,7 +1070,9 @@
                   "name": "staticMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMethod short text."
                   },

--- a/src/test/converter/category/specs.json
+++ b/src/test/converter/category/specs.json
@@ -145,7 +145,9 @@
                   "name": "myAbstractMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "void"
@@ -241,7 +243,9 @@
                   "name": "myAbstractMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "void"
@@ -334,7 +338,9 @@
                   "name": "new TestClass",
                   "kind": 16384,
                   "kindString": "Constructor signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Constructor short text."
                   },
@@ -444,7 +450,9 @@
                   "name": "privateMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "privateMethod short text."
                   },
@@ -477,7 +485,9 @@
                   "name": "protectedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "protectedMethod short text."
                   },
@@ -510,7 +520,9 @@
                   "name": "publicMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "publicMethod short text."
                   },
@@ -543,7 +555,9 @@
                   "name": "staticMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMethod short text."
                   },
@@ -662,7 +676,9 @@
                   "name": "new TestSubClass",
                   "kind": 16384,
                   "kindString": "Constructor signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Constructor short text."
                   },
@@ -672,7 +688,9 @@
                       "name": "p1",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Constructor param"
                       },
@@ -686,7 +704,9 @@
                       "name": "p2",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Private string property"
                       },
@@ -700,7 +720,9 @@
                       "name": "p3",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Public number property"
                       },
@@ -714,7 +736,9 @@
                       "name": "p4",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Public implicit any property\n"
                       },
@@ -897,7 +921,9 @@
                   "name": "mergedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "mergedMethod short text."
                   },
@@ -930,7 +956,9 @@
                   "name": "protectedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "protectedMethod short text."
                   },
@@ -973,7 +1001,9 @@
                   "name": "publicMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "publicMethod short text."
                   },
@@ -1016,7 +1046,9 @@
                   "name": "staticMergedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMergedMethod short text."
                   },
@@ -1049,7 +1081,9 @@
                   "name": "staticMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMethod short text."
                   },

--- a/src/test/converter/class/specs-without-exported.json
+++ b/src/test/converter/class/specs-without-exported.json
@@ -175,7 +175,9 @@
                   "name": "myAbstractMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "void"
@@ -271,7 +273,9 @@
                   "name": "myAbstractMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "void"
@@ -364,7 +368,9 @@
                   "name": "new TestClass",
                   "kind": 16384,
                   "kindString": "Constructor signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Constructor short text."
                   },
@@ -474,7 +480,9 @@
                   "name": "privateMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "privateMethod short text."
                   },
@@ -507,7 +515,9 @@
                   "name": "protectedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "protectedMethod short text."
                   },
@@ -540,7 +550,9 @@
                   "name": "publicMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "publicMethod short text."
                   },
@@ -573,7 +585,9 @@
                   "name": "staticMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMethod short text."
                   },
@@ -661,7 +675,9 @@
                   "name": "new TestSubClass",
                   "kind": 16384,
                   "kindString": "Constructor signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Constructor short text."
                   },
@@ -671,7 +687,9 @@
                       "name": "p1",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Constructor param"
                       },
@@ -685,7 +703,9 @@
                       "name": "p2",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Private string property"
                       },
@@ -699,7 +719,9 @@
                       "name": "p3",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Public number property"
                       },
@@ -713,7 +735,9 @@
                       "name": "p4",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Public implicit any property\n"
                       },
@@ -896,7 +920,9 @@
                   "name": "mergedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "mergedMethod short text."
                   },
@@ -929,7 +955,9 @@
                   "name": "protectedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "protectedMethod short text."
                   },
@@ -972,7 +1000,9 @@
                   "name": "publicMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "publicMethod short text."
                   },
@@ -1015,7 +1045,9 @@
                   "name": "staticMergedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMergedMethod short text."
                   },
@@ -1048,7 +1080,9 @@
                   "name": "staticMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMethod short text."
                   },

--- a/src/test/converter/class/specs.json
+++ b/src/test/converter/class/specs.json
@@ -259,7 +259,9 @@
                   "name": "myAbstractMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "void"
@@ -355,7 +357,9 @@
                   "name": "myAbstractMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "void"
@@ -448,7 +452,9 @@
                   "name": "new TestClass",
                   "kind": 16384,
                   "kindString": "Constructor signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Constructor short text."
                   },
@@ -558,7 +564,9 @@
                   "name": "privateMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "privateMethod short text."
                   },
@@ -591,7 +599,9 @@
                   "name": "protectedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "protectedMethod short text."
                   },
@@ -624,7 +634,9 @@
                   "name": "publicMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "publicMethod short text."
                   },
@@ -657,7 +669,9 @@
                   "name": "staticMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMethod short text."
                   },
@@ -745,7 +759,9 @@
                   "name": "new TestSubClass",
                   "kind": 16384,
                   "kindString": "Constructor signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Constructor short text."
                   },
@@ -755,7 +771,9 @@
                       "name": "p1",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Constructor param"
                       },
@@ -769,7 +787,9 @@
                       "name": "p2",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Private string property"
                       },
@@ -783,7 +803,9 @@
                       "name": "p3",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Public number property"
                       },
@@ -797,7 +819,9 @@
                       "name": "p4",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "comment": {
                         "shortText": "Public implicit any property\n"
                       },
@@ -980,7 +1004,9 @@
                   "name": "mergedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "mergedMethod short text."
                   },
@@ -1013,7 +1039,9 @@
                   "name": "protectedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "protectedMethod short text."
                   },
@@ -1056,7 +1084,9 @@
                   "name": "publicMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "publicMethod short text."
                   },
@@ -1099,7 +1129,9 @@
                   "name": "staticMergedMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMergedMethod short text."
                   },
@@ -1132,7 +1164,9 @@
                   "name": "staticMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "staticMethod short text."
                   },

--- a/src/test/converter/comment/specs.json
+++ b/src/test/converter/comment/specs.json
@@ -126,14 +126,18 @@
               "name": "multiply",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "parameters": [
                 {
                   "id": 4,
                   "name": "a",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"
@@ -144,7 +148,9 @@
                   "name": "b",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"

--- a/src/test/converter/constructor-properties/constructor-properties.ts
+++ b/src/test/converter/constructor-properties/constructor-properties.ts
@@ -1,32 +1,31 @@
 /**
  * A class with constructor properties.
  */
-class Vector2
-{
+class Vector2 {
     /**
      * @param x  X component of the Vector
      * @param y  Y component of the Vector
      * @param name Vector name
      */
-    constructor(public x:number, public y:number,
+    constructor(public x: number, public y: number,
                 readonly name: string) {
     }
 }
 
-
 /**
  * A class with inherited and overwritten constructor properties.
  */
-class Vector3 extends Vector2
-{
+class Vector3 extends Vector2 {
     /**
      * @param x  X component of the Vector
      * @param y  Y component of the Vector
      * @param z  Z component of the Vector
      * @param name Vector name
      */
-    constructor(x:number, public y:number, public z:number,
+    constructor(x: number, public y: number, public z: number,
                 readonly name: string) {
         super(x, y, name);
     }
 }
+
+export {};

--- a/src/test/converter/constructor-properties/specs.json
+++ b/src/test/converter/constructor-properties/specs.json
@@ -93,8 +93,8 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 5,
-                  "character": 1
+                  "line": 4,
+                  "character": 15
                 }
               ]
             },
@@ -112,7 +112,7 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 12,
+                  "line": 11,
                   "character": 29
                 }
               ],
@@ -136,7 +136,7 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 11,
+                  "line": 10,
                   "character": 24
                 }
               ],
@@ -160,8 +160,8 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 11,
-                  "character": 41
+                  "line": 10,
+                  "character": 42
                 }
               ],
               "type": {
@@ -301,8 +301,8 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 21,
-                  "character": 1
+                  "line": 18,
+                  "character": 31
                 }
               ],
               "overwrites": {
@@ -325,7 +325,7 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 29,
+                  "line": 26,
                   "character": 29
                 }
               ],
@@ -354,7 +354,7 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 11,
+                  "line": 10,
                   "character": 24
                 }
               ],
@@ -383,8 +383,8 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 28,
-                  "character": 34
+                  "line": 25,
+                  "character": 35
                 }
               ],
               "type": {
@@ -412,8 +412,8 @@
               "sources": [
                 {
                   "fileName": "constructor-properties.ts",
-                  "line": 28,
-                  "character": 51
+                  "line": 25,
+                  "character": 53
                 }
               ],
               "type": {
@@ -444,7 +444,7 @@
           "sources": [
             {
               "fileName": "constructor-properties.ts",
-              "line": 20,
+              "line": 18,
               "character": 13
             }
           ],

--- a/src/test/converter/declaration/declaration.d.ts
+++ b/src/test/converter/declaration/declaration.d.ts
@@ -1,0 +1,5 @@
+declare class Decl {
+    prop: number;
+}
+
+declare const x: number

--- a/src/test/converter/declaration/export-declaration.d.ts
+++ b/src/test/converter/declaration/export-declaration.d.ts
@@ -1,0 +1,3 @@
+export declare class Exported {}
+
+declare class NotExported {}

--- a/src/test/converter/declaration/specs.d.json
+++ b/src/test/converter/declaration/specs.d.json
@@ -1,0 +1,182 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "flags": {},
+  "children": [
+    {
+      "id": 1,
+      "name": "\"declaration.d\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/declaration/declaration.d.ts",
+      "children": [
+        {
+          "id": 2,
+          "name": "Decl",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "children": [
+            {
+              "id": 3,
+              "name": "prop",
+              "kind": 1024,
+              "kindString": "Property",
+              "flags": {
+                "isExported": true
+              },
+              "sources": [
+                {
+                  "fileName": "declaration.d.ts",
+                  "line": 2,
+                  "character": 8
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            }
+          ],
+          "groups": [
+            {
+              "title": "Properties",
+              "kind": 1024,
+              "children": [
+                3
+              ]
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "declaration.d.ts",
+              "line": 1,
+              "character": 18
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "name": "x",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isExported": true,
+            "isConst": true
+          },
+          "sources": [
+            {
+              "fileName": "declaration.d.ts",
+              "line": 5,
+              "character": 15
+            }
+          ],
+          "type": {
+            "type": "intrinsic",
+            "name": "number"
+          }
+        }
+      ],
+      "groups": [
+        {
+          "title": "Classes",
+          "kind": 128,
+          "children": [
+            2
+          ]
+        },
+        {
+          "title": "Variables",
+          "kind": 32,
+          "children": [
+            4
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "declaration.d.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "name": "\"export-declaration.d\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/declaration/export-declaration.d.ts",
+      "children": [
+        {
+          "id": 6,
+          "name": "Exported",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "sources": [
+            {
+              "fileName": "export-declaration.d.ts",
+              "line": 1,
+              "character": 29
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "name": "NotExported",
+          "kind": 128,
+          "kindString": "Class",
+          "flags": {
+            "isExported": true
+          },
+          "sources": [
+            {
+              "fileName": "export-declaration.d.ts",
+              "line": 3,
+              "character": 25
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Classes",
+          "kind": 128,
+          "children": [
+            6,
+            7
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "export-declaration.d.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "External modules",
+      "kind": 1,
+      "children": [
+        1,
+        5
+      ]
+    }
+  ]
+}

--- a/src/test/converter/decorators/decorators.ts
+++ b/src/test/converter/decorators/decorators.ts
@@ -4,8 +4,7 @@
 @decoratorWithOptions({
     name: 'Name of class'
 })
-class DecoratedClass
-{
+class DecoratedClass {
     /**
      * A decorated method.
      */
@@ -14,26 +13,23 @@ class DecoratedClass
     decoratedMethod() { }
 }
 
-
 /**
  * A decorator with no options.
  */
-function decoratorAtom(target:Object, propertyKey:string|symbol, descriptor:TypedPropertyDescriptor<any>) {
+function decoratorAtom(target: Object, propertyKey: string|symbol, descriptor: TypedPropertyDescriptor<any>) {
     target[propertyKey].writable = true;
 }
-
 
 /**
  * A decorator with a parameter.
  *
  * @param value  The parameter of this decorator.
  */
-function decoratorWithParam(value:boolean):MethodDecorator {
-    return function (target:Object, propertyKey:string|symbol, descriptor:TypedPropertyDescriptor<any>) {
+function decoratorWithParam(value: boolean): MethodDecorator {
+    return function (target: Object, propertyKey: string|symbol, descriptor: TypedPropertyDescriptor<any>) {
         target[propertyKey].enumerable = value;
-    }
+    };
 }
-
 
 /**
  * A decorator consuming an options object.
@@ -41,8 +37,9 @@ function decoratorWithParam(value:boolean):MethodDecorator {
  * @param options  The options object of this decorator.
  * @param options.name  A property on the options object of this decorator.
  */
-function decoratorWithOptions(options:{name:string}): ClassDecorator {
+function decoratorWithOptions(options: {name: string}): ClassDecorator {
     return function (target) {
         (target as any).options = options;
     };
 }
+export {}

--- a/src/test/converter/decorators/specs.json
+++ b/src/test/converter/decorators/specs.json
@@ -83,7 +83,7 @@
               "sources": [
                 {
                   "fileName": "decorators.ts",
-                  "line": 14,
+                  "line": 13,
                   "character": 19
                 }
               ]
@@ -188,7 +188,7 @@
           "sources": [
             {
               "fileName": "decorators.ts",
-              "line": 21,
+              "line": 19,
               "character": 22
             }
           ]
@@ -247,8 +247,8 @@
                           "sources": [
                             {
                               "fileName": "decorators.ts",
-                              "line": 44,
-                              "character": 43
+                              "line": 40,
+                              "character": 44
                             }
                           ],
                           "type": {
@@ -269,7 +269,7 @@
                       "sources": [
                         {
                           "fileName": "decorators.ts",
-                          "line": 44,
+                          "line": 40,
                           "character": 38
                         }
                       ]
@@ -286,7 +286,7 @@
           "sources": [
             {
               "fileName": "decorators.ts",
-              "line": 44,
+              "line": 40,
               "character": 29
             }
           ]
@@ -339,7 +339,7 @@
           "sources": [
             {
               "fileName": "decorators.ts",
-              "line": 31,
+              "line": 28,
               "character": 27
             }
           ]

--- a/src/test/converter/destructuring/destructuring.ts
+++ b/src/test/converter/destructuring/destructuring.ts
@@ -1,8 +1,7 @@
 /**
  * Destructuring objects.
  */
-const {destructObjectA, destructObjectB, destructObjectC} = {destructObjectA:0, destructObjectB:'string', destructObjectC:0};
-
+const {destructObjectA, destructObjectB, destructObjectC} = {destructObjectA: 0, destructObjectB: 'string', destructObjectC: 0};
 
 /**
  * Destructuring arrays.
@@ -22,4 +21,6 @@ const [destructArrayWithIgnoresA, , ...destructArrayWithIgnoresRest] = [1, 2, 3,
 /**
  * Destructuring function parameters.
  */
-function drawText({text = "", location:[x, y] = [0, 0], bold = false}) { }
+function drawText({text = '', location: [x, y] = [0, 0], bold = false}) { }
+
+export {};

--- a/src/test/converter/destructuring/specs.json
+++ b/src/test/converter/destructuring/specs.json
@@ -23,7 +23,7 @@
           "sources": [
             {
               "fileName": "destructuring.ts",
-              "line": 10,
+              "line": 9,
               "character": 21
             }
           ],
@@ -41,7 +41,7 @@
           "sources": [
             {
               "fileName": "destructuring.ts",
-              "line": 10,
+              "line": 9,
               "character": 37
             }
           ],
@@ -59,7 +59,7 @@
           "sources": [
             {
               "fileName": "destructuring.ts",
-              "line": 10,
+              "line": 9,
               "character": 53
             }
           ],
@@ -87,7 +87,7 @@
           "sources": [
             {
               "fileName": "destructuring.ts",
-              "line": 20,
+              "line": 19,
               "character": 32
             }
           ],
@@ -105,7 +105,7 @@
           "sources": [
             {
               "fileName": "destructuring.ts",
-              "line": 20,
+              "line": 19,
               "character": 67
             }
           ],
@@ -132,7 +132,7 @@
           "sources": [
             {
               "fileName": "destructuring.ts",
-              "line": 15,
+              "line": 14,
               "character": 79
             }
           ],
@@ -159,7 +159,7 @@
           "sources": [
             {
               "fileName": "destructuring.ts",
-              "line": 15,
+              "line": 14,
               "character": 29
             }
           ],
@@ -177,7 +177,7 @@
           "sources": [
             {
               "fileName": "destructuring.ts",
-              "line": 15,
+              "line": 14,
               "character": 53
             }
           ],
@@ -282,8 +282,8 @@
                           "sources": [
                             {
                               "fileName": "destructuring.ts",
-                              "line": 25,
-                              "character": 60
+                              "line": 24,
+                              "character": 61
                             }
                           ],
                           "type": {
@@ -301,8 +301,8 @@
                           "sources": [
                             {
                               "fileName": "destructuring.ts",
-                              "line": 25,
-                              "character": 45
+                              "line": 24,
+                              "character": 46
                             }
                           ],
                           "type": {
@@ -318,7 +318,7 @@
                               }
                             ]
                           },
-                          "defaultValue": " [0, 0]"
+                          "defaultValue": "[0, 0]"
                         },
                         {
                           "id": 17,
@@ -329,7 +329,7 @@
                           "sources": [
                             {
                               "fileName": "destructuring.ts",
-                              "line": 25,
+                              "line": 24,
                               "character": 23
                             }
                           ],
@@ -354,7 +354,7 @@
                       "sources": [
                         {
                           "fileName": "destructuring.ts",
-                          "line": 25,
+                          "line": 24,
                           "character": 18
                         }
                       ]
@@ -371,7 +371,7 @@
           "sources": [
             {
               "fileName": "destructuring.ts",
-              "line": 25,
+              "line": 24,
               "character": 17
             }
           ]

--- a/src/test/converter/dots.in.path/specs.json
+++ b/src/test/converter/dots.in.path/specs.json
@@ -28,7 +28,9 @@
               "name": "exportedFunction",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is a simple exported function."
               },
@@ -38,7 +40,9 @@
                   "name": "arg",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "reference",
                     "name": "EmptyInterface",

--- a/src/test/converter/enum/specs.json
+++ b/src/test/converter/enum/specs.json
@@ -124,7 +124,9 @@
                   "name": "enumFunction",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "This is a function appended to an enumeration."
                   },

--- a/src/test/converter/events-overloads/events-overloads.ts
+++ b/src/test/converter/events-overloads/events-overloads.ts
@@ -3,16 +3,15 @@
  *
  * @see https://github.com/sebastian-lenz/typedoc/issues/136
  */
-interface Test
-{
+interface Test {
     /**
      * Subscribe for a general event by name.
      *
      * @event
      * @param event The name of the event to subscribe for.
-     * @param handler The handler called when the event occure.
+     * @param handler The handler called when the event occurs.
      */
-    on(event: string, handler: (e:any) => void): void;
+    on(event: string, handler: (e: any) => void): void;
 
     /**
      * Subscribe for error notifications.
@@ -21,7 +20,7 @@ interface Test
      * @param event The name of the event to subscribe for.
      * @param handler A handler that will receive the error details
      */
-    on(event: "error", handler: (e:any) => void): void;
+    on(event: 'error', handler: (e: any) => void): void;
 
     /**
      * Subscribe for progress notifications.
@@ -30,7 +29,7 @@ interface Test
      * @param event The name of the event to subscribe for.
      * @param handler A handler that will receive a progress event with the current and expected total bytes
      */
-    on(event: "progress", handler: (e:any) => void): void;
+    on(event: 'progress', handler: (e: any) => void): void;
 
     /**
      * Subscribe for success notification.
@@ -39,5 +38,7 @@ interface Test
      * @param event The name of the event to subscribe for.
      * @param handler A function that will be called with general event data upon successful completion
      */
-    on(event: "complete", handler: (e:any) => void): void;
+    on(event: 'complete', handler: (e: any) => void): void;
 }
+
+export {};

--- a/src/test/converter/events-overloads/specs.json
+++ b/src/test/converter/events-overloads/specs.json
@@ -68,7 +68,7 @@
                       "kindString": "Parameter",
                       "flags": {},
                       "comment": {
-                        "text": "The handler called when the event occure.\n"
+                        "text": "The handler called when the event occurs.\n"
                       },
                       "type": {
                         "type": "reflection",
@@ -107,7 +107,7 @@
                           "sources": [
                             {
                               "fileName": "events-overloads.ts",
-                              "line": 15,
+                              "line": 14,
                               "character": 30
                             }
                           ]
@@ -190,7 +190,7 @@
                           "sources": [
                             {
                               "fileName": "events-overloads.ts",
-                              "line": 24,
+                              "line": 23,
                               "character": 31
                             }
                           ]
@@ -273,7 +273,7 @@
                           "sources": [
                             {
                               "fileName": "events-overloads.ts",
-                              "line": 33,
+                              "line": 32,
                               "character": 34
                             }
                           ]
@@ -356,7 +356,7 @@
                           "sources": [
                             {
                               "fileName": "events-overloads.ts",
-                              "line": 42,
+                              "line": 41,
                               "character": 34
                             }
                           ]
@@ -373,22 +373,22 @@
               "sources": [
                 {
                   "fileName": "events-overloads.ts",
-                  "line": 15,
+                  "line": 14,
                   "character": 6
                 },
                 {
                   "fileName": "events-overloads.ts",
-                  "line": 24,
+                  "line": 23,
                   "character": 6
                 },
                 {
                   "fileName": "events-overloads.ts",
-                  "line": 33,
+                  "line": 32,
                   "character": 6
                 },
                 {
                   "fileName": "events-overloads.ts",
-                  "line": 42,
+                  "line": 41,
                   "character": 6
                 }
               ]

--- a/src/test/converter/events/events.ts
+++ b/src/test/converter/events/events.ts
@@ -1,9 +1,10 @@
-class EventDispatcher
-{
+class EventDispatcher {
     /**
      * This is an event documentation.
      * @event
      */
-    static EVENT_CLICK:string = 'click';
+    static EVENT_CLICK = 'click';
 
 }
+
+export {};

--- a/src/test/converter/events/specs.json
+++ b/src/test/converter/events/specs.json
@@ -35,7 +35,7 @@
               "sources": [
                 {
                   "fileName": "events.ts",
-                  "line": 7,
+                  "line": 6,
                   "character": 22
                 }
               ],

--- a/src/test/converter/export-with-local/specs-without-exported.json
+++ b/src/test/converter/export-with-local/specs-without-exported.json
@@ -50,14 +50,18 @@
               "name": "add",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "parameters": [
                 {
                   "id": 5,
                   "name": "x",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"
@@ -68,7 +72,9 @@
                   "name": "y",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"

--- a/src/test/converter/export-with-local/specs.json
+++ b/src/test/converter/export-with-local/specs.json
@@ -71,14 +71,18 @@
               "name": "add",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "parameters": [
                 {
                   "id": 5,
                   "name": "x",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"
@@ -89,7 +93,9 @@
                   "name": "y",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"

--- a/src/test/converter/export/export.ts
+++ b/src/test/converter/export/export.ts
@@ -1,5 +1,13 @@
-export const x = 5;
+import ModDefault, { a as b } from './mod';
+import * as Mod from './mod';
+export * from './mod';
 
-export function add(x: number, y: number) {
+export { b as c, add, Mod, ModDefault };
+
+function add(x: number, y: number) {
     return x + y;
 }
+
+// Note that this will show up in the docs, not the default function from mod2.
+// export * from './mod2' does *not* re-export the default function.
+export default function (a: number) {}

--- a/src/test/converter/export/mod.ts
+++ b/src/test/converter/export/mod.ts
@@ -1,0 +1,16 @@
+/**
+ * A simple named export that will be exported from export.ts
+ */
+export const a = 1;
+
+/**
+ * An export of a local under a different name.
+ */
+export { a as b };
+
+/**
+ * Will not be re-exported from export.ts using export * from...
+ */
+export default function() {
+    console.log('Default');
+}

--- a/src/test/converter/export/mod.ts
+++ b/src/test/converter/export/mod.ts
@@ -9,6 +9,11 @@ export const a = 1;
 export { a as b };
 
 /**
+ * An export with a module specifier that comes from this file.
+ */
+export { a as c } from './mod';
+
+/**
  * Will not be re-exported from export.ts using export * from...
  */
 export default function() {

--- a/src/test/converter/export/specs.json
+++ b/src/test/converter/export/specs.json
@@ -5,7 +5,7 @@
   "flags": {},
   "children": [
     {
-      "id": 6,
+      "id": 7,
       "name": "\"export\"",
       "kind": 1,
       "kindString": "External module",
@@ -15,27 +15,7 @@
       "originalName": "%BASE%/export/export.ts",
       "children": [
         {
-          "id": 10,
-          "name": "Mod",
-          "kind": 16777216,
-          "kindString": "Reference",
-          "flags": {
-            "isExported": true
-          },
-          "target": 1
-        },
-        {
-          "id": 11,
-          "name": "ModDefault",
-          "kind": 16777216,
-          "kindString": "Reference",
-          "flags": {
-            "isExported": true
-          },
-          "target": 4
-        },
-        {
-          "id": 7,
+          "id": 8,
           "name": "a",
           "kind": 16777216,
           "kindString": "Reference",
@@ -45,7 +25,7 @@
           "target": 2
         },
         {
-          "id": 8,
+          "id": 9,
           "name": "b",
           "kind": 16777216,
           "kindString": "Reference",
@@ -55,7 +35,17 @@
           "target": 3
         },
         {
-          "id": 9,
+          "id": 10,
+          "name": "c",
+          "kind": 16777216,
+          "kindString": "Reference",
+          "flags": {
+            "isExported": true
+          },
+          "target": 4
+        },
+        {
+          "id": 11,
           "name": "c",
           "kind": 16777216,
           "kindString": "Reference",
@@ -161,11 +151,10 @@
           "title": "References",
           "kind": 16777216,
           "children": [
-            10,
-            11,
-            7,
             8,
-            9
+            9,
+            10,
+            11
           ]
         },
         {
@@ -206,6 +195,16 @@
           "target": 2
         },
         {
+          "id": 4,
+          "name": "c",
+          "kind": 16777216,
+          "kindString": "Reference",
+          "flags": {
+            "isExported": true
+          },
+          "target": 2
+        },
+        {
           "id": 2,
           "name": "a",
           "kind": 32,
@@ -231,14 +230,14 @@
           "defaultValue": "1"
         },
         {
-          "id": 4,
+          "id": 5,
           "name": "default",
           "kind": 64,
           "kindString": "Function",
           "flags": {},
           "signatures": [
             {
-              "id": 5,
+              "id": 6,
               "name": "default",
               "kind": 4096,
               "kindString": "Call signature",
@@ -255,8 +254,8 @@
           "sources": [
             {
               "fileName": "mod.ts",
-              "line": 9,
-              "character": 18
+              "line": 14,
+              "character": 31
             }
           ]
         }
@@ -266,7 +265,8 @@
           "title": "References",
           "kind": 16777216,
           "children": [
-            3
+            3,
+            4
           ]
         },
         {
@@ -280,7 +280,7 @@
           "title": "Functions",
           "kind": 64,
           "children": [
-            4
+            5
           ]
         }
       ],
@@ -298,7 +298,7 @@
       "title": "External modules",
       "kind": 1,
       "children": [
-        6,
+        7,
         1
       ]
     }

--- a/src/test/converter/export/specs.json
+++ b/src/test/converter/export/specs.json
@@ -59,7 +59,9 @@
           "name": "add",
           "kind": 64,
           "kindString": "Function",
-          "flags": {},
+          "flags": {
+            "isExported": true
+          },
           "signatures": [
             {
               "id": 13,

--- a/src/test/converter/export/specs.json
+++ b/src/test/converter/export/specs.json
@@ -5,7 +5,7 @@
   "flags": {},
   "children": [
     {
-      "id": 1,
+      "id": 6,
       "name": "\"export\"",
       "kind": 1,
       "kindString": "External module",
@@ -15,45 +15,71 @@
       "originalName": "%BASE%/export/export.ts",
       "children": [
         {
-          "id": 2,
-          "name": "x",
-          "kind": 32,
-          "kindString": "Variable",
-          "flags": {
-            "isExported": true,
-            "isConst": true
-          },
-          "sources": [
-            {
-              "fileName": "export.ts",
-              "line": 1,
-              "character": 14
-            }
-          ],
-          "type": {
-            "type": "unknown",
-            "name": "5"
-          },
-          "defaultValue": "5"
-        },
-        {
-          "id": 3,
-          "name": "add",
-          "kind": 64,
-          "kindString": "Function",
+          "id": 10,
+          "name": "Mod",
+          "kind": 16777216,
+          "kindString": "Reference",
           "flags": {
             "isExported": true
           },
+          "target": 1
+        },
+        {
+          "id": 11,
+          "name": "ModDefault",
+          "kind": 16777216,
+          "kindString": "Reference",
+          "flags": {
+            "isExported": true
+          },
+          "target": 4
+        },
+        {
+          "id": 7,
+          "name": "a",
+          "kind": 16777216,
+          "kindString": "Reference",
+          "flags": {
+            "isExported": true
+          },
+          "target": 2
+        },
+        {
+          "id": 8,
+          "name": "b",
+          "kind": 16777216,
+          "kindString": "Reference",
+          "flags": {
+            "isExported": true
+          },
+          "target": 3
+        },
+        {
+          "id": 9,
+          "name": "c",
+          "kind": 16777216,
+          "kindString": "Reference",
+          "flags": {
+            "isExported": true
+          },
+          "target": 2
+        },
+        {
+          "id": 12,
+          "name": "add",
+          "kind": 64,
+          "kindString": "Function",
+          "flags": {},
           "signatures": [
             {
-              "id": 4,
+              "id": 13,
               "name": "add",
               "kind": 4096,
               "kindString": "Call signature",
               "flags": {},
               "parameters": [
                 {
-                  "id": 5,
+                  "id": 14,
                   "name": "x",
                   "kind": 32768,
                   "kindString": "Parameter",
@@ -64,7 +90,7 @@
                   }
                 },
                 {
-                  "id": 6,
+                  "id": 15,
                   "name": "y",
                   "kind": 32768,
                   "kindString": "Parameter",
@@ -84,13 +110,165 @@
           "sources": [
             {
               "fileName": "export.ts",
-              "line": 3,
-              "character": 19
+              "line": 7,
+              "character": 12
+            }
+          ]
+        },
+        {
+          "id": 16,
+          "name": "default",
+          "kind": 64,
+          "kindString": "Function",
+          "flags": {},
+          "signatures": [
+            {
+              "id": 17,
+              "name": "default",
+              "kind": 4096,
+              "kindString": "Call signature",
+              "flags": {},
+              "parameters": [
+                {
+                  "id": 18,
+                  "name": "a",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "void"
+              }
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "export.ts",
+              "line": 9,
+              "character": 1
             }
           ]
         }
       ],
       "groups": [
+        {
+          "title": "References",
+          "kind": 16777216,
+          "children": [
+            10,
+            11,
+            7,
+            8,
+            9
+          ]
+        },
+        {
+          "title": "Functions",
+          "kind": 64,
+          "children": [
+            12,
+            16
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "fileName": "export.ts",
+          "line": 1,
+          "character": 0
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "\"mod\"",
+      "kind": 1,
+      "kindString": "External module",
+      "flags": {
+        "isExported": true
+      },
+      "originalName": "%BASE%/export/mod.ts",
+      "children": [
+        {
+          "id": 3,
+          "name": "b",
+          "kind": 16777216,
+          "kindString": "Reference",
+          "flags": {
+            "isExported": true
+          },
+          "target": 2
+        },
+        {
+          "id": 2,
+          "name": "a",
+          "kind": 32,
+          "kindString": "Variable",
+          "flags": {
+            "isExported": true,
+            "isConst": true
+          },
+          "comment": {
+            "shortText": "A simple named export that will be exported from export.ts"
+          },
+          "sources": [
+            {
+              "fileName": "mod.ts",
+              "line": 4,
+              "character": 14
+            }
+          ],
+          "type": {
+            "type": "unknown",
+            "name": "1"
+          },
+          "defaultValue": "1"
+        },
+        {
+          "id": 4,
+          "name": "default",
+          "kind": 64,
+          "kindString": "Function",
+          "flags": {},
+          "signatures": [
+            {
+              "id": 5,
+              "name": "default",
+              "kind": 4096,
+              "kindString": "Call signature",
+              "flags": {},
+              "comment": {
+                "shortText": "Will not be re-exported from export.ts using export * from..."
+              },
+              "type": {
+                "type": "intrinsic",
+                "name": "void"
+              }
+            }
+          ],
+          "sources": [
+            {
+              "fileName": "mod.ts",
+              "line": 9,
+              "character": 18
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "References",
+          "kind": 16777216,
+          "children": [
+            3
+          ]
+        },
         {
           "title": "Variables",
           "kind": 32,
@@ -102,13 +280,13 @@
           "title": "Functions",
           "kind": 64,
           "children": [
-            3
+            4
           ]
         }
       ],
       "sources": [
         {
-          "fileName": "export.ts",
+          "fileName": "mod.ts",
           "line": 1,
           "character": 0
         }
@@ -120,6 +298,7 @@
       "title": "External modules",
       "kind": 1,
       "children": [
+        6,
         1
       ]
     }

--- a/src/test/converter/export/specs.json
+++ b/src/test/converter/export/specs.json
@@ -68,14 +68,18 @@
               "name": "add",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "parameters": [
                 {
                   "id": 14,
                   "name": "x",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"
@@ -86,7 +90,9 @@
                   "name": "y",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"

--- a/src/test/converter/function/specs.json
+++ b/src/test/converter/function/specs.json
@@ -444,7 +444,7 @@
                     "type": "intrinsic",
                     "name": "number"
                   },
-                  "defaultValue": " Number.NaN"
+                  "defaultValue": "Number.NaN"
                 },
                 {
                   "id": 23,
@@ -474,7 +474,7 @@
                     "type": "intrinsic",
                     "name": "boolean"
                   },
-                  "defaultValue": " null"
+                  "defaultValue": "null"
                 }
               ],
               "type": {

--- a/src/test/converter/function/specs.json
+++ b/src/test/converter/function/specs.json
@@ -31,7 +31,9 @@
               "name": "moduleFunction",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is a function that is extended by a module."
               },
@@ -41,7 +43,9 @@
                   "name": "arg",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "An argument.\n"
                   },
@@ -186,7 +190,9 @@
               "name": "assertIsNonNull",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "Asserts that an argument is not null."
               },
@@ -196,7 +202,9 @@
                   "name": "T",
                   "kind": 131072,
                   "kindString": "Type parameter",
-                  "flags": {}
+                  "flags": {
+                    "isExported": true
+                  }
                 }
               ],
               "parameters": [
@@ -205,7 +213,9 @@
                   "name": "arg",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "\n"
                   },
@@ -261,7 +271,9 @@
               "name": "assertionFunction",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is an assertion function."
               },
@@ -271,7 +283,9 @@
                   "name": "condition",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "The condition that is asserted to be true when this function returns.\n"
                   },
@@ -310,7 +324,9 @@
               "name": "checkerFunction",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "Assertion function with a type."
               },
@@ -320,7 +336,9 @@
                   "name": "anything",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "\n"
                   },
@@ -363,7 +381,9 @@
               "name": "exportedFunction",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is a simple exported function."
               },
@@ -395,7 +415,9 @@
               "name": "functionWithDefaults",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is a function with a parameter that has a default value.",
                 "returns": "This is the return value of the function.\n"
@@ -406,7 +428,9 @@
                   "name": "valueA",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "A parameter with a default string value."
                   },
@@ -421,7 +445,9 @@
                   "name": "valueB",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "A parameter with a default numeric value."
                   },
@@ -436,7 +462,9 @@
                   "name": "valueC",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "A parameter with a default NaN value."
                   },
@@ -451,7 +479,9 @@
                   "name": "valueD",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "A parameter with a default boolean value."
                   },
@@ -466,7 +496,9 @@
                   "name": "valueE",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "A parameter with a default null value."
                   },
@@ -505,7 +537,9 @@
               "name": "functionWithOptionalValue",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is a function with a parameter that is optional."
               },
@@ -515,7 +549,9 @@
                   "name": "requiredParam",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "A normal parameter."
                   },
@@ -530,6 +566,7 @@
                   "kind": 32768,
                   "kindString": "Parameter",
                   "flags": {
+                    "isExported": true,
                     "isOptional": true
                   },
                   "comment": {
@@ -569,7 +606,9 @@
               "name": "functionWithParameters",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is a function with multiple arguments and a return value.",
                 "returns": "This is the return value of the function.\n"
@@ -580,7 +619,9 @@
                   "name": "paramZ",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "This is a string parameter."
                   },
@@ -594,7 +635,9 @@
                   "name": "paramG",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "This is a parameter flagged with any.\n    This sentence is placed in the next line.\n"
                   },
@@ -608,7 +651,9 @@
                   "name": "paramA",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "\n  This is a **parameter** pointing to an interface.\n\n  ~~~\n  const value:BaseClass = new BaseClass('test');\n  functionWithArguments('arg', 0, value);\n  ~~~\n"
                   },
@@ -728,7 +773,9 @@
               "name": "isNonNull",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "Checks that an argument is not null."
               },
@@ -738,7 +785,9 @@
                   "name": "T",
                   "kind": 131072,
                   "kindString": "Type parameter",
-                  "flags": {}
+                  "flags": {
+                    "isExported": true
+                  }
                 }
               ],
               "parameters": [
@@ -747,7 +796,9 @@
                   "name": "arg",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "\n"
                   },
@@ -807,7 +858,9 @@
               "name": "multipleSignatures",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is the first signature of a function with multiple signatures.",
                 "returns": "This is the return value of the function.\n"
@@ -818,7 +871,9 @@
                   "name": "value",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "The name value.\n"
                   },
@@ -838,7 +893,9 @@
               "name": "multipleSignatures",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is the second signature of a function with multiple signatures.",
                 "returns": "This is the return value of the function.\n"
@@ -849,7 +906,9 @@
                   "name": "value",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "text": "An object containing the name value."
                   },
@@ -860,14 +919,18 @@
                       "name": "__type",
                       "kind": 65536,
                       "kindString": "Type literal",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "children": [
                         {
                           "id": 34,
                           "name": "name",
                           "kind": 32,
                           "kindString": "Variable",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "comment": {
                             "text": "A value of the object.\n"
                           },
@@ -947,7 +1010,9 @@
               "name": "variableFunction",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "This is a function that is assigned to a variable.",
                 "returns": "This is the return value of the function.\n"
@@ -958,7 +1023,9 @@
                   "name": "someParam",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "This is some numeric parameter."
                   },

--- a/src/test/converter/generic-class/generic-class.ts
+++ b/src/test/converter/generic-class/generic-class.ts
@@ -6,18 +6,18 @@ class GenericClass<T> {
     /**
      * Generic property.
      */
-    protected value:T;
+    protected value: T;
 
     /**
      * Generic property array.
      */
-    protected values:T[];
+    protected values: T[];
 
     /**
      * Constructor short text.
      * @param value  Constructor parameter.
      */
-    constructor(value:T) {
+    constructor(value: T) {
         this.value = value;
     }
 
@@ -25,13 +25,14 @@ class GenericClass<T> {
      * getValue short text.
      * @return Return value comment.
      */
-    getValue():T {
+    getValue(): T {
         return this.value;
     }
 }
-
 
 /**
  * NonGenericClass short text.
  */
 class NonGenericClass extends GenericClass<string> {}
+
+export {};

--- a/src/test/converter/generic-class/specs.json
+++ b/src/test/converter/generic-class/specs.json
@@ -82,7 +82,7 @@
                 {
                   "fileName": "generic-class.ts",
                   "line": 14,
-                  "character": 25
+                  "character": 26
                 }
               ]
             },
@@ -267,7 +267,7 @@
                 {
                   "fileName": "generic-class.ts",
                   "line": 14,
-                  "character": 25
+                  "character": 26
                 }
               ],
               "inheritedFrom": {
@@ -404,7 +404,7 @@
           "sources": [
             {
               "fileName": "generic-class.ts",
-              "line": 37,
+              "line": 36,
               "character": 21
             }
           ],

--- a/src/test/converter/generic-function/generic-function.ts
+++ b/src/test/converter/generic-function/generic-function.ts
@@ -4,10 +4,9 @@
  * @param value  Generic function parameter.
  * @returns      Generic function return value.
  */
-function genericFunction<T extends Object>(value:T):T {
+function genericFunction<T extends Object>(value: T): T {
     return value;
 }
-
 
 /**
  * A function with a generic type array parameter.
@@ -16,6 +15,8 @@ function genericFunction<T extends Object>(value:T):T {
  * @param params A generic array parameter.
  * @returns A generic array.
  */
-function functionWithGenericArrayParameter<T>(param:T, params:T[]):T[] {
+function functionWithGenericArrayParameter<T>(param: T, params: T[]): T[] {
     return params;
 }
+
+export {};

--- a/src/test/converter/generic-function/specs.json
+++ b/src/test/converter/generic-function/specs.json
@@ -85,7 +85,7 @@
           "sources": [
             {
               "fileName": "generic-function.ts",
-              "line": 19,
+              "line": 18,
               "character": 42
             }
           ]

--- a/src/test/converter/getter-setter/getter-setter.ts
+++ b/src/test/converter/getter-setter/getter-setter.ts
@@ -1,12 +1,12 @@
-class GetterSetter
-{
-    private _name:string;
+class GetterSetter {
+    private _name: string;
 
+    get name(): string { return this._name; }
+    set name(value: string) { this._name = value; }
 
-    get name():string { return this._name; }
-    set name(value:string) { this._name = value; }
+    get readOnlyName(): string { return this._name; }
 
-    get readOnlyName():string { return this._name; }
-
-    set writeOnlyName(value:string) { this._name = value; }
+    set writeOnlyName(value: string) { this._name = value; }
 }
+
+export {};

--- a/src/test/converter/getter-setter/specs.json
+++ b/src/test/converter/getter-setter/specs.json
@@ -32,7 +32,7 @@
               "sources": [
                 {
                   "fileName": "getter-setter.ts",
-                  "line": 3,
+                  "line": 2,
                   "character": 17
                 }
               ],
@@ -89,12 +89,12 @@
               "sources": [
                 {
                   "fileName": "getter-setter.ts",
-                  "line": 6,
+                  "line": 4,
                   "character": 12
                 },
                 {
                   "fileName": "getter-setter.ts",
-                  "line": 7,
+                  "line": 5,
                   "character": 12
                 }
               ]
@@ -121,7 +121,7 @@
               "sources": [
                 {
                   "fileName": "getter-setter.ts",
-                  "line": 9,
+                  "line": 7,
                   "character": 20
                 }
               ]
@@ -161,7 +161,7 @@
               "sources": [
                 {
                   "fileName": "getter-setter.ts",
-                  "line": 11,
+                  "line": 9,
                   "character": 21
                 }
               ]

--- a/src/test/converter/implicit-types/specs.json
+++ b/src/test/converter/implicit-types/specs.json
@@ -239,7 +239,9 @@
               "name": "getBreakpoints",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "type": {
                 "type": "reflection",
                 "declaration": {
@@ -247,14 +249,18 @@
                   "name": "__type",
                   "kind": 65536,
                   "kindString": "Type literal",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "children": [
                     {
                       "id": 17,
                       "name": "large",
                       "kind": 32,
                       "kindString": "Variable",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "sources": [
                         {
                           "fileName": "implicit-types.ts",
@@ -273,7 +279,9 @@
                       "name": "medium",
                       "kind": 32,
                       "kindString": "Variable",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "sources": [
                         {
                           "fileName": "implicit-types.ts",
@@ -292,7 +300,9 @@
                       "name": "small",
                       "kind": 32,
                       "kindString": "Variable",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "sources": [
                         {
                           "fileName": "implicit-types.ts",
@@ -311,7 +321,9 @@
                       "name": "xlarge",
                       "kind": 32,
                       "kindString": "Variable",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "sources": [
                         {
                           "fileName": "implicit-types.ts",
@@ -330,7 +342,9 @@
                       "name": "xxlarge",
                       "kind": 32,
                       "kindString": "Variable",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "sources": [
                         {
                           "fileName": "implicit-types.ts",

--- a/src/test/converter/interface-empty/interface-empty.ts
+++ b/src/test/converter/interface-empty/interface-empty.ts
@@ -4,11 +4,12 @@
 interface EmptyInterface {
 }
 
-
 /**
  * A class implementing an empty interface.
  */
 class ClassImplementingEmptyInterface implements EmptyInterface {
-    private name:string;
+    private name: string;
     public goto() {}
 }
+
+export {};

--- a/src/test/converter/interface-empty/specs.json
+++ b/src/test/converter/interface-empty/specs.json
@@ -35,7 +35,7 @@
               "sources": [
                 {
                   "fileName": "interface-empty.ts",
-                  "line": 12,
+                  "line": 11,
                   "character": 16
                 }
               ],
@@ -68,7 +68,7 @@
               "sources": [
                 {
                   "fileName": "interface-empty.ts",
-                  "line": 13,
+                  "line": 12,
                   "character": 15
                 }
               ]
@@ -93,7 +93,7 @@
           "sources": [
             {
               "fileName": "interface-empty.ts",
-              "line": 11,
+              "line": 10,
               "character": 37
             }
           ],

--- a/src/test/converter/interface-implementation/interface-implementation.ts
+++ b/src/test/converter/interface-implementation/interface-implementation.ts
@@ -1,75 +1,67 @@
-module Forms
-{
+module Forms {
     /**
      * Function signature of an event listener callback
      */
-    interface IEventListener<T>
-    {
-        (parameter:T):any;
+    interface IEventListener<T> {
+        (parameter: T): any;
     }
-
 
     /**
      * Encapsulates a subscription to an event dispatcher, and allows for unsubscribing
      */
-    interface ISubscription<T>
-    {
-        listener: IEventListener<T>
-        priority: number
-        filter: any
+    interface ISubscription<T> {
+        listener: IEventListener<T>;
+        priority: number;
+        filter: any;
 
         /**
          * Remove this subscription from its dispatcher
          */
-        unsubscribe():void
+        unsubscribe(): void;
     }
 
+    class Subscription<V> implements ISubscription<V> {
+        constructor(public listener: IEventListener<V>, public filter: any, public priority: number, public dispatcher: EventDispatcher<V>) { }
 
-    class Subscription<V> implements ISubscription<V>
-    {
-        constructor(public listener:IEventListener<V>, public filter:any, public priority:number, public dispatcher:EventDispatcher<V>) { }
-
-        unsubscribe():void { }
+        unsubscribe(): void { }
     }
-
 
     /**
      * The main interface of the event system.
      * An IEventDispatcher is an object that keeps a list of listeners, and sends dispatches events of a certain type to them.
      * This might otherwise be known as a Signal.
      */
-    export interface IEventDispatcher<U>
-    {
-        add(listener:IEventListener<U>, filter?:any, priority?:number):ISubscription<U>;
-        remove(subscription:ISubscription<U>): void;
-        dispatch(parameter:U): boolean;
-        clear():void;
-        hasListeners():boolean;
+    export interface IEventDispatcher<U> {
+        add(listener: IEventListener<U>, filter?: any, priority?: number): ISubscription<U>;
+        remove(subscription: ISubscription<U>): void;
+        dispatch(parameter: U): boolean;
+        clear(): void;
+        hasListeners(): boolean;
     }
-
 
     /**
      * Implementation of IEventDispatcher
      * @see IEventDispatcher
      */
-    export class EventDispatcher<T> implements IEventDispatcher<T>
-    {
-        private subscriptions:ISubscription<T>[];
+    export class EventDispatcher<T> implements IEventDispatcher<T> {
+        private subscriptions: ISubscription<T>[];
 
-        add(listener:IEventListener<T>, filter:any=null, priority:number = 0):ISubscription<T> {
+        add(listener: IEventListener<T>, filter: any= null, priority: number = 0): ISubscription<T> {
             return new Subscription<T>(listener, filter, priority, this);
         }
 
-        remove(subscription:ISubscription<T>):void { }
+        remove(subscription: ISubscription<T>): void { }
 
-        dispatch(event:T):boolean {
+        dispatch(event: T): boolean {
             return false;
         }
 
-        clear():void { }
+        clear(): void { }
 
-        hasListeners():boolean {
+        hasListeners(): boolean {
             return false;
         }
     }
 }
+
+export {};

--- a/src/test/converter/interface-implementation/specs.json
+++ b/src/test/converter/interface-implementation/specs.json
@@ -60,7 +60,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 57,
+                      "line": 47,
                       "character": 29
                     }
                   ],
@@ -159,7 +159,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 59,
+                      "line": 49,
                       "character": 11
                     }
                   ],
@@ -198,7 +198,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 69,
+                      "line": 59,
                       "character": 13
                     }
                   ],
@@ -250,7 +250,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 65,
+                      "line": 55,
                       "character": 16
                     }
                   ],
@@ -289,7 +289,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 71,
+                      "line": 61,
                       "character": 20
                     }
                   ],
@@ -348,7 +348,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 63,
+                      "line": 53,
                       "character": 14
                     }
                   ],
@@ -382,7 +382,7 @@
               "sources": [
                 {
                   "fileName": "interface-implementation.ts",
-                  "line": 55,
+                  "line": 46,
                   "character": 32
                 }
               ],
@@ -499,8 +499,8 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 29,
-                      "character": 5
+                      "line": 23,
+                      "character": 55
                     }
                   ]
                 },
@@ -516,8 +516,8 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 30,
-                      "character": 115
+                      "line": 24,
+                      "character": 118
                     }
                   ],
                   "type": {
@@ -544,8 +544,8 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 30,
-                      "character": 68
+                      "line": 24,
+                      "character": 69
                     }
                   ],
                   "type": {
@@ -570,7 +570,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 30,
+                      "line": 24,
                       "character": 35
                     }
                   ],
@@ -603,8 +603,8 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 30,
-                      "character": 89
+                      "line": 24,
+                      "character": 91
                     }
                   ],
                   "type": {
@@ -644,7 +644,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 32,
+                      "line": 26,
                       "character": 19
                     }
                   ],
@@ -684,7 +684,7 @@
               "sources": [
                 {
                   "fileName": "interface-implementation.ts",
-                  "line": 28,
+                  "line": 23,
                   "character": 22
                 }
               ],
@@ -800,7 +800,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 43,
+                      "line": 35,
                       "character": 11
                     }
                   ]
@@ -829,7 +829,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 46,
+                      "line": 38,
                       "character": 13
                     }
                   ]
@@ -871,7 +871,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 45,
+                      "line": 37,
                       "character": 16
                     }
                   ]
@@ -900,7 +900,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 47,
+                      "line": 39,
                       "character": 20
                     }
                   ]
@@ -949,7 +949,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 44,
+                      "line": 36,
                       "character": 14
                     }
                   ]
@@ -971,7 +971,7 @@
               "sources": [
                 {
                   "fileName": "interface-implementation.ts",
-                  "line": 41,
+                  "line": 34,
                   "character": 37
                 }
               ],
@@ -1033,7 +1033,7 @@
               "sources": [
                 {
                   "fileName": "interface-implementation.ts",
-                  "line": 6,
+                  "line": 5,
                   "character": 28
                 }
               ]
@@ -1066,7 +1066,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 19,
+                      "line": 15,
                       "character": 14
                     }
                   ],
@@ -1084,7 +1084,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 17,
+                      "line": 13,
                       "character": 16
                     }
                   ],
@@ -1109,7 +1109,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 18,
+                      "line": 14,
                       "character": 16
                     }
                   ],
@@ -1143,7 +1143,7 @@
                   "sources": [
                     {
                       "fileName": "interface-implementation.ts",
-                      "line": 24,
+                      "line": 20,
                       "character": 19
                     }
                   ]
@@ -1170,7 +1170,7 @@
               "sources": [
                 {
                   "fileName": "interface-implementation.ts",
-                  "line": 15,
+                  "line": 12,
                   "character": 27
                 }
               ],

--- a/src/test/converter/interface-implementation/specs.json
+++ b/src/test/converter/interface-implementation/specs.json
@@ -44,7 +44,9 @@
                   "name": "T",
                   "kind": 131072,
                   "kindString": "Type parameter",
-                  "flags": {}
+                  "flags": {
+                    "isExported": true
+                  }
                 }
               ],
               "children": [
@@ -93,14 +95,18 @@
                       "name": "add",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "parameters": [
                         {
                           "id": 50,
                           "name": "listener",
                           "kind": 32768,
                           "kindString": "Parameter",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "type": {
                             "type": "reference",
                             "name": "IEventListener",
@@ -118,7 +124,9 @@
                           "name": "filter",
                           "kind": 32768,
                           "kindString": "Parameter",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "type": {
                             "type": "intrinsic",
                             "name": "any"
@@ -130,7 +138,9 @@
                           "name": "priority",
                           "kind": 32768,
                           "kindString": "Parameter",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "type": {
                             "type": "intrinsic",
                             "name": "number"
@@ -183,7 +193,9 @@
                       "name": "clear",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "intrinsic",
                         "name": "void"
@@ -222,14 +234,18 @@
                       "name": "dispatch",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "parameters": [
                         {
                           "id": 58,
                           "name": "event",
                           "kind": 32768,
                           "kindString": "Parameter",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "type": {
                             "type": "typeParameter",
                             "name": "T"
@@ -274,7 +290,9 @@
                       "name": "hasListeners",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "intrinsic",
                         "name": "boolean"
@@ -313,14 +331,18 @@
                       "name": "remove",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "parameters": [
                         {
                           "id": 55,
                           "name": "subscription",
                           "kind": 32768,
                           "kindString": "Parameter",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "type": {
                             "type": "reference",
                             "name": "ISubscription",
@@ -719,7 +741,9 @@
                   "name": "U",
                   "kind": 131072,
                   "kindString": "Type parameter",
-                  "flags": {}
+                  "flags": {
+                    "isExported": true
+                  }
                 }
               ],
               "children": [
@@ -737,14 +761,18 @@
                       "name": "add",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "parameters": [
                         {
                           "id": 32,
                           "name": "listener",
                           "kind": 32768,
                           "kindString": "Parameter",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "type": {
                             "type": "reference",
                             "name": "IEventListener",
@@ -763,6 +791,7 @@
                           "kind": 32768,
                           "kindString": "Parameter",
                           "flags": {
+                            "isExported": true,
                             "isOptional": true
                           },
                           "type": {
@@ -776,6 +805,7 @@
                           "kind": 32768,
                           "kindString": "Parameter",
                           "flags": {
+                            "isExported": true,
                             "isOptional": true
                           },
                           "type": {
@@ -819,7 +849,9 @@
                       "name": "clear",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "intrinsic",
                         "name": "void"
@@ -848,14 +880,18 @@
                       "name": "dispatch",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "parameters": [
                         {
                           "id": 40,
                           "name": "parameter",
                           "kind": 32768,
                           "kindString": "Parameter",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "type": {
                             "type": "typeParameter",
                             "name": "U"
@@ -890,7 +926,9 @@
                       "name": "hasListeners",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "intrinsic",
                         "name": "boolean"
@@ -919,14 +957,18 @@
                       "name": "remove",
                       "kind": 4096,
                       "kindString": "Call signature",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "parameters": [
                         {
                           "id": 37,
                           "name": "subscription",
                           "kind": 32768,
                           "kindString": "Parameter",
-                          "flags": {},
+                          "flags": {
+                            "isExported": true
+                          },
                           "type": {
                             "type": "reference",
                             "name": "ISubscription",

--- a/src/test/converter/literal-object-callbacks/literal-object-callbacks.ts
+++ b/src/test/converter/literal-object-callbacks/literal-object-callbacks.ts
@@ -16,3 +16,5 @@ const callbackReturn = {
         return callbackReturn;
     }
 };
+
+export {};

--- a/src/test/converter/literal-object/literal-object.ts
+++ b/src/test/converter/literal-object/literal-object.ts
@@ -6,9 +6,11 @@ const objectLiteral = {
     valueY: function() { return 'foo'; },
     valueX: {
         valueZ: 'foo',
-        valueY: (z:string) => { return {a:'test', b:z}; },
+        valueY: (z: string) => { return {a: 'test', b: z}; },
         valueA: [100, 200, 300]
     },
     valueA: 100,
     valueB: true
 };
+
+export {};

--- a/src/test/converter/literal-object/specs.json
+++ b/src/test/converter/literal-object/specs.json
@@ -137,7 +137,7 @@
                       "name": "number"
                     }
                   },
-                  "defaultValue": " [100, 200, 300]"
+                  "defaultValue": "[100, 200, 300]"
                 },
                 {
                   "id": 7,
@@ -203,7 +203,7 @@
                                 {
                                   "fileName": "literal-object.ts",
                                   "line": 9,
-                                  "character": 41
+                                  "character": 42
                                 }
                               ],
                               "type": {
@@ -222,7 +222,7 @@
                                 {
                                   "fileName": "literal-object.ts",
                                   "line": 9,
-                                  "character": 51
+                                  "character": 53
                                 }
                               ],
                               "type": {

--- a/src/test/converter/literal-type/literal-type.ts
+++ b/src/test/converter/literal-type/literal-type.ts
@@ -1,11 +1,13 @@
-let typeLiteral:{
-    valueZ:string;
-    valueY:{():string;};
-    valueX:{
-        valueZ:string;
-        valueY:{(z:string):{a:string; b:string}; };
-        valueA:number[];
+let typeLiteral: {
+    valueZ: string;
+    valueY: {(): string; };
+    valueX: {
+        valueZ: string;
+        valueY: {(z: string): {a: string; b: string}; };
+        valueA: number[];
     };
-    valueA?:number;
-    valueB?:boolean;
+    valueA?: number;
+    valueB?: boolean;
 };
+
+export {};

--- a/src/test/converter/literal-type/specs.json
+++ b/src/test/converter/literal-type/specs.json
@@ -181,7 +181,7 @@
                                             {
                                               "fileName": "literal-type.ts",
                                               "line": 6,
-                                              "character": 29
+                                              "character": 32
                                             }
                                           ],
                                           "type": {
@@ -199,7 +199,7 @@
                                             {
                                               "fileName": "literal-type.ts",
                                               "line": 6,
-                                              "character": 39
+                                              "character": 43
                                             }
                                           ],
                                           "type": {
@@ -222,7 +222,7 @@
                                         {
                                           "fileName": "literal-type.ts",
                                           "line": 6,
-                                          "character": 27
+                                          "character": 29
                                         }
                                       ]
                                     }

--- a/src/test/converter/mixin/specs.json
+++ b/src/test/converter/mixin/specs.json
@@ -61,7 +61,9 @@
                   "name": "baseMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"
@@ -233,7 +235,9 @@
                   "name": "baseMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"
@@ -282,7 +286,9 @@
                   "name": "classWithMixinMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "string"
@@ -311,14 +317,18 @@
                   "name": "method1",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 39,
                       "name": "arg",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reference",
                         "name": "Mixin1Type",
@@ -374,14 +384,18 @@
                   "name": "method2",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 35,
                       "name": "arg",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reference",
                         "name": "Mixin2"
@@ -583,7 +597,9 @@
                   "name": "baseMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"
@@ -632,14 +648,18 @@
                   "name": "method1",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 11,
                       "name": "arg",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reference",
                         "name": "Mixin1Type",
@@ -714,7 +734,9 @@
                         "name": "__type",
                         "kind": 65536,
                         "kindString": "Type literal",
-                        "flags": {}
+                        "flags": {
+                          "isExported": true
+                        }
                       }
                     }
                   ]
@@ -839,7 +861,9 @@
                   "name": "baseMethod",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "intrinsic",
                     "name": "number"
@@ -888,14 +912,18 @@
                   "name": "method1",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 24,
                       "name": "arg",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reference",
                         "name": "Mixin1Type",
@@ -951,14 +979,18 @@
                   "name": "method2",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 20,
                       "name": "arg",
                       "kind": 32768,
                       "kindString": "Parameter",
-                      "flags": {},
+                      "flags": {
+                        "isExported": true
+                      },
                       "type": {
                         "type": "reference",
                         "name": "Mixin2"
@@ -1033,7 +1065,9 @@
                         "name": "__type",
                         "kind": 65536,
                         "kindString": "Type literal",
-                        "flags": {}
+                        "flags": {
+                          "isExported": true
+                        }
                       }
                     }
                   ]
@@ -1066,7 +1100,9 @@
               "name": "A",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {}
+              "flags": {
+                "isExported": true
+              }
             }
           ],
           "sources": [
@@ -1083,7 +1119,9 @@
               "name": "__type",
               "kind": 65536,
               "kindString": "Type literal",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "sources": [
                 {
                   "fileName": "mixin.ts",
@@ -1108,7 +1146,9 @@
               "name": "A",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {}
+              "flags": {
+                "isExported": true
+              }
             }
           ],
           "sources": [
@@ -1125,14 +1165,18 @@
               "name": "__type",
               "kind": 65536,
               "kindString": "Type literal",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "signatures": [
                 {
                   "id": 46,
                   "name": "__call",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "parameters": [
                     {
                       "id": 47,
@@ -1140,6 +1184,7 @@
                       "kind": 32768,
                       "kindString": "Parameter",
                       "flags": {
+                        "isExported": true,
                         "isRest": true
                       },
                       "type": {
@@ -1181,7 +1226,9 @@
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "type": {
                 "type": "reference",
                 "name": "AnyFunction",
@@ -1267,7 +1314,9 @@
               "name": "Mixin1Func",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "The \"mixin function\" of the Mixin1"
               },
@@ -1277,7 +1326,9 @@
                   "name": "T",
                   "kind": 131072,
                   "kindString": "Type parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "reference",
                     "name": "AnyConstructor",
@@ -1298,7 +1349,9 @@
                   "name": "base",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "typeParameter",
                     "name": "T",
@@ -1358,7 +1411,9 @@
               "name": "Mixin2",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "The \"mixin function\" of the Mixin2"
               },
@@ -1368,7 +1423,9 @@
                   "name": "T",
                   "kind": 131072,
                   "kindString": "Type parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "reference",
                     "name": "AnyConstructor",
@@ -1399,7 +1456,9 @@
                   "name": "base",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "typeParameter",
                     "name": "T",
@@ -1469,7 +1528,9 @@
               "name": "Mixin3",
               "kind": 4096,
               "kindString": "Call signature",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "comment": {
                 "shortText": "The \"mixin function\" of the Mixin3"
               },
@@ -1479,7 +1540,9 @@
                   "name": "T",
                   "kind": 131072,
                   "kindString": "Type parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "reference",
                     "name": "AnyConstructor",
@@ -1499,7 +1562,9 @@
                   "name": "base",
                   "kind": 32768,
                   "kindString": "Parameter",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "type": {
                     "type": "typeParameter",
                     "name": "T",

--- a/src/test/converter/promise-object/promise-object.ts
+++ b/src/test/converter/promise-object/promise-object.ts
@@ -1,3 +1,5 @@
 let x: object;
 let y: Promise<string>;
 let z: Promise<object>;
+
+export {};

--- a/src/test/converter/this/specs.json
+++ b/src/test/converter/this/specs.json
@@ -42,7 +42,9 @@
                   "name": "chain",
                   "kind": 4096,
                   "kindString": "Call signature",
-                  "flags": {},
+                  "flags": {
+                    "isExported": true
+                  },
                   "comment": {
                     "shortText": "Chain method that returns this."
                   },

--- a/src/test/converter/type-operator/specs.json
+++ b/src/test/converter/type-operator/specs.json
@@ -28,7 +28,9 @@
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
-              "flags": {},
+              "flags": {
+                "isExported": true
+              },
               "type": {
                 "type": "typeOperator",
                 "operator": "keyof",

--- a/src/test/renderer.test.ts
+++ b/src/test/renderer.test.ts
@@ -62,7 +62,8 @@ describe('Renderer', function() {
             readme: Path.join(src, '..', 'README.md'),
             module: 'CommonJS',
             gaSite: 'foo.com', // verify theme option without modifying output
-            name: 'typedoc'
+            name: 'typedoc',
+            ignoreCompilerErrors: true
         });
     });
 

--- a/src/test/renderer/specs/classes/_access_.privateclass.html
+++ b/src/test/renderer/specs/classes/_access_.privateclass.html
@@ -219,6 +219,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_classes_.baseclass.html
+++ b/src/test/renderer/specs/classes/_classes_.baseclass.html
@@ -509,6 +509,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_classes_.genericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.genericclass.html
@@ -350,6 +350,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_classes_.internalclass.html
+++ b/src/test/renderer/specs/classes/_classes_.internalclass.html
@@ -165,6 +165,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_classes_.nongenericclass.html
+++ b/src/test/renderer/specs/classes/_classes_.nongenericclass.html
@@ -328,6 +328,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_classes_.subclassa.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassa.html
@@ -648,6 +648,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_classes_.subclassb.html
+++ b/src/test/renderer/specs/classes/_classes_.subclassb.html
@@ -483,6 +483,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
+++ b/src/test/renderer/specs/classes/_default_export_.defaultexportedclass.html
@@ -207,6 +207,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
@@ -231,6 +237,9 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
+					<li class=" tsd-kind-reference tsd-parent-kind-external-module">
+						<a href="../modules/_default_export_.html#exportedclassname" class="tsd-kind-icon">Exported<wbr>Class<wbr>Name</a>
+					</li>
 				</ul>
 				<ul class="current">
 					<li class="current tsd-kind-class tsd-parent-kind-external-module">

--- a/src/test/renderer/specs/classes/_default_export_.notexportedclassname.html
+++ b/src/test/renderer/specs/classes/_default_export_.notexportedclassname.html
@@ -208,6 +208,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
@@ -232,6 +238,9 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
+					<li class=" tsd-kind-reference tsd-parent-kind-external-module">
+						<a href="../modules/_default_export_.html#exportedclassname" class="tsd-kind-icon">Exported<wbr>Class<wbr>Name</a>
+					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
 						<a href="_default_export_.defaultexportedclass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a>
 					</li>

--- a/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
+++ b/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
@@ -88,30 +88,30 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Constructors</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
+								<li class="tsd-kind-constructor tsd-parent-kind-class"><a href="_flattened_.flattenedclass.html#constructor" class="tsd-kind-icon">constructor</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#callback" class="tsd-kind-icon">callback</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#indexed" class="tsd-kind-icon">indexed</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#multiplecallsignatures" class="tsd-kind-icon">multiple<wbr>Call<wbr>Signatures</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_flattened_.flattenedclass.html#options" class="tsd-kind-icon">options</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_flattened_.flattenedclass.html#callback" class="tsd-kind-icon">callback</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_flattened_.flattenedclass.html#indexed" class="tsd-kind-icon">indexed</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_flattened_.flattenedclass.html#multiplecallsignatures" class="tsd-kind-icon">multiple<wbr>Call<wbr>Signatures</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_flattened_.flattenedclass.html#options" class="tsd-kind-icon">options</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Constructors</h2>
-				<section class="tsd-panel tsd-member tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-constructor tsd-parent-kind-class">
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
-					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">new flattened<wbr>Class<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_flattened_.flattenedclass.html" class="tsd-signature-type">flattenedClass</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -170,9 +170,9 @@
 					</ul>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Properties</h2>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="callback" class="tsd-anchor"></a>
 					<h3>callback</h3>
 					<div class="tsd-signature tsd-kind-icon">callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
@@ -190,7 +190,7 @@
 						<h4>Type declaration</h4>
 						<ul class="tsd-parameters">
 							<li class="tsd-parameter-siganture">
-								<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-property tsd-is-not-exported">
+								<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-property">
 									<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>param<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, optionalParam<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
 								</ul>
 								<ul class="tsd-descriptions">
@@ -217,7 +217,7 @@
 						</ul>
 					</div>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="indexed" class="tsd-anchor"></a>
 					<h3>indexed</h3>
 					<div class="tsd-signature tsd-kind-icon">indexed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
@@ -254,7 +254,7 @@
 						</ul>
 					</div>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="multiplecallsignatures" class="tsd-anchor"></a>
 					<h3>multiple<wbr>Call<wbr>Signatures</h3>
 					<div class="tsd-signature tsd-kind-icon">multiple<wbr>Call<wbr>Signatures<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
@@ -277,7 +277,7 @@
 						<h4>Type declaration</h4>
 						<ul class="tsd-parameters">
 							<li class="tsd-parameter-siganture">
-								<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-property tsd-is-not-exported">
+								<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-property">
 									<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
 									<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_flattened_.flattenedclass.html" class="tsd-signature-type">flattenedClass</a></li>
 								</ul>
@@ -314,7 +314,7 @@
 						</ul>
 					</div>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="options" class="tsd-anchor"></a>
 					<h3>options</h3>
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
@@ -422,35 +422,35 @@
 				<ul class="before-current">
 				</ul>
 				<ul class="current">
-					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class="current tsd-kind-class tsd-parent-kind-external-module">
 						<a href="_flattened_.flattenedclass.html" class="tsd-kind-icon">flattened<wbr>Class</a>
 						<ul>
-							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-not-exported">
+							<li class=" tsd-kind-constructor tsd-parent-kind-class">
 								<a href="_flattened_.flattenedclass.html#constructor" class="tsd-kind-icon">constructor</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+							<li class=" tsd-kind-property tsd-parent-kind-class">
 								<a href="_flattened_.flattenedclass.html#callback" class="tsd-kind-icon">callback</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+							<li class=" tsd-kind-property tsd-parent-kind-class">
 								<a href="_flattened_.flattenedclass.html#indexed" class="tsd-kind-icon">indexed</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+							<li class=" tsd-kind-property tsd-parent-kind-class">
 								<a href="_flattened_.flattenedclass.html#multiplecallsignatures" class="tsd-kind-icon">multiple<wbr>Call<wbr>Signatures</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+							<li class=" tsd-kind-property tsd-parent-kind-class">
 								<a href="_flattened_.flattenedclass.html#options" class="tsd-kind-icon">options</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="../modules/_flattened_.html#flattenedcallback" class="tsd-kind-icon">flattened<wbr>Callback</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="../modules/_flattened_.html#flattenedindexsignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="../modules/_flattened_.html#flattenedparameter" class="tsd-kind-icon">flattened<wbr>Parameter</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
+++ b/src/test/renderer/specs/classes/_flattened_.flattenedclass.html
@@ -390,6 +390,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_single_export_.notexportedclass.html
+++ b/src/test/renderer/specs/classes/_single_export_.notexportedclass.html
@@ -206,6 +206,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class="current tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_single_export_.singleexportedclass.html
+++ b/src/test/renderer/specs/classes/_single_export_.singleexportedclass.html
@@ -207,6 +207,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class="current tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
@@ -258,6 +258,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.classwithprotectedmembers.html
@@ -93,28 +93,28 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#privateproperty" class="tsd-kind-icon">private<wbr>Property</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_typescript_1_3_.classwithprotectedmembers.html#privateproperty" class="tsd-kind-icon">private<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><a href="_typescript_1_3_.classwithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_typescript_1_3_.classwithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#privatemethod" class="tsd-kind-icon">private<wbr>Method</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-not-exported"><a href="_typescript_1_3_.classwithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_typescript_1_3_.classwithprotectedmembers.html#privatemethod" class="tsd-kind-icon">private<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected"><a href="_typescript_1_3_.classwithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_typescript_1_3_.classwithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Properties</h2>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private">
 					<a name="privateproperty" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> private<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">private<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span></div>
@@ -129,7 +129,7 @@
 						</div>
 					</div>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-protected">
 					<a name="protectedproperty" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> protected<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">protected<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -144,7 +144,7 @@
 						</div>
 					</div>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="publicproperty" class="tsd-anchor"></a>
 					<h3>public<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -160,12 +160,12 @@
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private">
 					<a name="privatemethod" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> private<wbr>Method</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private">
 						<li class="tsd-signature tsd-kind-icon">private<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -184,10 +184,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-protected">
 					<a name="protectedmethod" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> protected<wbr>Method</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-protected">
 						<li class="tsd-signature tsd-kind-icon">protected<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -206,10 +206,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
 					<a name="publicmethod" class="tsd-anchor"></a>
 					<h3>public<wbr>Method</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
 						<li class="tsd-signature tsd-kind-icon">public<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -290,35 +290,35 @@
 				<ul class="before-current">
 				</ul>
 				<ul class="current">
-					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class="current tsd-kind-class tsd-parent-kind-external-module">
 						<a href="_typescript_1_3_.classwithprotectedmembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a>
 						<ul>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private">
 								<a href="_typescript_1_3_.classwithprotectedmembers.html#privateproperty" class="tsd-kind-icon">private<wbr>Property</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-protected">
 								<a href="_typescript_1_3_.classwithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-not-exported">
+							<li class=" tsd-kind-property tsd-parent-kind-class">
 								<a href="_typescript_1_3_.classwithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private">
 								<a href="_typescript_1_3_.classwithprotectedmembers.html#privatemethod" class="tsd-kind-icon">private<wbr>Method</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-protected tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-protected">
 								<a href="_typescript_1_3_.classwithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-class">
 								<a href="_typescript_1_3_.classwithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module">
 						<a href="_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="../modules/_typescript_1_3_.html#tupletype" class="tsd-kind-icon">tuple<wbr>Type</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
@@ -93,26 +93,26 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
+						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
+						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group tsd-is-inherited">
 				<h2>Properties</h2>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 					<a name="protectedproperty" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> protected<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">protected<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -128,7 +128,7 @@
 						</div>
 					</div>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
 					<a name="publicproperty" class="tsd-anchor"></a>
 					<h3>public<wbr>Property</h3>
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -145,12 +145,12 @@
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group tsd-is-inherited">
 				<h2>Methods</h2>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 					<a name="protectedmethod" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagProtected">Protected</span> protected<wbr>Method</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 						<li class="tsd-signature tsd-kind-icon">protected<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -170,10 +170,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 					<a name="publicmethod" class="tsd-anchor"></a>
 					<h3>public<wbr>Method</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">public<wbr>Method<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -253,31 +253,31 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module">
 						<a href="_typescript_1_3_.classwithprotectedmembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a>
 					</li>
 				</ul>
 				<ul class="current">
-					<li class="current tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class="current tsd-kind-class tsd-parent-kind-external-module">
 						<a href="_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a>
 						<ul>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 								<a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedproperty" class="tsd-kind-icon">protected<wbr>Property</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
 								<a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicproperty" class="tsd-kind-icon">public<wbr>Property</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 								<a href="_typescript_1_3_.subclasswithprotectedmembers.html#protectedmethod" class="tsd-kind-icon">protected<wbr>Method</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
 								<a href="_typescript_1_3_.subclasswithprotectedmembers.html#publicmethod" class="tsd-kind-icon">public<wbr>Method</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="../modules/_typescript_1_3_.html#tupletype" class="tsd-kind-icon">tuple<wbr>Type</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
+++ b/src/test/renderer/specs/classes/_typescript_1_3_.subclasswithprotectedmembers.html
@@ -223,6 +223,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/classes/_typescript_1_4_.simpleclass.html
+++ b/src/test/renderer/specs/classes/_typescript_1_4_.simpleclass.html
@@ -177,6 +177,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/enums/_enumerations_.directions.html
+++ b/src/test/renderer/specs/enums/_enumerations_.directions.html
@@ -216,6 +216,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/enums/_enumerations_.size.html
+++ b/src/test/renderer/specs/enums/_enumerations_.size.html
@@ -235,6 +235,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/globals.html
+++ b/src/test/renderer/specs/globals.html
@@ -77,6 +77,8 @@
 								<li class="tsd-kind-external-module"><a href="modules/_flattened_.html" class="tsd-kind-icon">&quot;flattened&quot;</a></li>
 								<li class="tsd-kind-external-module"><a href="modules/_functions_.html" class="tsd-kind-icon">&quot;functions&quot;</a></li>
 								<li class="tsd-kind-external-module"><a href="modules/_generics_.html" class="tsd-kind-icon">&quot;generics&quot;</a></li>
+								<li class="tsd-kind-external-module"><a href="modules/_mod_.html" class="tsd-kind-icon">&quot;mod&quot;</a></li>
+								<li class="tsd-kind-external-module"><a href="modules/_mod2_.html" class="tsd-kind-icon">&quot;mod2&quot;</a></li>
 								<li class="tsd-kind-external-module"><a href="modules/_modules_.html" class="tsd-kind-icon">&quot;modules&quot;</a></li>
 								<li class="tsd-kind-external-module"><a href="modules/_single_export_.html" class="tsd-kind-icon">&quot;single-<wbr>export&quot;</a></li>
 								<li class="tsd-kind-external-module"><a href="modules/_typescript_1_3_.html" class="tsd-kind-icon">&quot;typescript-<wbr>1.3&quot;</a></li>
@@ -116,6 +118,12 @@
 					</li>
 					<li class=" tsd-kind-external-module">
 						<a href="modules/_generics_.html">&quot;generics&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="modules/_mod2_.html">&quot;mod2&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
 						<a href="modules/_modules_.html">&quot;modules&quot;</a>

--- a/src/test/renderer/specs/index.html
+++ b/src/test/renderer/specs/index.html
@@ -144,6 +144,12 @@
 						<a href="modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.inameinterface.html
@@ -190,6 +190,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintinterface.html
@@ -163,6 +163,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
+++ b/src/test/renderer/specs/interfaces/_classes_.iprintnameinterface.html
@@ -247,6 +247,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_generics_.a.html
+++ b/src/test/renderer/specs/interfaces/_generics_.a.html
@@ -106,21 +106,21 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported"><a href="_generics_.a.html#gett" class="tsd-kind-icon">getT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface"><a href="_generics_.a.html#gett" class="tsd-kind-icon">getT</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface">
 					<a name="gett" class="tsd-anchor"></a>
 					<h3>getT</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
 						<li class="tsd-signature tsd-kind-icon">getT<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -202,38 +202,38 @@
 				<ul class="before-current">
 				</ul>
 				<ul class="current">
-					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
 						<ul>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface">
 								<a href="_generics_.a.html#gett" class="tsd-kind-icon">getT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#horriblerecursivetypethatshouldnotbeusedbyanyone" class="tsd-kind-icon">Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#popfront" class="tsd-kind-icon">Pop<wbr>Front</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/interfaces/_generics_.a.html
+++ b/src/test/renderer/specs/interfaces/_generics_.a.html
@@ -170,6 +170,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_generics_.ab.html
+++ b/src/test/renderer/specs/interfaces/_generics_.ab.html
@@ -118,23 +118,23 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
+						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ab.html#getc" class="tsd-kind-icon">getC</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ab.html#gett" class="tsd-kind-icon">getT</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.ab.html#sett" class="tsd-kind-icon">setT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_generics_.ab.html#getc" class="tsd-kind-icon">getC</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_generics_.ab.html#gett" class="tsd-kind-icon">getT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_generics_.ab.html#sett" class="tsd-kind-icon">setT</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group tsd-is-inherited">
 				<h2>Methods</h2>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 					<a name="getc" class="tsd-anchor"></a>
 					<h3>getC</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">getC<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -155,10 +155,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 					<a name="gett" class="tsd-anchor"></a>
 					<h3>getT</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">getT<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -179,10 +179,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 					<a name="sett" class="tsd-anchor"></a>
 					<h3>setT</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">setT<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -271,46 +271,46 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
 					</li>
 				</ul>
 				<ul class="current">
-					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
 						<ul>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 								<a href="_generics_.ab.html#getc" class="tsd-kind-icon">getC</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 								<a href="_generics_.ab.html#gett" class="tsd-kind-icon">getT</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 								<a href="_generics_.ab.html#sett" class="tsd-kind-icon">setT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#horriblerecursivetypethatshouldnotbeusedbyanyone" class="tsd-kind-icon">Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#popfront" class="tsd-kind-icon">Pop<wbr>Front</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/interfaces/_generics_.ab.html
+++ b/src/test/renderer/specs/interfaces/_generics_.ab.html
@@ -241,6 +241,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_generics_.abnumber.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abnumber.html
@@ -93,23 +93,23 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
+						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abnumber.html#getc" class="tsd-kind-icon">getC</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abnumber.html#gett" class="tsd-kind-icon">getT</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abnumber.html#sett" class="tsd-kind-icon">setT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_generics_.abnumber.html#getc" class="tsd-kind-icon">getC</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_generics_.abnumber.html#gett" class="tsd-kind-icon">getT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_generics_.abnumber.html#sett" class="tsd-kind-icon">setT</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group tsd-is-inherited">
 				<h2>Methods</h2>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 					<a name="getc" class="tsd-anchor"></a>
 					<h3>getC</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">getC<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -130,10 +130,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 					<a name="gett" class="tsd-anchor"></a>
 					<h3>getT</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">getT<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -154,10 +154,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 					<a name="sett" class="tsd-anchor"></a>
 					<h3>setT</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">setT<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -246,46 +246,46 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
 					</li>
 				</ul>
 				<ul class="current">
-					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class="current tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
 						<ul>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 								<a href="_generics_.abnumber.html#getc" class="tsd-kind-icon">getC</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 								<a href="_generics_.abnumber.html#gett" class="tsd-kind-icon">getT</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 								<a href="_generics_.abnumber.html#sett" class="tsd-kind-icon">setT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#horriblerecursivetypethatshouldnotbeusedbyanyone" class="tsd-kind-icon">Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#popfront" class="tsd-kind-icon">Pop<wbr>Front</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/interfaces/_generics_.abnumber.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abnumber.html
@@ -216,6 +216,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_generics_.abstring.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abstring.html
@@ -216,6 +216,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_generics_.abstring.html
+++ b/src/test/renderer/specs/interfaces/_generics_.abstring.html
@@ -93,23 +93,23 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-inherited tsd-is-not-exported">
+						<section class="tsd-index-section tsd-is-inherited">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abstring.html#getc" class="tsd-kind-icon">getC</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abstring.html#gett" class="tsd-kind-icon">getT</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported"><a href="_generics_.abstring.html#sett" class="tsd-kind-icon">setT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_generics_.abstring.html#getc" class="tsd-kind-icon">getC</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_generics_.abstring.html#gett" class="tsd-kind-icon">getT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-inherited"><a href="_generics_.abstring.html#sett" class="tsd-kind-icon">setT</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-inherited tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group tsd-is-inherited">
 				<h2>Methods</h2>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 					<a name="getc" class="tsd-anchor"></a>
 					<h3>getC</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">getC<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -130,10 +130,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 					<a name="gett" class="tsd-anchor"></a>
 					<h3>getT</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">getT<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -154,10 +154,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 					<a name="sett" class="tsd-anchor"></a>
 					<h3>setT</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 						<li class="tsd-signature tsd-kind-icon">setT<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -246,46 +246,46 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
 				</ul>
 				<ul class="current">
-					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class="current tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
 						<ul>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 								<a href="_generics_.abstring.html#getc" class="tsd-kind-icon">getC</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 								<a href="_generics_.abstring.html#gett" class="tsd-kind-icon">getT</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
 								<a href="_generics_.abstring.html#sett" class="tsd-kind-icon">setT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#horriblerecursivetypethatshouldnotbeusedbyanyone" class="tsd-kind-icon">Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#popfront" class="tsd-kind-icon">Pop<wbr>Front</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/interfaces/_generics_.b.html
+++ b/src/test/renderer/specs/interfaces/_generics_.b.html
@@ -114,22 +114,22 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Methods</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported"><a href="_generics_.b.html#getc" class="tsd-kind-icon">getC</a></li>
-								<li class="tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported"><a href="_generics_.b.html#sett" class="tsd-kind-icon">setT</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface"><a href="_generics_.b.html#getc" class="tsd-kind-icon">getC</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-interface"><a href="_generics_.b.html#sett" class="tsd-kind-icon">setT</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Methods</h2>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface">
 					<a name="getc" class="tsd-anchor"></a>
 					<h3>getC</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
 						<li class="tsd-signature tsd-kind-icon">getC<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">C</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -149,10 +149,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface">
 					<a name="sett" class="tsd-anchor"></a>
 					<h3>setT</h3>
-					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
 						<li class="tsd-signature tsd-kind-icon">setT<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -240,43 +240,43 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.a.html" class="tsd-kind-icon">A</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.ab.html" class="tsd-kind-icon">AB</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
 					</li>
 				</ul>
 				<ul class="current">
-					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class="current tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.b.html" class="tsd-kind-icon">B</a>
 						<ul>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface">
 								<a href="_generics_.b.html#getc" class="tsd-kind-icon">getC</a>
 							</li>
-							<li class=" tsd-kind-method tsd-parent-kind-interface tsd-is-not-exported">
+							<li class=" tsd-kind-method tsd-parent-kind-interface">
 								<a href="_generics_.b.html#sett" class="tsd-kind-icon">setT</a>
 							</li>
 						</ul>
 					</li>
 				</ul>
 				<ul class="after-current">
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#horriblerecursivetypethatshouldnotbeusedbyanyone" class="tsd-kind-icon">Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#popfront" class="tsd-kind-icon">Pop<wbr>Front</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="../modules/_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../modules/_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/interfaces/_generics_.b.html
+++ b/src/test/renderer/specs/interfaces/_generics_.b.html
@@ -210,6 +210,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/interfaces/_typescript_1_4_.runoptions.html
+++ b/src/test/renderer/specs/interfaces/_typescript_1_4_.runoptions.html
@@ -150,6 +150,12 @@
 						<a href="../modules/_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="../modules/_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_access_.html
+++ b/src/test/renderer/specs/modules/_access_.html
@@ -213,6 +213,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_access_.privatemodule.html
+++ b/src/test/renderer/specs/modules/_access_.privatemodule.html
@@ -143,6 +143,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_classes_.html
+++ b/src/test/renderer/specs/modules/_classes_.html
@@ -121,6 +121,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_default_export_.html
+++ b/src/test/renderer/specs/modules/_default_export_.html
@@ -71,6 +71,12 @@
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
 						<section class="tsd-index-section ">
+							<h3>References</h3>
+							<ul class="tsd-index-list">
+								<li class="tsd-kind-reference tsd-parent-kind-external-module"><a href="_default_export_.html#exportedclassname" class="tsd-kind-icon">Exported<wbr>Class<wbr>Name</a></li>
+							</ul>
+						</section>
+						<section class="tsd-index-section ">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
 								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_default_export_.defaultexportedclass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a></li>
@@ -78,6 +84,14 @@
 							</ul>
 						</section>
 					</div>
+				</section>
+			</section>
+			<section class="tsd-panel-group tsd-member-group ">
+				<h2>References</h2>
+				<section class="tsd-panel tsd-member tsd-kind-reference tsd-parent-kind-external-module">
+					<a name="exportedclassname" class="tsd-anchor"></a>
+					<h3>Exported<wbr>Class<wbr>Name</h3>
+					Renames and exports <a href="../classes/_default_export_.notexportedclassname.html">NotExportedClassName</a>
 				</section>
 			</section>
 		</div>
@@ -109,6 +123,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
@@ -133,6 +153,9 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
+					<li class=" tsd-kind-reference tsd-parent-kind-external-module">
+						<a href="_default_export_.html#exportedclassname" class="tsd-kind-icon">Exported<wbr>Class<wbr>Name</a>
+					</li>
 					<li class=" tsd-kind-class tsd-parent-kind-external-module">
 						<a href="../classes/_default_export_.defaultexportedclass.html" class="tsd-kind-icon">Default<wbr>Exported<wbr>Class</a>
 					</li>

--- a/src/test/renderer/specs/modules/_enumerations_.html
+++ b/src/test/renderer/specs/modules/_enumerations_.html
@@ -109,6 +109,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_flattened_.html
+++ b/src/test/renderer/specs/modules/_flattened_.html
@@ -70,29 +70,29 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_flattened_.flattenedclass.html" class="tsd-kind-icon">flattened<wbr>Class</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_flattened_.flattenedclass.html" class="tsd-kind-icon">flattened<wbr>Class</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_flattened_.html#flattenedcallback" class="tsd-kind-icon">flattened<wbr>Callback</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_flattened_.html#flattenedindexsignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_flattened_.html#flattenedparameter" class="tsd-kind-icon">flattened<wbr>Parameter</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_flattened_.html#flattenedcallback" class="tsd-kind-icon">flattened<wbr>Callback</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_flattened_.html#flattenedindexsignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_flattened_.html#flattenedparameter" class="tsd-kind-icon">flattened<wbr>Parameter</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Functions</h2>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
 					<a name="flattenedcallback" class="tsd-anchor"></a>
 					<h3>flattened<wbr>Callback</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">flattened<wbr>Callback<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -116,7 +116,7 @@
 									</div>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
-											<ul class="tsd-signatures tsd-kind-type-literal tsd-is-not-exported">
+											<ul class="tsd-signatures tsd-kind-type-literal">
 												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>param<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, optionalParam<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
@@ -147,10 +147,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
 					<a name="flattenedindexsignature" class="tsd-anchor"></a>
 					<h3>flattened<wbr>Index<wbr>Signature</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">flattened<wbr>Index<wbr>Signature<span class="tsd-signature-symbol">(</span>indexed<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -197,10 +197,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
 					<a name="flattenedparameter" class="tsd-anchor"></a>
 					<h3>flattened<wbr>Parameter</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">flattened<wbr>Parameter<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -319,16 +319,16 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module">
 						<a href="../classes/_flattened_.flattenedclass.html" class="tsd-kind-icon">flattened<wbr>Class</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="_flattened_.html#flattenedcallback" class="tsd-kind-icon">flattened<wbr>Callback</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="_flattened_.html#flattenedindexsignature" class="tsd-kind-icon">flattened<wbr>Index<wbr>Signature</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="_flattened_.html#flattenedparameter" class="tsd-kind-icon">flattened<wbr>Parameter</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/modules/_flattened_.html
+++ b/src/test/renderer/specs/modules/_flattened_.html
@@ -289,6 +289,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_functions_.html
+++ b/src/test/renderer/specs/modules/_functions_.html
@@ -576,6 +576,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_functions_.html
+++ b/src/test/renderer/specs/modules/_functions_.html
@@ -123,7 +123,7 @@
 								</li>
 								<li class="tsd-parameter">
 									<h5>do<wbr>Another<wbr>Thing<span class="tsd-signature-symbol">: </span>function</h5>
-									<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-type-literal tsd-is-not-exported">
+									<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-type-literal">
 										<li class="tsd-signature tsd-kind-icon">do<wbr>Another<wbr>Thing<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 									</ul>
 									<ul class="tsd-descriptions">
@@ -138,7 +138,7 @@
 								</ul>        </li>
 								<li class="tsd-parameter">
 									<h5>do<wbr>Something<span class="tsd-signature-symbol">: </span>function</h5>
-									<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-type-literal tsd-is-not-exported">
+									<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-type-literal">
 										<li class="tsd-signature tsd-kind-icon">do<wbr>Something<span class="tsd-signature-symbol">(</span>a<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
 									</ul>
 									<ul class="tsd-descriptions">

--- a/src/test/renderer/specs/modules/_generics_.html
+++ b/src/test/renderer/specs/modules/_generics_.html
@@ -242,6 +242,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_generics_.html
+++ b/src/test/renderer/specs/modules/_generics_.html
@@ -70,36 +70,36 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Interfaces</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../interfaces/_generics_.a.html" class="tsd-kind-icon">A</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../interfaces/_generics_.ab.html" class="tsd-kind-icon">AB</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported"><a href="../interfaces/_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported"><a href="../interfaces/_generics_.abstring.html" class="tsd-kind-icon">ABString</a></li>
-								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="../interfaces/_generics_.b.html" class="tsd-kind-icon">B</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter"><a href="../interfaces/_generics_.a.html" class="tsd-kind-icon">A</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter"><a href="../interfaces/_generics_.ab.html" class="tsd-kind-icon">AB</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module"><a href="../interfaces/_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module"><a href="../interfaces/_generics_.abstring.html" class="tsd-kind-icon">ABString</a></li>
+								<li class="tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter"><a href="../interfaces/_generics_.b.html" class="tsd-kind-icon">B</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Type aliases</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="_generics_.html#horriblerecursivetypethatshouldnotbeusedbyanyone" class="tsd-kind-icon">Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone</a></li>
-								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="_generics_.html#popfront" class="tsd-kind-icon">Pop<wbr>Front</a></li>
+								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter"><a href="_generics_.html#horriblerecursivetypethatshouldnotbeusedbyanyone" class="tsd-kind-icon">Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone</a></li>
+								<li class="tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter"><a href="_generics_.html#popfront" class="tsd-kind-icon">Pop<wbr>Front</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported"><a href="_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter"><a href="_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Type aliases</h2>
-				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 					<a name="horriblerecursivetypethatshouldnotbeusedbyanyone" class="tsd-anchor"></a>
 					<h3>Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone</h3>
 					<div class="tsd-signature tsd-kind-icon">Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone&lt;T, R&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object[T[&quot;length&quot;] extends 0 ? 0 : 1]</span></div>
@@ -124,7 +124,7 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 					<a name="popfront" class="tsd-anchor"></a>
 					<h3>Pop<wbr>Front</h3>
 					<div class="tsd-signature tsd-kind-icon">Pop<wbr>Front&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function extends function ? R : never</span></div>
@@ -146,12 +146,12 @@
 					</ul>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Functions</h2>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
 					<a name="getgenericarray" class="tsd-anchor"></a>
 					<h3>get<wbr>Generic<wbr>Array</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Generic<wbr>Array<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -171,10 +171,10 @@
 						</li>
 					</ul>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
 					<a name="testfunction" class="tsd-anchor"></a>
 					<h3>test<wbr>Function</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
 						<li class="tsd-signature tsd-kind-icon">test<wbr>Function&lt;T&gt;<span class="tsd-signature-symbol">(</span>value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -272,31 +272,31 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../interfaces/_generics_.a.html" class="tsd-kind-icon">A</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../interfaces/_generics_.ab.html" class="tsd-kind-icon">AB</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="../interfaces/_generics_.abnumber.html" class="tsd-kind-icon">ABNumber</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module">
 						<a href="../interfaces/_generics_.abstring.html" class="tsd-kind-icon">ABString</a>
 					</li>
-					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-interface tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="../interfaces/_generics_.b.html" class="tsd-kind-icon">B</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.html#horriblerecursivetypethatshouldnotbeusedbyanyone" class="tsd-kind-icon">Horrible<wbr>Recursive<wbr>Type<wbr>That<wbr>Should<wbr>Not<wbr>BeUsed<wbr>ByAnyone</a>
 					</li>
-					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-type-alias tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.html#popfront" class="tsd-kind-icon">Pop<wbr>Front</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="_generics_.html#getgenericarray" class="tsd-kind-icon">get<wbr>Generic<wbr>Array</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
 						<a href="_generics_.html#testfunction" class="tsd-kind-icon">test<wbr>Function</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/modules/_mod2_.html
+++ b/src/test/renderer/specs/modules/_mod2_.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in mod2.ts:1</li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/mod2.ts#L1">mod2.ts:1</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/test/renderer/specs/modules/_mod2_.html
+++ b/src/test/renderer/specs/modules/_mod2_.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>moduleFunction | typedoc</title>
+	<title>&quot;mod2&quot; | typedoc</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="../assets/css/main.css">
@@ -56,134 +56,61 @@
 					<a href="../globals.html">Globals</a>
 				</li>
 				<li>
-					<a href="_functions_.html">&quot;functions&quot;</a>
-				</li>
-				<li>
-					<a href="_functions_.modulefunction.html">moduleFunction</a>
+					<a href="_mod2_.html">&quot;mod2&quot;</a>
 				</li>
 			</ul>
-			<h1>Module moduleFunction</h1>
+			<h1>External module &quot;mod2&quot;</h1>
 		</div>
 	</div>
 </header>
 <div class="container container-main">
 	<div class="row">
 		<div class="col-8 col-content">
-			<section class="tsd-panel tsd-comment">
-				<div class="tsd-comment tsd-typography">
-					<div class="lead">
-						<p>This is the module extending the function moduleFunction().</p>
-					</div>
-				</div>
-			</section>
-			<section class="tsd-panel">
-				<h3 class="tsd-before-signature">Callable</h3>
-				<ul class="tsd-signatures tsd-kind-module tsd-parent-kind-external-module">
-					<li class="tsd-signature tsd-kind-icon">module<wbr>Function<span class="tsd-signature-symbol">(</span>arg<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
-				</ul>
-				<ul class="tsd-descriptions">
-					<li class="tsd-description">
-						<aside class="tsd-sources">
-							<ul>
-								<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/functions.ts#L141">functions.ts:141</a></li>
-							</ul>
-						</aside>
-						<div class="tsd-comment tsd-typography">
-							<div class="lead">
-								<p>This is a function that is extended by a module.</p>
-							</div>
-						</div>
-						<h4 class="tsd-parameters-title">Parameters</h4>
-						<ul class="tsd-parameters">
-							<li>
-								<h5>arg: <span class="tsd-signature-type">string</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An argument.</p>
-								</div>
-							</li>
-						</ul>
-						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
-					</li>
-				</ul>
-			</section>
 			<section class="tsd-panel-group tsd-index-group">
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
-							<h3>Variables</h3>
+						<section class="tsd-index-section ">
+							<h3>References</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.modulefunction.html#functionvariable" class="tsd-kind-icon">function<wbr>Variable</a></li>
+								<li class="tsd-kind-reference tsd-parent-kind-external-module"><a href="_mod2_.html#a" class="tsd-kind-icon">a</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.modulefunction.html#append" class="tsd-kind-icon">append</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.modulefunction.html#prepend" class="tsd-kind-icon">prepend</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_mod2_.html#default" class="tsd-kind-icon">default</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
-				<h2>Variables</h2>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-					<a name="functionvariable" class="tsd-anchor"></a>
-					<h3>function<wbr>Variable</h3>
-					<div class="tsd-signature tsd-kind-icon">function<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
-					<aside class="tsd-sources">
-						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/functions.ts#L152">functions.ts:152</a></li>
-						</ul>
-					</aside>
-					<div class="tsd-comment tsd-typography">
-						<div class="lead">
-							<p>This variable is appended to a function.</p>
-						</div>
-					</div>
+			<section class="tsd-panel-group tsd-member-group ">
+				<h2>References</h2>
+				<section class="tsd-panel tsd-member tsd-kind-reference tsd-parent-kind-external-module">
+					<a name="a" class="tsd-anchor"></a>
+					<h3>a</h3>
+					Re-exports <a href="_mod_.html#a">a</a>
 				</section>
 			</section>
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Functions</h2>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-					<a name="append" class="tsd-anchor"></a>
-					<h3>append</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">append<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<a name="default" class="tsd-anchor"></a>
+					<h3>default</h3>
+					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+						<li class="tsd-signature tsd-kind-icon">default<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/functions.ts#L158">functions.ts:158</a></li>
+									<li>Defined in mod2.ts:1</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>This function is appended to another function.</p>
-								</div>
-							</div>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
-						</li>
-					</ul>
-				</section>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-					<a name="prepend" class="tsd-anchor"></a>
-					<h3>prepend</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">prepend<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
-					</ul>
-					<ul class="tsd-descriptions">
-						<li class="tsd-description">
-							<aside class="tsd-sources">
-								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/functions.ts#L165">functions.ts:165</a></li>
-								</ul>
-							</aside>
-							<div class="tsd-comment tsd-typography">
-								<div class="lead">
-									<p>This function is appended to another function.</p>
+									<p>Will be exported from mod2, unlike the default function in mod</p>
 								</div>
 							</div>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -213,13 +140,8 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_flattened_.html">&quot;flattened&quot;</a>
 					</li>
-					<li class="current tsd-kind-external-module">
+					<li class=" tsd-kind-external-module">
 						<a href="_functions_.html">&quot;functions&quot;</a>
-						<ul>
-							<li class="current tsd-kind-module tsd-parent-kind-external-module">
-								<a href="_functions_.modulefunction.html">module<wbr>Function</a>
-							</li>
-						</ul>
 					</li>
 					<li class=" tsd-kind-external-module">
 						<a href="_generics_.html">&quot;generics&quot;</a>
@@ -227,7 +149,7 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_mod_.html">&quot;mod&quot;</a>
 					</li>
-					<li class=" tsd-kind-external-module">
+					<li class="current tsd-kind-external-module">
 						<a href="_mod2_.html">&quot;mod2&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
@@ -255,14 +177,11 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_functions_.modulefunction.html#functionvariable" class="tsd-kind-icon">function<wbr>Variable</a>
+					<li class=" tsd-kind-reference tsd-parent-kind-external-module">
+						<a href="_mod2_.html#a" class="tsd-kind-icon">a</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_functions_.modulefunction.html#append" class="tsd-kind-icon">append</a>
-					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_functions_.modulefunction.html#prepend" class="tsd-kind-icon">prepend</a>
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+						<a href="_mod2_.html#default" class="tsd-kind-icon">default</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_mod_.html
+++ b/src/test/renderer/specs/modules/_mod_.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>moduleFunction | typedoc</title>
+	<title>&quot;mod&quot; | typedoc</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="../assets/css/main.css">
@@ -56,134 +56,66 @@
 					<a href="../globals.html">Globals</a>
 				</li>
 				<li>
-					<a href="_functions_.html">&quot;functions&quot;</a>
-				</li>
-				<li>
-					<a href="_functions_.modulefunction.html">moduleFunction</a>
+					<a href="_mod_.html">&quot;mod&quot;</a>
 				</li>
 			</ul>
-			<h1>Module moduleFunction</h1>
+			<h1>External module &quot;mod&quot;</h1>
 		</div>
 	</div>
 </header>
 <div class="container container-main">
 	<div class="row">
 		<div class="col-8 col-content">
-			<section class="tsd-panel tsd-comment">
-				<div class="tsd-comment tsd-typography">
-					<div class="lead">
-						<p>This is the module extending the function moduleFunction().</p>
-					</div>
-				</div>
-			</section>
-			<section class="tsd-panel">
-				<h3 class="tsd-before-signature">Callable</h3>
-				<ul class="tsd-signatures tsd-kind-module tsd-parent-kind-external-module">
-					<li class="tsd-signature tsd-kind-icon">module<wbr>Function<span class="tsd-signature-symbol">(</span>arg<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
-				</ul>
-				<ul class="tsd-descriptions">
-					<li class="tsd-description">
-						<aside class="tsd-sources">
-							<ul>
-								<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/functions.ts#L141">functions.ts:141</a></li>
-							</ul>
-						</aside>
-						<div class="tsd-comment tsd-typography">
-							<div class="lead">
-								<p>This is a function that is extended by a module.</p>
-							</div>
-						</div>
-						<h4 class="tsd-parameters-title">Parameters</h4>
-						<ul class="tsd-parameters">
-							<li>
-								<h5>arg: <span class="tsd-signature-type">string</span></h5>
-								<div class="tsd-comment tsd-typography">
-									<p>An argument.</p>
-								</div>
-							</li>
-						</ul>
-						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
-					</li>
-				</ul>
-			</section>
 			<section class="tsd-panel-group tsd-index-group">
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.modulefunction.html#functionvariable" class="tsd-kind-icon">function<wbr>Variable</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_mod_.html#a" class="tsd-kind-icon">a</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section tsd-is-not-exported">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.modulefunction.html#append" class="tsd-kind-icon">append</a></li>
-								<li class="tsd-kind-function tsd-parent-kind-module tsd-is-not-exported"><a href="_functions_.modulefunction.html#prepend" class="tsd-kind-icon">prepend</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_mod_.html#default" class="tsd-kind-icon">default</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Variables</h2>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-					<a name="functionvariable" class="tsd-anchor"></a>
-					<h3>function<wbr>Variable</h3>
-					<div class="tsd-signature tsd-kind-icon">function<wbr>Variable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
+					<a name="a" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagConst">Const</span> a</h3>
+					<div class="tsd-signature tsd-kind-icon">a<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">1</span><span class="tsd-signature-symbol"> =&nbsp;1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/functions.ts#L152">functions.ts:152</a></li>
+							<li>Defined in mod.ts:1</li>
 						</ul>
 					</aside>
-					<div class="tsd-comment tsd-typography">
-						<div class="lead">
-							<p>This variable is appended to a function.</p>
-						</div>
-					</div>
 				</section>
 			</section>
 			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
 				<h2>Functions</h2>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-					<a name="append" class="tsd-anchor"></a>
-					<h3>append</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">append<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<a name="default" class="tsd-anchor"></a>
+					<h3>default</h3>
+					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+						<li class="tsd-signature tsd-kind-icon">default<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/functions.ts#L158">functions.ts:158</a></li>
+									<li>Defined in mod.ts:1</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>This function is appended to another function.</p>
-								</div>
-							</div>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
-						</li>
-					</ul>
-				</section>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-					<a name="prepend" class="tsd-anchor"></a>
-					<h3>prepend</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">prepend<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
-					</ul>
-					<ul class="tsd-descriptions">
-						<li class="tsd-description">
-							<aside class="tsd-sources">
-								<ul>
-									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/functions.ts#L165">functions.ts:165</a></li>
-								</ul>
-							</aside>
-							<div class="tsd-comment tsd-typography">
-								<div class="lead">
-									<p>This function is appended to another function.</p>
+									<p>Will not be included in mod2</p>
 								</div>
 							</div>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -213,18 +145,13 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_flattened_.html">&quot;flattened&quot;</a>
 					</li>
-					<li class="current tsd-kind-external-module">
+					<li class=" tsd-kind-external-module">
 						<a href="_functions_.html">&quot;functions&quot;</a>
-						<ul>
-							<li class="current tsd-kind-module tsd-parent-kind-external-module">
-								<a href="_functions_.modulefunction.html">module<wbr>Function</a>
-							</li>
-						</ul>
 					</li>
 					<li class=" tsd-kind-external-module">
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
-					<li class=" tsd-kind-external-module">
+					<li class="current tsd-kind-external-module">
 						<a href="_mod_.html">&quot;mod&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
@@ -255,14 +182,11 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-variable tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_functions_.modulefunction.html#functionvariable" class="tsd-kind-icon">function<wbr>Variable</a>
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
+						<a href="_mod_.html#a" class="tsd-kind-icon">a</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_functions_.modulefunction.html#append" class="tsd-kind-icon">append</a>
-					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<a href="_functions_.modulefunction.html#prepend" class="tsd-kind-icon">prepend</a>
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+						<a href="_mod_.html#default" class="tsd-kind-icon">default</a>
 					</li>
 				</ul>
 			</nav>

--- a/src/test/renderer/specs/modules/_mod_.html
+++ b/src/test/renderer/specs/modules/_mod_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">a<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">1</span><span class="tsd-signature-symbol"> =&nbsp;1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in mod.ts:1</li>
+							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/mod.ts#L1">mod.ts:1</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in mod.ts:1</li>
+									<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/mod.ts#L1">mod.ts:1</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/test/renderer/specs/modules/_modules_.html
+++ b/src/test/renderer/specs/modules/_modules_.html
@@ -376,6 +376,12 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
 					<li class="current tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 						<ul>

--- a/src/test/renderer/specs/modules/_modules_.mymodule.html
+++ b/src/test/renderer/specs/modules/_modules_.mymodule.html
@@ -225,6 +225,12 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
 					<li class="current tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 						<ul>

--- a/src/test/renderer/specs/modules/_modules_.mymodule.mysubmodule.html
+++ b/src/test/renderer/specs/modules/_modules_.mymodule.mysubmodule.html
@@ -144,6 +144,12 @@
 					<li class=" tsd-kind-external-module">
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
 					<li class="current tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 						<ul>

--- a/src/test/renderer/specs/modules/_single_export_.html
+++ b/src/test/renderer/specs/modules/_single_export_.html
@@ -109,6 +109,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class="current tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_typescript_1_3_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_3_.html
@@ -70,25 +70,25 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Classes</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_typescript_1_3_.classwithprotectedmembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a></li>
-								<li class="tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported"><a href="../classes/_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_typescript_1_3_.classwithprotectedmembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a></li>
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_3_.html#tupletype" class="tsd-kind-icon">tuple<wbr>Type</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_3_.html#tupletype" class="tsd-kind-icon">tuple<wbr>Type</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Variables</h2>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="tupletype" class="tsd-anchor"></a>
 					<h3>tuple<wbr>Type</h3>
 					<div class="tsd-signature tsd-kind-icon">tuple<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><a href="../classes/_typescript_1_3_.classwithprotectedmembers.html" class="tsd-signature-type">ClassWithProtectedMembers</a><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> =&nbsp;[&#x27;test&#x27;, new ClassWithProtectedMembers()]</span></div>
@@ -163,13 +163,13 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module">
 						<a href="../classes/_typescript_1_3_.classwithprotectedmembers.html" class="tsd-kind-icon">Class<wbr>With<wbr>Protected<wbr>Members</a>
 					</li>
-					<li class=" tsd-kind-class tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module">
 						<a href="../classes/_typescript_1_3_.subclasswithprotectedmembers.html" class="tsd-kind-icon">Subclass<wbr>With<wbr>Protected<wbr>Members</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_3_.html#tupletype" class="tsd-kind-icon">tuple<wbr>Type</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/modules/_typescript_1_3_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_3_.html
@@ -133,6 +133,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_typescript_1_4_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_4_.html
@@ -185,7 +185,7 @@
 						<h4>Type declaration</h4>
 						<ul class="tsd-parameters">
 							<li class="tsd-parameter-siganture">
-								<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-type-alias tsd-has-type-parameter tsd-is-not-exported">
+								<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-type-alias tsd-has-type-parameter">
 									<li class="tsd-signature tsd-kind-icon">&lt;T&gt;<span class="tsd-signature-symbol">(</span>val<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span>, index<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, arr<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span></li>
 								</ul>
 								<ul class="tsd-descriptions">

--- a/src/test/renderer/specs/modules/_typescript_1_4_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_4_.html
@@ -416,6 +416,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_typescript_1_5_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_5_.html
@@ -288,6 +288,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_typescript_1_5_.html
+++ b/src/test/renderer/specs/modules/_typescript_1_5_.html
@@ -70,34 +70,34 @@
 				<h2>Index</h2>
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Variables</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraya" class="tsd-kind-icon">destruct<wbr>ArrayA</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarrayb" class="tsd-kind-icon">destruct<wbr>ArrayB</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarrayc" class="tsd-kind-icon">destruct<wbr>ArrayC</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithignoresa" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>IgnoresA</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithignoresrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithresta" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestA</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructarraywithrestb" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestB</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructobjecta" class="tsd-kind-icon">destruct<wbr>ObjectA</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructobjectb" class="tsd-kind-icon">destruct<wbr>ObjectB</a></li>
-								<li class="tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#destructobjectc" class="tsd-kind-icon">destruct<wbr>ObjectC</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructarraya" class="tsd-kind-icon">destruct<wbr>ArrayA</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructarrayb" class="tsd-kind-icon">destruct<wbr>ArrayB</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructarrayc" class="tsd-kind-icon">destruct<wbr>ArrayC</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructarraywithignoresa" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>IgnoresA</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructarraywithignoresrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructarraywithrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructarraywithresta" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestA</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructarraywithrestb" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestB</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructobjecta" class="tsd-kind-icon">destruct<wbr>ObjectA</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructobjectb" class="tsd-kind-icon">destruct<wbr>ObjectB</a></li>
+								<li class="tsd-kind-variable tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#destructobjectc" class="tsd-kind-icon">destruct<wbr>ObjectC</a></li>
 							</ul>
 						</section>
-						<section class="tsd-index-section tsd-is-not-exported">
+						<section class="tsd-index-section ">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
-								<li class="tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported"><a href="_typescript_1_5_.html#drawtext" class="tsd-kind-icon">draw<wbr>Text</a></li>
+								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_typescript_1_5_.html#drawtext" class="tsd-kind-icon">draw<wbr>Text</a></li>
 							</ul>
 						</section>
 					</div>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Variables</h2>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructarraya" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ArrayA</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ArrayA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -107,7 +107,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructarrayb" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ArrayB</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ArrayB<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -117,7 +117,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructarrayc" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ArrayC</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ArrayC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;10</span></div>
@@ -127,7 +127,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructarraywithignoresa" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>IgnoresA</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>IgnoresA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -137,7 +137,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructarraywithignoresrest" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
@@ -147,7 +147,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructarraywithrest" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>Rest</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
@@ -157,7 +157,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructarraywithresta" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>RestA</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -167,7 +167,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructarraywithrestb" class="tsd-anchor"></a>
 					<h3>destruct<wbr>Array<wbr>With<wbr>RestB</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestB<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -177,7 +177,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructobjecta" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ObjectA</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ObjectA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -187,7 +187,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructobjectb" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ObjectB</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ObjectB<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -197,7 +197,7 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-external-module">
 					<a name="destructobjectc" class="tsd-anchor"></a>
 					<h3>destruct<wbr>ObjectC</h3>
 					<div class="tsd-signature tsd-kind-icon">destruct<wbr>ObjectC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -208,12 +208,12 @@
 					</aside>
 				</section>
 			</section>
-			<section class="tsd-panel-group tsd-member-group tsd-is-not-exported">
+			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Functions</h2>
-				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+				<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-external-module">
 					<a name="drawtext" class="tsd-anchor"></a>
 					<h3>draw<wbr>Text</h3>
-					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-external-module">
 						<li class="tsd-signature tsd-kind-icon">draw<wbr>Text<span class="tsd-signature-symbol">(</span>__namedParameters<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
@@ -318,40 +318,40 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructarraya" class="tsd-kind-icon">destruct<wbr>ArrayA</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructarrayb" class="tsd-kind-icon">destruct<wbr>ArrayB</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructarrayc" class="tsd-kind-icon">destruct<wbr>ArrayC</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructarraywithignoresa" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>IgnoresA</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructarraywithignoresrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Ignores<wbr>Rest</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructarraywithrest" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>Rest</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructarraywithresta" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestA</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructarraywithrestb" class="tsd-kind-icon">destruct<wbr>Array<wbr>With<wbr>RestB</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructobjecta" class="tsd-kind-icon">destruct<wbr>ObjectA</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructobjectb" class="tsd-kind-icon">destruct<wbr>ObjectB</a>
 					</li>
-					<li class=" tsd-kind-variable tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-variable tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#destructobjectc" class="tsd-kind-icon">destruct<wbr>ObjectC</a>
 					</li>
-					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-is-not-exported">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="_typescript_1_5_.html#drawtext" class="tsd-kind-icon">draw<wbr>Text</a>
 					</li>
 				</ul>

--- a/src/test/renderer/specs/modules/_variables_.html
+++ b/src/test/renderer/specs/modules/_variables_.html
@@ -158,6 +158,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">

--- a/src/test/renderer/specs/modules/_weird_names_.html
+++ b/src/test/renderer/specs/modules/_weird_names_.html
@@ -146,6 +146,12 @@
 						<a href="_generics_.html">&quot;generics&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">
+						<a href="_mod_.html">&quot;mod&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="_mod2_.html">&quot;mod2&quot;</a>
+					</li>
+					<li class=" tsd-kind-external-module">
 						<a href="_modules_.html">&quot;modules&quot;</a>
 					</li>
 					<li class=" tsd-kind-external-module">


### PR DESCRIPTION
After examining prior implementations (#646, #801, #1079, #1143), and spending a good bit of time trying to satisfy myself with #801, I decided to just try implementing a new type of declaration that references another declaration.

This is the result of that effort. The diff appears far larger than it really is since it includes updates to the tests (specifically, the rendering tests explode for any small change). I recommend looking at [just the TS changes](https://github.com/TypeStrong/typedoc/pull/1157/files?file-filters%5B%5D=.ts)

### Try it out:

This PR has been published as `typedoc@0.16.0-0`, which can be installed with `npm i typedoc@next`

```bash
npm i typedoc@next
npx typedoc --out docs src/index.ts
npx serve docs
```

### Comparisons:

| Issue | Pros | Cons |
| --- | --- | --- |
| #646 | Simple implementation, reflection links lead directly to the referenced reflections | Depends on the conversion order, will fail to create reflections in some cases. |
| #801 | Defers resolution until after conversion, does not suffer from conversion order issues | Introduces performance penalties due to early export trimming |
| #1079 | Simple implementation, copies imported reflections as if they existed where they are re-exported | Bloats output size, renamed symbols are confusing + may break links in doc comments |
| #1143 | Simple change to mark reflections exported with export declarations as exported | Does not handle re-exports, only exporting reflections existing in a file. |
| This PR | Avoids conversion order + deferred conversion problems, relatively simple implementation | All renamed reflections require 2 clicks to get to the actual reflection in the default theme |

I think the two biggest problems with this solution are that:

1. Re-exports with the same name require an extra click. - This could be changed by a theme, and I'd be open to accepting a PR that changes it in the default theme, but I've spent way too long trying to figure out how to do this without rebuilding the output builder entirely...
2. References aren't nicely grouped according to their type. - Again, this could be changed by a theme. The Rust docs ([example](https://doc.rust-lang.org/std/#reexports)) do the same thing, so maybe this is okay?

### Screenshots

`a` is re-exported using `export * from './mod'`

![image](https://user-images.githubusercontent.com/19329837/71563394-e28c9800-2a4b-11ea-9d9f-888fa3ba00b8.png)

`ExportedClassName` is exported using `export { NotExportedClassName as ExportedClassName }`

![image](https://user-images.githubusercontent.com/19329837/71563401-f0dab400-2a4b-11ea-9ec2-12dbd0254c91.png)
