### PR TITLE
Generate json file for index search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -343,6 +343,12 @@
       "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
       "dev": true
     },
+    "@types/lunr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/lunr/-/lunr-2.3.3.tgz",
+      "integrity": "sha512-09sXZZVsB3Ib41U0fC+O1O+4UOZT1bl/e+/QubPxpqDWHNEchvx/DEb1KJMOwq6K3MTNzZFoNSzVdR++o1DVnw==",
+      "dev": true
+    },
     "@types/marked": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "handlebars": "^4.7.3",
     "highlight.js": "^9.18.1",
     "lodash": "^4.17.15",
+    "lunr": "^2.3.8",
     "marked": "0.8.0",
     "minimatch": "^3.0.0",
     "progress": "^2.0.3",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
     "@types/lodash": "^4.14.149",
+    "@types/lunr": "^2.3.3",
     "@types/marked": "^0.7.3",
     "@types/minimatch": "3.0.3",
     "@types/mocha": "^7.0.2",

--- a/src/lib/output/plugins/JavascriptIndexPlugin.ts
+++ b/src/lib/output/plugins/JavascriptIndexPlugin.ts
@@ -66,12 +66,18 @@ export class JavascriptIndexPlugin extends RendererComponent {
             rows.push(row);
         }
 
-        const fileName = Path.join(event.outputDirectory, 'assets', 'js', 'search.js');
-        const data =
-            `var typedoc = typedoc || {};
+        const jsFileName = Path.join(event.outputDirectory, 'assets', 'js', 'search.js');
+        const jsData =
+            `console.warn('[typedoc] search.js file is deprecated. Please, use search.json file in your custom theme instead.');
+            var typedoc = typedoc || {};
             typedoc.search = typedoc.search || {};
             typedoc.search.data = ${JSON.stringify({kinds: kinds, rows: rows})};`;
 
-        writeFile(fileName, data, false);
+        writeFile(jsFileName, jsData, false);
+
+        const jsonFileName = Path.join(event.outputDirectory, 'assets', 'js', 'search.json');
+        const jsonData = JSON.stringify({kinds: kinds, rows: rows});
+
+        writeFile(jsonFileName, jsonData, false);
     }
 }


### PR DESCRIPTION
This is implementation of #1251.
Here I added additional file in JSON format and wrote warning for custom themes, which use JS format. JS file was not removed for backward compatibility. Next step: to support this changes in `typedoc-default-themes` package.