### PR TITLE
feat: extract & expose `toString` for stringifying types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { Application } from './lib/application';
 export { CliApplication } from './lib/cli';
-export * from './lib/stringifiers';
+export { stringifyType } from './lib/stringifiers';
 
 export { EventDispatcher, Event } from './lib/utils/events';
 export { createMinimatch } from './lib/utils/paths';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { Application } from './lib/application';
 export { CliApplication } from './lib/cli';
+export * from './lib/stringifiers';
 
 export { EventDispatcher, Event } from './lib/utils/events';
 export { createMinimatch } from './lib/utils/paths';

--- a/src/lib/models/types/abstract.ts
+++ b/src/lib/models/types/abstract.ts
@@ -33,7 +33,7 @@ export abstract class Type {
      * Return a string representation of this type.
      */
     toString(): string {
-        return this.type === 'void' ? 'void' : stringifyType(this);
+        return stringifyType(this);
     }
 
     /**

--- a/src/lib/models/types/abstract.ts
+++ b/src/lib/models/types/abstract.ts
@@ -1,3 +1,5 @@
+import { stringifyType } from '../../stringifiers';
+
 /**
  * Base class of all type definitions.
  *
@@ -31,7 +33,7 @@ export abstract class Type {
      * Return a string representation of this type.
      */
     toString(): string {
-        return 'void';
+        return this.type === 'void' ? 'void' : stringifyType(this);
     }
 
     /**

--- a/src/lib/models/types/array.ts
+++ b/src/lib/models/types/array.ts
@@ -1,4 +1,4 @@
-import { Type, UnionType, IntersectionType } from './index';
+import { Type } from './index';
 
 /**
  * Represents an array type.
@@ -49,17 +49,5 @@ export class ArrayType extends Type {
             return false;
         }
         return type.elementType.equals(this.elementType);
-    }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        const elementTypeStr = this.elementType.toString();
-        if (this.elementType instanceof UnionType || this.elementType instanceof IntersectionType) {
-            return '(' + elementTypeStr + ')[]';
-        } else {
-            return elementTypeStr + '[]';
-        }
     }
 }

--- a/src/lib/models/types/conditional.ts
+++ b/src/lib/models/types/conditional.ts
@@ -47,11 +47,4 @@ export class ConditionalType extends Type {
             this.trueType.equals(type.trueType) &&
             this.falseType.equals(type.falseType);
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        return this.checkType + ' extends ' + this.extendsType + ' ? ' + this.trueType + ' : ' + this.falseType;
-    }
 }

--- a/src/lib/models/types/indexed-access.ts
+++ b/src/lib/models/types/indexed-access.ts
@@ -39,11 +39,4 @@ export class IndexedAccessType extends Type {
         }
         return type.objectType.equals(this.objectType) && type.indexType.equals(this.indexType);
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        return `${this.objectType.toString()}[${this.indexType.toString()}]`;
-    }
 }

--- a/src/lib/models/types/inferred.ts
+++ b/src/lib/models/types/inferred.ts
@@ -38,11 +38,4 @@ export class InferredType extends Type {
         }
         return this.name === type.name;
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        return `infer ${this.name}`;
-    }
 }

--- a/src/lib/models/types/intersection.ts
+++ b/src/lib/models/types/intersection.ts
@@ -49,16 +49,4 @@ export class IntersectionType extends Type {
         }
         return Type.isTypeListSimilar(type.types, this.types);
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        const names: string[] = [];
-        this.types.forEach((element) => {
-            names.push(element.toString());
-        });
-
-        return names.join(' & ');
-    }
 }

--- a/src/lib/models/types/intrinsic.ts
+++ b/src/lib/models/types/intrinsic.ts
@@ -47,11 +47,4 @@ export class IntrinsicType extends Type {
         return type instanceof IntrinsicType &&
             type.name === this.name;
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        return this.name;
-    }
 }

--- a/src/lib/models/types/predicate.ts
+++ b/src/lib/models/types/predicate.ts
@@ -73,16 +73,4 @@ export class PredicateType extends Type {
             && this.asserts === type.asserts
             && (this.targetType?.equals(type.targetType!) ?? true);
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        const out = this.asserts ? ['asserts', this.name] : [this.name];
-        if (this.targetType) {
-            out.push('is', this.targetType.toString());
-        }
-
-        return out.join(' ');
-    }
 }

--- a/src/lib/models/types/query.ts
+++ b/src/lib/models/types/query.ts
@@ -25,8 +25,4 @@ export class QueryType extends Type {
     equals(other: Type) {
         return other instanceof QueryType && this.queryType.equals(other.queryType);
     }
-
-    toString() {
-        return `typeof ${this.queryType.toString()}`;
-    }
 }

--- a/src/lib/models/types/reference.ts
+++ b/src/lib/models/types/reference.ts
@@ -87,20 +87,4 @@ export class ReferenceType extends Type {
     equals(other: ReferenceType): boolean {
         return other instanceof ReferenceType && (other.symbolFullyQualifiedName === this.symbolFullyQualifiedName || other.reflection === this.reflection);
     }
-
-    /**
-     * Return a string representation of this type.
-     * @example EventEmitter<any>
-     */
-    toString() {
-        const name = this.reflection ? this.reflection.name : this.name;
-        let typeArgs = '';
-        if (this.typeArguments) {
-            typeArgs += '<';
-            typeArgs += this.typeArguments.map(arg => arg.toString()).join(', ');
-            typeArgs += '>';
-        }
-
-        return name + typeArgs;
-    }
 }

