### PR TITLE
Avoid iterating over undefined array.

### DIFF
--- a/src/lib/converter/nodes/class.ts
+++ b/src/lib/converter/nodes/class.ts
@@ -69,9 +69,12 @@ export class ClassConverter extends ConverterNodeComponent<ts.ClassDeclaration> 
                     const typesToInheritFrom: ts.Type[] = type.isIntersection() ? type.types : [ type ];
 
                     typesToInheritFrom.forEach((typeToInheritFrom: ts.Type) => {
-                        typeToInheritFrom.symbol 
-                        && typeToInheritFrom.symbol.declarations
-                        && typeToInheritFrom.symbol.declarations.forEach((declaration) => {
+                        // TODO: The TS declaration file claims that:
+                        // 1. type.symbol is non-nullable
+                        // 2. symbol.declarations is non-nullable
+                        // These are both incorrect, GH#1207 for #2 and existing tests for #1.
+                        // Figure out why this is the case and document.
+                        typeToInheritFrom.symbol?.declarations?.forEach((declaration) => {
                             context.inherit(declaration, baseType.typeArguments);
                         });
                     });

--- a/src/lib/converter/nodes/class.ts
+++ b/src/lib/converter/nodes/class.ts
@@ -69,7 +69,9 @@ export class ClassConverter extends ConverterNodeComponent<ts.ClassDeclaration> 
                     const typesToInheritFrom: ts.Type[] = type.isIntersection() ? type.types : [ type ];
 
                     typesToInheritFrom.forEach((typeToInheritFrom: ts.Type) => {
-                        typeToInheritFrom.symbol && typeToInheritFrom.symbol.declarations.forEach((declaration) => {
+                        typeToInheritFrom.symbol 
+                        && typeToInheritFrom.symbol.declarations
+                        && typeToInheritFrom.symbol.declarations.forEach((declaration) => {
                             context.inherit(declaration, baseType.typeArguments);
                         });
                     });


### PR DESCRIPTION
Fixes #1207. 

I've been using this patch to unblock my project, but I'm unsure if additional logic is needed in the case that `typeToInheritFrom.symbol` is defined but `typeToInheritFrom.symbol.declarations` is not.