### PR TITLE
fix: Prevent @hidden signature from removing method declaration

### DIFF
--- a/src/test/converter/comment/comment.ts
+++ b/src/test/converter/comment/comment.ts
@@ -39,6 +39,42 @@ export class CommentedClass {
   hiddenprop: string;
 
   /**
+   * Hidden function
+   * @hidden
+   */
+  hidden(...args: any[]): void {}
+
+  /**
+   * Single hidden signature
+   * @hidden
+   */
+  hiddenWithImplementation(arg: any);
+  hiddenWithImplementation(...args: any[]): void {}
+
+  /**
+   * Multiple hidden 1
+   * @hidden
+   */
+  multipleHidden(arg: any);
+  /**
+   * Multiple hidden 2
+   * @hidden
+   */
+  multipleHidden(arg1: any, arg2: any);
+  multipleHidden(...args: any[]): void {}
+
+  /**
+   * Mixed hidden 1
+   * @hidden
+   */
+  mixedHidden(arg: any);
+  /**
+   * Mixed hidden 2
+   */
+  mixedHidden(arg1: any, arg2: any);
+  mixedHidden(...args: any[]): void {}
+
+  /**
    * @ignore
    */
   ignoredprop: string;

--- a/src/test/converter/comment/specs.json
+++ b/src/test/converter/comment/specs.json
@@ -62,6 +62,78 @@
                 "type": "intrinsic",
                 "name": "string"
               }
+            },
+            {
+              "id": 22,
+              "name": "mixedHidden",
+              "kind": 2048,
+              "kindString": "Method",
+              "flags": {
+                "isExported": true
+              },
+              "signatures": [
+                {
+                  "id": 25,
+                  "name": "mixedHidden",
+                  "kind": 4096,
+                  "kindString": "Call signature",
+                  "flags": {
+                    "isExported": true
+                  },
+                  "comment": {
+                    "shortText": "Mixed hidden 2"
+                  },
+                  "parameters": [
+                    {
+                      "id": 26,
+                      "name": "arg1",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isExported": true
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    },
+                    {
+                      "id": 27,
+                      "name": "arg2",
+                      "kind": 32768,
+                      "kindString": "Parameter",
+                      "flags": {
+                        "isExported": true
+                      },
+                      "type": {
+                        "type": "intrinsic",
+                        "name": "any"
+                      }
+                    }
+                  ],
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "any"
+                  }
+                }
+              ],
+              "sources": [
+                {
+                  "fileName": "comment.ts",
+                  "line": 70,
+                  "character": 13
+                },
+                {
+                  "fileName": "comment.ts",
+                  "line": 74,
+                  "character": 13
+                },
+                {
+                  "fileName": "comment.ts",
+                  "line": 75,
+                  "character": 13
+                }
+              ]
             }
           ],
           "groups": [
@@ -70,6 +142,13 @@
               "kind": 1024,
               "children": [
                 8
+              ]
+            },
+            {
+              "title": "Methods",
+              "kind": 2048,
+              "children": [
+                22
               ]
             }
           ],
@@ -82,7 +161,7 @@
           ]
         },
         {
-          "id": 11,
+          "id": 29,
           "name": "gh1164",
           "kind": 64,
           "kindString": "Function",
@@ -91,7 +170,7 @@
           },
           "signatures": [
             {
-              "id": 12,
+              "id": 30,
               "name": "gh1164",
               "kind": 4096,
               "kindString": "Call signature",
@@ -104,7 +183,7 @@
               },
               "parameters": [
                 {
-                  "id": 13,
+                  "id": 31,
                   "name": "scope",
                   "kind": 32768,
                   "kindString": "Parameter",
@@ -129,7 +208,7 @@
           "sources": [
             {
               "fileName": "comment.ts",
-              "line": 52,
+              "line": 88,
               "character": 22
             }
           ]
@@ -147,7 +226,7 @@
           "title": "Functions",
           "kind": 64,
           "children": [
-            11
+            29
           ]
         }
       ],


### PR DESCRIPTION
For #1142

The declaration was being treat as hidden when `applyModifiers` was being called. This change determines if the reflection is hidden during resolution instead.