--- a/src/lib/models/types/reflection.ts
+++ b/src/lib/models/types/reflection.ts
@@ -47,15 +47,4 @@ export class ReflectionType extends Type {
     equals(type: ReflectionType): boolean {
         return type === this;
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        if (!this.declaration.children && this.declaration.signatures) {
-            return 'function';
-        } else {
-            return 'object';
-        }
-    }
 }

--- a/src/lib/models/types/string-literal.ts
+++ b/src/lib/models/types/string-literal.ts
@@ -47,11 +47,4 @@ export class StringLiteralType extends Type {
         return type instanceof StringLiteralType &&
             type.value === this.value;
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString(): string {
-        return '"' + this.value + '"';
-    }
 }

--- a/src/lib/models/types/tuple.ts
+++ b/src/lib/models/types/tuple.ts
@@ -49,16 +49,4 @@ export class TupleType extends Type {
         }
         return Type.isTypeListEqual(type.elements, this.elements);
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        const names: string[] = [];
-        this.elements.forEach((element) => {
-            names.push(element.toString());
-        });
-
-        return '[' + names.join(', ') + ']';
-    }
 }

--- a/src/lib/models/types/type-operator.ts
+++ b/src/lib/models/types/type-operator.ts
@@ -47,11 +47,4 @@ export class TypeOperatorType extends Type {
 
         return type.target.equals(this.target);
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        return `${this.operator} ${this.target.toString()}`;
-    }
 }

--- a/src/lib/models/types/type-parameter.ts
+++ b/src/lib/models/types/type-parameter.ts
@@ -55,11 +55,4 @@ export class TypeParameterType extends Type {
             return false;
         }
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        return this.name;
-    }
 }

--- a/src/lib/models/types/union.ts
+++ b/src/lib/models/types/union.ts
@@ -49,16 +49,4 @@ export class UnionType extends Type {
         }
         return Type.isTypeListSimilar(type.types, this.types);
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        const names: string[] = [];
-        this.types.forEach((element) => {
-            names.push(element.toString());
-        });
-
-        return names.join(' | ');
-    }
 }

--- a/src/lib/models/types/unknown.ts
+++ b/src/lib/models/types/unknown.ts
@@ -43,11 +43,4 @@ export class UnknownType extends Type {
         return type instanceof UnknownType &&
             type.name === this.name;
     }
-
-    /**
-     * Return a string representation of this type.
-     */
-    toString() {
-        return this.name;
-    }
 }

