### PR TITLE
No need to convert defaultValue for options of type map

### DIFF
--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -258,38 +258,27 @@ export function convert<T extends DeclarationOption>(value: unknown, option: T):
             return Result.Ok([]);
         case ParameterType.Map:
             const optionMap = option as MapDeclarationOption<unknown>;
-            const key = String(value).toLowerCase();
-            if (optionMap.map instanceof Map) {
-                if (optionMap.map.has(key)) {
-                    return Result.Ok(optionMap.map.get(key));
-                }
-                if ([...optionMap.map.values()].includes(value)) {
-                    return Result.Ok(value);
-                }
-            } else {
-                if (optionMap.map.hasOwnProperty(key)) {
-                    return Result.Ok(optionMap.map[key]);
-                }
-                if (Object.values(optionMap.map).includes(value)) {
-                    return Result.Ok(value);
-                }
+            if (getTypeOf(value) === getTypeOf(optionMap.defaultValue)) {
+                return Result.Ok(value);
             }
-            return Result.Err(optionMap.mapError ?? getMapError(optionMap.map, optionMap.name));
+            return Result.Err(optionMap.mapError ?? `Invalid type for value of ${optionMap.name}`);
         case ParameterType.Mixed:
             return Result.Ok(value);
     }
 }
 
-function getMapError(map: MapDeclarationOption<unknown>['map'], name: string) {
-    let keys = map instanceof Map ? [...map.keys()] : Object.keys(map);
-    const getString = (key: string) => String(map instanceof Map ? map.get(key) : map[key]);
+/**
+ * Returns the type of a value.
+ * @param value The value whoes type is wanted.
+ * @returns The type of the value;
+ */
+function getTypeOf(value: unknown): unknown {
+    const typeOfValue = typeof value;
 
-    // If the map is a TS numeric enum we need to filter out the numeric keys.
-    // TS numeric enums have the property that every key maps to a value, which maps back to that key.
-    if (!(map instanceof Map) && keys.every(key => getString(getString(key)) === key)) {
-        // This works because TS enum keys may not be numeric.
-        keys = keys.filter(key => Number.isNaN(parseInt(key, 10)));
+    // null is also of type 'object'
+    if (typeOfValue === 'object' && value) {
+        return Object.getPrototypeOf(value) as unknown;
+    } else {
+        return typeOfValue;
     }
-
-    return `${name} must be one of ${keys.join(', ')}`;
 }

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import * as ts from 'typescript';
 
-import { DeclarationOption, ParameterScope, convert, TypeDocOptions, KeyToDeclaration, TypeDocAndTSOptions, TypeDocOptionMap } from './declaration';
+import { DeclarationOption, ParameterScope, ParameterType, convert, TypeDocOptions, KeyToDeclaration, TypeDocAndTSOptions, TypeDocOptionMap } from './declaration';
 import { Logger } from '../loggers';
 import { Result, Ok, Err } from '../result';
 import { insertPrioritySorted } from '../array';
@@ -109,10 +109,7 @@ export class Options {
      */
     reset() {
         for (const declaration of this._declarations.values()) {
-            if (declaration.scope !== ParameterScope.TypeScript) {
-                this._values[declaration.name] = convert(declaration.defaultValue, declaration)
-                    .expect(`Failed to validate default value for ${declaration.name}`);
-            }
+            this.setOptionValueToDefault(declaration);
         }
         this._compilerOptions = {};
     }
@@ -169,10 +166,7 @@ export class Options {
             }
         }
 
-        if (declaration.scope !== ParameterScope.TypeScript) {
-            this._values[declaration.name] = convert(declaration.defaultValue, declaration)
-                .expect(`Failed to validate default value for ${declaration.name}`);
-        }
+        this.setOptionValueToDefault(declaration);
     }
 
     /**
@@ -319,6 +313,22 @@ export class Options {
             });
         }
         return errors.length ? Err(errors) : Ok(void 0);
+    }
+
+    /**
+     * Sets the value of a given option to its default value.
+     * @param declaration The option whoes value should be reset.
+     */
+    private setOptionValueToDefault(declaration: Readonly<DeclarationOption>): void {
+        if (declaration.scope !== ParameterScope.TypeScript) {
+            // No nead to convert the defaultValue for a map type as it has to be of a specific type
+            if (declaration.type === ParameterType.Map) {
+                this._values[declaration.name] = declaration.defaultValue;
+            } else {
+                this._values[declaration.name] = convert(declaration.defaultValue, declaration)
+                    .expect(`Failed to validate default value for ${declaration.name}`);
+            }
+        }
     }
 }
 

--- a/src/test/utils/options/options.test.ts
+++ b/src/test/utils/options/options.test.ts
@@ -25,6 +25,21 @@ describe('Options', () => {
         options.removeDeclarationByName(declaration.name);
     });
 
+    it('Does not error if a map declaration has a default value that is not part of the map of possible values', () => {
+        logger.resetErrors();
+        options.addDeclaration({
+            name: 'testMapDeclarationWithForeignDefaultValue',
+            help: '',
+            type: ParameterType.Map,
+            map: new Map([
+                ['a', 1],
+                ['b', 2]
+            ]),
+            defaultValue: 0
+        });
+        equal(logger.hasErrors(), false);
+    });
+
     it('Supports removing a declaration by name', () => {
         options.addDeclaration({ name: 'not-an-option', help: '' });
         options.removeDeclarationByName('not-an-option');


### PR DESCRIPTION
Fixes: https://github.com/TypeStrong/typedoc/issues/1249

The convert function was used to "validate" the default value for all options. This is not necessary for options of type map, since the type of the default value is provided via the template class MapDeclarationOption and must be of the right type. Moreover the conversion throws an error if the default value for the option is of the right type, but not listed in the map of possible values.