### PR TITLE
Re-export TypeScript namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,6 @@ export {
 } from './lib/utils/options';
 
 export { JSONOutput } from './lib/serialization';
+
+import * as TypeScript from 'typescript';
+export { TypeScript };


### PR DESCRIPTION
Fix https://github.com/TypeStrong/typedoc/issues/1213