--- a/src/lib/stringifiers.ts
+++ b/src/lib/stringifiers.ts
@@ -1,0 +1,151 @@
+import * as t from './models/types';
+import * as r from './models/reflections';
+
+const stringifyList = (list: t.Type[], separator: string): string => {
+    return list.map(t => stringifyType(t)).join(separator);
+};
+
+export const stringifyArray = (node: t.ArrayType): string => {
+    const elementTypeStr = stringifyType(node.elementType);
+    if (node.elementType instanceof t.UnionType || node.elementType instanceof t.IntersectionType) {
+        return `(${elementTypeStr})[]`;
+    } else {
+        return `${elementTypeStr}[]`;
+    }
+};
+
+export const stringifyConditional = (node: t.ConditionalType): string => {
+    return `${node.checkType} extends ${node.extendsType} ? ${node.trueType} : ${node.falseType}`;
+};
+
+export const stringifyIndexedAccess = (node: t.IndexedAccessType): string => {
+    return `${stringifyType(node.objectType)}[${stringifyType(node.indexType)}]`;
+};
+
+export const stringifyInferred = (node: t.InferredType): string => {
+    return `infer ${node.name}`;
+};
+
+export const stringifyIntersection = (node: t.IntersectionType): string => {
+    return stringifyList(node.types, ' & ');
+};
+
+export const stringifyIntrinsic = (node: t.IntrinsicType): string => {
+    return node.name;
+};
+
+export const stringifyPredicate = (node: t.PredicateType): string => {
+    const out = node.asserts ? ['asserts', node.name] : [node.name];
+    if (node.targetType) {
+        out.push('is', stringifyType(node.targetType));
+    }
+
+    return out.join(' ');
+};
+
+export const stringifyQuery = (node: t.QueryType): string => {
+    return `typeof ${stringifyType(node.queryType)}`;
+};
+
+export const stringifyReference = (node: t.ReferenceType): string => {
+    const name = node.reflection ? node.reflection.name : node.name;
+    let typeArgs = '';
+    if (node.typeArguments) {
+        typeArgs += '<';
+        typeArgs += stringifyList(node.typeArguments, ', ');
+        typeArgs += '>';
+    }
+
+    return name + typeArgs;
+};
+
+export const stringifyReflection = (node: t.ReflectionType): string => {
+    if (!node.declaration.children && node.declaration.signatures) {
+        return 'function';
+    } else {
+        return 'object';
+    }
+};
+
+export const stringifyStringLiteral = (node: t.StringLiteralType): string => {
+    return `"${node.value}"`;
+};
+
+export const stringifyTuple = (node: t.TupleType): string => {
+    return `[${stringifyList(node.elements, ', ')}]`;
+};
+
+export const stringifyTypeOperator = (node: t.TypeOperatorType): string => {
+    return `${node.operator} ${stringifyType(node.target)}`;
+};
+
+export const stringifyTypeParameter = (node: t.TypeParameterType): string => {
+    return node.name;
+};
+
+export const stringifyUnion = (node: t.UnionType): string => {
+    return stringifyList(node.types, ' | ');
+};
+
+export const stringifyUnknown = (node: t.UnknownType): string => {
+    return node.name;
+};
+
+export const stringifyVoid = (): string => {
+    return 'void';
+};
+
+const stringifiers = {
+    array: stringifyArray,
+    conditional: stringifyConditional,
+    indexedAccess: stringifyIndexedAccess,
+    inferred: stringifyInferred,
+    intersection: stringifyIntersection,
+    intrinsic: stringifyIntrinsic,
+    predicate: stringifyPredicate,
+    query: stringifyQuery,
+    reference: stringifyReference,
+    reflection: stringifyReflection,
+    stringLiteral: stringifyStringLiteral,
+    tuple: stringifyTuple,
+    typeOperator: stringifyTypeOperator,
+    typeParameter: stringifyTypeParameter,
+    union: stringifyUnion,
+    unknown: stringifyUnknown,
+    void: stringifyVoid
+};
+
+/**
+ * Return a string representation of the given type.
+ */
+export const stringifyType = (node: t.Type): string => {
+    if (!node || !node.type || !{}.hasOwnProperty.call(stringifiers, node.type)) {
+        throw new TypeError(`Cannot stringify type '${node.type}'`);
+    }
+
+    return stringifiers[node.type](node);
+};
+
+export const stringifyCallSignature = (node: r.SignatureReflection, name = '') => {
+    const {
+        parameters = [],
+        typeParameters = [],
+        type
+    } = node;
+
+    const types = typeParameters.map(t => t.name).join(', ');
+
+    const params = parameters.map(p => {
+        const type = p.type ? ': ' + stringifyType(p.type) : '';
+        return `${p.flags.isRest ? '...' : ''}${p.name}${type}`;
+    }).join(', ');
+
+    const returns = type ? stringifyType(type) : '';
+
+    const returnToken = name === '' ? ' => ' : ': ';
+    const typeParams = types === '' ? '' : ' <' + types + '>';
+
+    return `
+        ${name}${typeParams} (${params})${returnToken}${returns}
+    `.trim();
+};

