### PR TITLE
Moved @types/minimatch dependency to devDepencencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "node": ">= 6.0.0"
   },
   "dependencies": {
-    "@types/minimatch": "3.0.3",
     "fs-extra": "^8.1.0",
     "handlebars": "^4.7.2",
     "highlight.js": "^9.17.1",
@@ -43,6 +42,7 @@
     "typescript": "3.7.x"
   },
   "devDependencies": {
+    "@types/minimatch": "3.0.3",
     "@types/fs-extra": "^8.0.1",
     "@types/lodash": "^4.14.149",
     "@types/marked": "^0.7.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ export { Application } from './lib/application';
 export { CliApplication } from './lib/cli';
 
 export { EventDispatcher, Event } from './lib/utils/events';
-export { createMinimatch } from './lib/utils/paths';
 export { resetReflectionID } from './lib/models/reflections/abstract';
 export { normalizePath } from './lib/utils/fs';
 export * from './lib/models/reflections';

--- a/src/test/utils/paths.test.ts
+++ b/src/test/utils/paths.test.ts
@@ -4,7 +4,7 @@ import { Minimatch } from 'minimatch';
 import isEqual = require('lodash/isEqual');
 import Assert = require('assert');
 
-import { createMinimatch } from '../..';
+import { createMinimatch } from '../../lib/utils/paths';
 
 // Used to ensure uniform path cross OS
 const absolutePath = (path: string) => Path.resolve(path.replace(/^\w:/, '')).replace(/[\\]/g, '/');


### PR DESCRIPTION
I moved @types/minimatch to devDependencies because, right now any project that uses typedoc, installs along with the main package, also minimatch's types. They shouldn't be installed if not for development.

Or is there a specific reason for which these types have been inserted in dependencies? If any, can you please explain it?

😊