### PR TITLE
fix: Only set inputFiles from tsconfig if not already set

### DIFF
--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -51,14 +51,19 @@ export class TSConfigReader implements OptionsReader {
         fileToRead = resolve(fileToRead);
 
         const { config } = ts.readConfigFile(fileToRead, ts.sys.readFile);
-        const { fileNames, options, raw: { typedocOptions = {} }} = ts.parseJsonConfigFileContent(
+        const { fileNames, errors, options, raw: { typedocOptions = {} }} = ts.parseJsonConfigFileContent(
             config,
             ts.sys,
             dirname(fileToRead),
             {},
             fileToRead);
 
-        container.setValue('inputFiles', fileNames).unwrap();
+        logger?.diagnostics(errors);
+
+        if (container.isDefault('inputFiles')) {
+            container.setValue('inputFiles', fileNames).unwrap();
+        }
+
         for (const key of IGNORED) {
             delete options[key];
         }

--- a/src/test/utils/options/readers/data/file.ts
+++ b/src/test/utils/options/readers/data/file.ts
@@ -1,0 +1,2 @@
+// This is referenced in valid.tsconfig.json
+export const test = true

--- a/src/test/utils/options/readers/data/file.ts
+++ b/src/test/utils/options/readers/data/file.ts
@@ -1,2 +1,2 @@
 // This is referenced in valid.tsconfig.json
-export const test = true
+export const test = true;

--- a/src/test/utils/options/readers/data/valid.tsconfig.json
+++ b/src/test/utils/options/readers/data/valid.tsconfig.json
@@ -1,7 +1,12 @@
 {
+    "$schema": "http://json.schemastore.org/tsconfig",
     "compilerOptions": {
         "target": "ESNext"
     },
+    "files": [
+        // This has to specify a file that exists or TS will drop it.
+        "./file.ts"
+    ],
     "typedocOptions": {
         "help": true
     }

--- a/src/test/utils/options/readers/tsconfig.test.ts
+++ b/src/test/utils/options/readers/tsconfig.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { deepStrictEqual as equal } from 'assert';
 
 import { TSConfigReader } from '../../../../lib/utils/options/readers';
@@ -48,4 +48,19 @@ describe('Options - TSConfigReader', () => {
         equal(options.getValue('help'), true);
         equal(options.getCompilerOptions().target, ScriptTarget.ESNext);
     });
+
+    it('Sets inputFiles if they have not been set', () => {
+        options.reset();
+        options.setValue('tsconfig', join(__dirname, 'data/valid.tsconfig.json')).unwrap();
+        options.read(new Logger());
+        equal(options.getValue('inputFiles').map(f => resolve(f)), [resolve(__dirname, './data/file.ts')]);
+    })
+
+    it('Does not set inputFiles if they have been set', () => {
+        options.reset();
+        options.setValue('tsconfig', join(__dirname, 'data/valid.tsconfig.json')).unwrap();
+        options.setValue('inputFiles', ['foo.ts']).unwrap();
+        options.read(new Logger());
+        equal(options.getValue('inputFiles'), ['foo.ts']);
+    })
 });

--- a/src/test/utils/options/readers/tsconfig.test.ts
+++ b/src/test/utils/options/readers/tsconfig.test.ts
@@ -54,7 +54,7 @@ describe('Options - TSConfigReader', () => {
         options.setValue('tsconfig', join(__dirname, 'data/valid.tsconfig.json')).unwrap();
         options.read(new Logger());
         equal(options.getValue('inputFiles').map(f => resolve(f)), [resolve(__dirname, './data/file.ts')]);
-    })
+    });
 
     it('Does not set inputFiles if they have been set', () => {
         options.reset();
@@ -62,5 +62,5 @@ describe('Options - TSConfigReader', () => {
         options.setValue('inputFiles', ['foo.ts']).unwrap();
         options.read(new Logger());
         equal(options.getValue('inputFiles'), ['foo.ts']);
-    })
+    });
 });


### PR DESCRIPTION
Note: This effectively sets the minimum Node version to 9.0.0 since it uses [util.isDeepStrictEqual](https://nodejs.org/api/util.html#util_util_isdeepstrictequal_val1_val2) and as such can't really be merged until 0.18... I didn't want to add a dependency just for this.

fix: Options.isDefault was always false when passed non-literals.

Closes #1263