### PR TITLE
Logger extensions now also count the warnings

### DIFF
--- a/src/lib/utils/loggers.ts
+++ b/src/lib/utils/loggers.ts
@@ -184,9 +184,7 @@ export class ConsoleLogger extends Logger {
      * @param newLine  Should the logger print a trailing whitespace?
      */
     public log(message: string, level: LogLevel = LogLevel.Info, newLine?: boolean) {
-        if (level === LogLevel.Error) {
-            this.errorCount += 1;
-        }
+        super.log(message, level, newLine);
 
         let output = '';
         if (level === LogLevel.Error) {
@@ -234,9 +232,7 @@ export class CallbackLogger extends Logger {
      * @param newLine  Should the logger print a trailing whitespace?
      */
     public log(message: string, level: LogLevel = LogLevel.Info, newLine?: boolean) {
-        if (level === LogLevel.Error) {
-            this.errorCount += 1;
-        }
+        super.log(message, level, newLine);
 
         this.callback(message, level, newLine);
     }


### PR DESCRIPTION
I cannot believe I messed up that previous PR (https://github.com/TypeStrong/typedoc/pull/1205), but the extensions of the `Logger` class did not count the warnings.
Solved this by removing the error counting code from the child classes, and called the super method instead.
This ensures that both the error count and the warning count increases.