### PR TITLE
fix: Plugin resolution for relative paths

### DIFF
--- a/src/test/plugin-host.test.ts
+++ b/src/test/plugin-host.test.ts
@@ -1,6 +1,7 @@
 import { Application } from '..';
 import Assert = require('assert');
 import * as mockery from 'mockery';
+import * as path from 'path';
 
 describe('PluginHost', function () {
   before (function () {
@@ -25,6 +26,29 @@ describe('PluginHost', function () {
     Assert.deepEqual(app.plugins.plugins, [
       'typedoc-plugin-1',
       'typedoc-plugin-2'
+    ]);
+  });
+
+  it('loads a plugin with relative path', function () {
+    const app = new Application();
+    app.bootstrap({
+      plugin: ['./dist/test/plugins/relative']
+    });
+
+    Assert.deepEqual(app.plugins.plugins, [
+      './dist/test/plugins/relative'
+    ]);
+  });
+
+  it('loads a plugin with absolute path', function () {
+    const app = new Application();
+    const absolutePath = path.resolve(__dirname, './plugins/absolute');
+    app.bootstrap({
+      plugin: [absolutePath]
+    });
+
+    Assert.deepEqual(app.plugins.plugins, [
+        absolutePath
     ]);
   });
 });

--- a/src/test/plugins/absolute.ts
+++ b/src/test/plugins/absolute.ts
@@ -1,0 +1,4 @@
+import { Application } from '../..';
+
+module.exports = (pluginHost: Application) => {
+};

--- a/src/test/plugins/relative.ts
+++ b/src/test/plugins/relative.ts
@@ -1,0 +1,4 @@
+import { Application } from '../..';
+
+module.exports = (pluginHost: Application) => {
+};


### PR DESCRIPTION
Resolve plugin modules relative to the current path instead of the internal path.

Fixes #1188