### PR TITLE
Refactor DefaultTheme to be more easily extended

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   ],
   "scripts": {
     "pretest": "node scripts/copy_test_files.js",
-    "test": "nyc --reporter=html --reporter=text-summary mocha --timeout=10000 dist/test/**/*.test.js",
+    "test": "nyc --reporter=html --reporter=text-summary mocha --timeout=10000 'dist/test/**/*.test.js'",
     "prerebuild_specs": "npm run pretest",
     "rebuild_specs": "node scripts/rebuild_specs.js",
     "build": "tsc --project .",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export { normalizePath } from './lib/utils/fs';
 export * from './lib/models/reflections';
 export * from './lib/output/plugins';
 export { Renderer } from './lib/output/renderer';
-export { DefaultTheme } from './lib/output/themes/DefaultTheme';
+export { DefaultTheme, NavigationBuilder } from './lib/output/themes/DefaultTheme';
 export { NavigationItem } from './lib/output/models/NavigationItem';
 export { UrlMapping } from './lib/output/models/UrlMapping';
 

--- a/src/lib/output/themes/DefaultTheme.ts
+++ b/src/lib/output/themes/DefaultTheme.ts
@@ -384,7 +384,7 @@ export class NavigationBuilder {
                 target = target.parent;
             }
 
-            if (inScope && someModule instanceof DeclarationReflection) {
+            if (inScope && someModule instanceof DeclarationReflection && someModule.children && someModule.children.length > 0) {
                 modules.push(someModule);
             }
         });


### PR DESCRIPTION
I pulled the internal functions out of `getNavigation` into a separate `NavigationBuilder` class so that a custom theme doesn't have to re-implement all of them. 

I also changed the default behavior of `build` to no longer add links to empty modules.  This fixes #1126 