--- a/src/test/stringifiers.test.ts
+++ b/src/test/stringifiers.test.ts
@@ -1,0 +1,129 @@
+import { stringifyType } from '..';
+import * as t from '../lib/models/types';
+
+import Assert = require('assert');
+
+const union = new t.UnionType([
+    new t.IntrinsicType('string'),
+    new t.IntrinsicType('number'),
+    new t.TupleType([
+        new t.IntrinsicType('boolean'),
+        new t.IntrinsicType('string')
+    ])
+]);
+
+describe('stringifiers', function() {
+    it('maintains the `toString` method on type models', function() {
+        Assert.equal(union.toString(), stringifyType(union));
+    });
+
+    it('stringifies intrinsic types', function() {
+        const types = ['string', 'number', 'boolean', 'Object'];
+        for (const type of types) {
+            const input = new t.IntrinsicType(type);
+            Assert.equal(stringifyType(input), type);
+        }
+    });
+
+    it('stringifies conditional types', function() {
+        const input = new t.ConditionalType(
+            new t.StringLiteralType('foo'),
+            new t.IntrinsicType('string'),
+            new t.IntrinsicType('number'),
+            new t.IntrinsicType('boolean')
+        );
+
+        Assert.equal(stringifyType(input), '"foo" extends string ? number : boolean');
+    });
+
+    it('stringifies inferred types', function() {
+        const input = new t.ConditionalType(
+            new t.ReferenceType('T', t.ReferenceType.SYMBOL_FQN_RESOLVED),
+            new t.ArrayType(new t.InferredType('E')),
+            new t.IntrinsicType('number'),
+            new t.IntrinsicType('boolean')
+        );
+
+        Assert.equal(stringifyType(input), 'T extends infer E[] ? number : boolean');
+    });
+
+    it('stringifies query types', function() {
+        const input = new t.QueryType(
+            new t.ReferenceType('T', t.ReferenceType.SYMBOL_FQN_RESOLVED)
+        );
+
+        Assert.equal(stringifyType(input), 'typeof T');
+    });
+
+    it('stringifies indexed access types', function() {
+        const input = new t.IndexedAccessType(
+            new t.ReferenceType('T', t.ReferenceType.SYMBOL_FQN_RESOLVED),
+            new t.StringLiteralType('foobar')
+        );
+
+        Assert.equal(stringifyType(input), 'T["foobar"]');
+    });
+
+    it('stringifies union types', function() {
+        Assert.equal(stringifyType(union), 'string | number | [boolean, string]');
+    });
+
+    it('stringifies intersection types', function() {
+        const intersection = new t.IntersectionType([
+            new t.ReferenceType('T', t.ReferenceType.SYMBOL_FQN_RESOLVED),
+            new t.ReferenceType('U', t.ReferenceType.SYMBOL_FQN_RESOLVED),
+            new t.ReferenceType('V', t.ReferenceType.SYMBOL_FQN_RESOLVED)
+        ]);
+
+        Assert.equal(stringifyType(intersection), 'T & U & V');
+    });
+
+    it('stringifies complex union & intersection types', function() {
+        const input = new t.UnionType([
+            new t.ReferenceType('T', t.ReferenceType.SYMBOL_FQN_RESOLVED),
+            new t.IntersectionType([
+                new t.ReferenceType('U', t.ReferenceType.SYMBOL_FQN_RESOLVED),
+                new t.ReferenceType('V', t.ReferenceType.SYMBOL_FQN_RESOLVED)
+            ]),
+            new t.StringLiteralType('foo')
+        ]);
+
+        Assert.equal(stringifyType(input), 'T | U & V | "foo"');
+    });
+
+    it('stringifies tuple types', function() {
+        const input = new t.TupleType([
+            new t.IntrinsicType('boolean'),
+            new t.IntrinsicType('string')
+        ]);
+
+        Assert.equal(stringifyType(input), '[boolean, string]');
+    });
+
+    it('stringifies basic array types', function() {
+        const input = new t.ArrayType(new t.IntrinsicType('string'));
+        const expected = 'string[]';
+        Assert.equal(stringifyType(input), expected);
+    });
+
+    it('stringifies complex array types', function() {
+        const input = new t.ArrayType(union);
+        const expected = '(string | number | [boolean, string])[]';
+        Assert.equal(stringifyType(input), expected);
+    });
+
+    it('stringifies predicate types', function() {
+        const input = new t.PredicateType('T', false, new t.IntrinsicType('string'));
+        Assert.equal(stringifyType(input), 'T is string');
+    });
+
+    it('throws on invalid types', function() {
+        Assert.throws(
+            () => stringifyType({ type: 'bad' } as unknown as t.Type),
+            {
+                name: 'TypeError',
+                message: `Cannot stringify type 'bad'`
+            }
+        );
+    });
+});

--- a/src/test/stringifiers.test.ts
+++ b/src/test/stringifiers.test.ts
@@ -1,7 +1,7 @@
 import { stringifyType } from '..';
 import * as t from '../lib/models/types';
 
