### PR TITLE
Resolve TypeOperatorType to allow it to be hyperlinkable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2060,9 +2060,8 @@
       }
     },
     "typedoc-default-themes": {
-      "version": "0.7.0-2",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.7.0-2.tgz",
-      "integrity": "sha512-L/f3mKgOImj2A4i9fb9kzU+Hb0cYXkN9Qn9QpM0BZ/704kEwRSijntRWhRaBt+pcXIwidxTYEVdUYNzGGsa67g==",
+      "version": "file:../typedoc-default-themes/typedoc-default-themes-0.6.4.tgz",
+      "integrity": "sha512-dNCR5LD7ixuNm0C4sYT9Yf084DiQRZmZ4lr12zxuXLGSeLkRuBvcpBzzgm9H3mIilG6+atPqpzdRp0/fnQdrlg==",
       "requires": {
         "backbone": "^1.4.0",
         "jquery": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "minimatch": "^3.0.0",
     "progress": "^2.0.3",
     "shelljs": "^0.8.3",
-    "typedoc-default-themes": "0.7.0-2",
+    "typedoc-default-themes": "file:../typedoc-default-themes/typedoc-default-themes-0.6.4.tgz",
     "typescript": "3.7.x"
   },
   "devDependencies": {

--- a/src/lib/converter/plugins/TypePlugin.ts
+++ b/src/lib/converter/plugins/TypePlugin.ts
@@ -1,5 +1,5 @@
 import { Reflection, ReflectionKind, Decorator, DeclarationReflection, DeclarationHierarchy } from '../../models/reflections/index';
-import { Type, ReferenceType, TupleType, UnionType, IntersectionType, ArrayType } from '../../models/types/index';
+import { Type, ReferenceType, TupleType, UnionType, IntersectionType, ArrayType, TypeOperatorType } from '../../models/types/index';
 import { Component, ConverterComponent } from '../components';
 import { Converter } from '../converter';
 import { Context } from '../context';
@@ -106,6 +106,8 @@ export class TypePlugin extends ConverterComponent {
                 resolveTypes(reflection, type.types);
             } else if (type instanceof ArrayType) {
                 resolveType(reflection, type.elementType);
+            } else if (type instanceof TypeOperatorType) {
+                resolveType(reflection, type.target);
             }
         }
     }

--- a/src/test/.editorconfig
+++ b/src/test/.editorconfig
@@ -1,0 +1,2 @@
+[*.html]
+insert_final_newline = false

--- a/src/test/converter/type-operator/specs.json
+++ b/src/test/converter/type-operator/specs.json
@@ -35,6 +35,7 @@
                 "type": "typeOperator",
                 "operator": "keyof",
                 "target": {
+                  "id": 2,
                   "type": "reference",
                   "name": "TestClass"
                 }
@@ -64,6 +65,7 @@
                   "type": "typeOperator",
                   "operator": "keyof",
                   "target": {
+                    "id": 2,
                     "type": "reference",
                     "name": "TestClass"
                   }

--- a/src/test/renderer/specs/classes/_classes_.baseclass.html
+++ b/src/test/renderer/specs/classes/_classes_.baseclass.html
@@ -181,7 +181,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private">
 					<a name="internalclass" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> internal<wbr>Class</h3>
-					<div class="tsd-signature tsd-kind-icon">internal<wbr>Class<span class="tsd-signature-symbol">:</span> <a href="_classes_.internalclass.html" class="tsd-signature-type">InternalClass</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">keyof BaseClass</span><span class="tsd-signature-symbol">&gt;</span></div>
+					<div class="tsd-signature tsd-kind-icon">internal<wbr>Class<span class="tsd-signature-symbol">:</span> <a href="_classes_.internalclass.html" class="tsd-signature-type">InternalClass</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">keyof <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/sebastian-lenz/typedoc/blob/master/examples/basic/src/classes.ts#L76">classes.ts:76</a></li>

--- a/src/test/renderer/specs/classes/_classes_.internalclass.html
+++ b/src/test/renderer/specs/classes/_classes_.internalclass.html
@@ -80,7 +80,7 @@
 				<h3>Type parameters</h3>
 				<ul class="tsd-type-parameters">
 					<li>
-						<h4>TTT<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">keyof BaseClass</span></h4>
+						<h4>TTT<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">keyof <a href="_classes_.baseclass.html" class="tsd-signature-type">BaseClass</a></span></h4>
 					</li>
 				</ul>
 			</section>


### PR DESCRIPTION
The change add type resolution for `TypeOperatorType` types so that it can be hyperlinkable.

This change depends on https://github.com/TypeStrong/typedoc-default-themes/pull/91 and was raised because of the following issue: https://github.com/TypeStrong/typedoc/issues/1148#issuecomment-568608150

> Not linking to callbacks in `keyof Callbacks` sounds like a bug to me.
