### PR TITLE
Logger: also count the warning messages

### DIFF
--- a/src/lib/utils/loggers.ts
+++ b/src/lib/utils/loggers.ts
@@ -128,7 +128,7 @@ export class Logger {
         if (level === LogLevel.Error) {
             this.errorCount += 1;
         }
-        if (level === LogLevel.Warning) {
+        if (level === LogLevel.Warn) {
             this.warningCount += 1;
         }
     }

--- a/src/lib/utils/loggers.ts
+++ b/src/lib/utils/loggers.ts
@@ -23,7 +23,7 @@ export class Logger {
      * How many error messages have been logged?
      */
     errorCount = 0;
-    
+
     /**
      * How many warning messages have been logged?
      */
@@ -35,7 +35,7 @@ export class Logger {
     public hasErrors(): boolean {
         return this.errorCount > 0;
     }
-    
+
     /**
      * Has a warning been raised through the log method?
      */
@@ -49,7 +49,7 @@ export class Logger {
     public resetErrors() {
         this.errorCount = 0;
     }
-    
+
     /**
      * Reset the warning counter.
      */

--- a/src/lib/utils/loggers.ts
+++ b/src/lib/utils/loggers.ts
@@ -39,7 +39,7 @@ export class Logger {
     /**
      * Has a warning been raised through the log method?
      */
-    public hasErrors(): boolean {
+    public hasWarnings(): boolean {
         return this.warningCount > 0;
     }
 

--- a/src/lib/utils/loggers.ts
+++ b/src/lib/utils/loggers.ts
@@ -23,6 +23,11 @@ export class Logger {
      * How many error messages have been logged?
      */
     errorCount = 0;
+    
+    /**
+     * How many warning messages have been logged?
+     */
+    warningCount = 0;
 
     /**
      * Has an error been raised through the log method?
@@ -30,12 +35,26 @@ export class Logger {
     public hasErrors(): boolean {
         return this.errorCount > 0;
     }
+    
+    /**
+     * Has a warning been raised through the log method?
+     */
+    public hasErrors(): boolean {
+        return this.warningCount > 0;
+    }
 
     /**
      * Reset the error counter.
      */
     public resetErrors() {
         this.errorCount = 0;
+    }
+    
+    /**
+     * Reset the warning counter.
+     */
+    public resetWarnings() {
+        this.warningCount = 0;
     }
 
     /**
@@ -108,6 +127,9 @@ export class Logger {
     public log(message: string, level: LogLevel = LogLevel.Info, newLine?: boolean) {
         if (level === LogLevel.Error) {
             this.errorCount += 1;
+        }
+        if (level === LogLevel.Warning) {
+            this.warningCount += 1;
         }
     }
 


### PR DESCRIPTION
If you want to make your build fail on error messages, you currently can do
```
const result = app.generateDocs(project, OUTPUT_DIR);
if (!result || app.logger.hasErrors() ) {
  console.log("Errors were logged during the generation of the documentation. Check the log for more information");
  process.exit(1);
}
```

However, warning messages typically indicate a problem as well. If you want to make your build fail on those as well, you need a custom logger to keep track of the warning messages yourself.

This PR makes this easier by counting the warning messages in a similar fashion as the error messages.