-import Assert = require('assert');
+import { strictEqual as equal, throws } from 'assert';
 
 const union = new t.UnionType([
     new t.IntrinsicType('string'),
@@ -14,14 +14,14 @@ const union = new t.UnionType([
 
 describe('stringifiers', function() {
     it('maintains the `toString` method on type models', function() {
-        Assert.equal(union.toString(), stringifyType(union));
+        equal(union.toString(), stringifyType(union));
     });
 
     it('stringifies intrinsic types', function() {
         const types = ['string', 'number', 'boolean', 'Object'];
         for (const type of types) {
             const input = new t.IntrinsicType(type);
-            Assert.equal(stringifyType(input), type);
+            equal(stringifyType(input), type);
         }
     });
 
@@ -33,7 +33,7 @@ describe('stringifiers', function() {
             new t.IntrinsicType('boolean')
         );
 
-        Assert.equal(stringifyType(input), '"foo" extends string ? number : boolean');
+        equal(stringifyType(input), '"foo" extends string ? number : boolean');
     });
 
     it('stringifies inferred types', function() {
@@ -44,7 +44,7 @@ describe('stringifiers', function() {
             new t.IntrinsicType('boolean')
         );
 
-        Assert.equal(stringifyType(input), 'T extends infer E[] ? number : boolean');
+        equal(stringifyType(input), 'T extends infer E[] ? number : boolean');
     });
 
     it('stringifies query types', function() {
@@ -52,7 +52,7 @@ describe('stringifiers', function() {
             new t.ReferenceType('T', t.ReferenceType.SYMBOL_FQN_RESOLVED)
         );
 
-        Assert.equal(stringifyType(input), 'typeof T');
+        equal(stringifyType(input), 'typeof T');
     });
 
     it('stringifies indexed access types', function() {
@@ -61,11 +61,11 @@ describe('stringifiers', function() {
             new t.StringLiteralType('foobar')
         );
 
-        Assert.equal(stringifyType(input), 'T["foobar"]');
+        equal(stringifyType(input), 'T["foobar"]');
     });
 
     it('stringifies union types', function() {
-        Assert.equal(stringifyType(union), 'string | number | [boolean, string]');
+        equal(stringifyType(union), 'string | number | [boolean, string]');
     });
 
     it('stringifies intersection types', function() {
@@ -75,7 +75,7 @@ describe('stringifiers', function() {
             new t.ReferenceType('V', t.ReferenceType.SYMBOL_FQN_RESOLVED)
         ]);
 
-        Assert.equal(stringifyType(intersection), 'T & U & V');
+        equal(stringifyType(intersection), 'T & U & V');
     });
 
     it('stringifies complex union & intersection types', function() {
@@ -88,7 +88,7 @@ describe('stringifiers', function() {
             new t.StringLiteralType('foo')
         ]);
 
-        Assert.equal(stringifyType(input), 'T | U & V | "foo"');
+        equal(stringifyType(input), 'T | U & V | "foo"');
     });
 
     it('stringifies tuple types', function() {
@@ -97,28 +97,28 @@ describe('stringifiers', function() {
             new t.IntrinsicType('string')
         ]);
 
-        Assert.equal(stringifyType(input), '[boolean, string]');
+        equal(stringifyType(input), '[boolean, string]');
     });
 
     it('stringifies basic array types', function() {
         const input = new t.ArrayType(new t.IntrinsicType('string'));
         const expected = 'string[]';
-        Assert.equal(stringifyType(input), expected);
+        equal(stringifyType(input), expected);
     });
 
     it('stringifies complex array types', function() {
         const input = new t.ArrayType(union);
         const expected = '(string | number | [boolean, string])[]';
-        Assert.equal(stringifyType(input), expected);
+        equal(stringifyType(input), expected);
     });
 
     it('stringifies predicate types', function() {
         const input = new t.PredicateType('T', false, new t.IntrinsicType('string'));
-        Assert.equal(stringifyType(input), 'T is string');
+        equal(stringifyType(input), 'T is string');
     });
 
     it('throws on invalid types', function() {
-        Assert.throws(
+        throws(
             () => stringifyType({ type: 'bad' } as unknown as t.Type),
             {
                 name: 'TypeError',


### PR DESCRIPTION
Closes #1160

This essentially moves all the type model `toString` implementations into a separate module and exposes them for users, as spec'd in the above issue. `toString` is implemented on the base model now, so that method is still kept around for backward compatibility currently.

Currently it should have parity, and has a start for stringifying reflections in a similar manner (just call signature for now).

I've also added tests, which don't cover everything, but these weren't actually tested before at all. Progress!