### PR TITLE
Do not silently swallow the missed file errors - issue warnings

### DIFF
--- a/src/lib/output/plugins/MarkedPlugin.ts
+++ b/src/lib/output/plugins/MarkedPlugin.ts
@@ -135,6 +135,7 @@ export class MarkedPlugin extends ContextAwareRendererComponent {
                         return contents;
                     }
                 } else {
+                    this.application.logger.warn('Could not find file for include: ' + path);
                     return '';
                 }
             });

--- a/src/lib/output/plugins/MarkedPlugin.ts
+++ b/src/lib/output/plugins/MarkedPlugin.ts
@@ -135,7 +135,7 @@ export class MarkedPlugin extends ContextAwareRendererComponent {
                         return contents;
                     }
                 } else {
-                    this.application.logger.warn('Could not find file for include: ' + path);
+                    this.application.logger.warn('Could not find file to include: ' + path);
                     return '';
                 }
             });
@@ -143,9 +143,12 @@ export class MarkedPlugin extends ContextAwareRendererComponent {
 
         if (this.mediaDirectory) {
             text = text.replace(this.mediaPattern, (match: string, path: string) => {
-                if (FS.existsSync(Path.join(this.mediaDirectory!, path))) {
+                const fileName = Path.join(this.mediaDirectory!, path);
+
+                if (FS.existsSync(fileName) && FS.statSync(fileName).isFile()) {
                     return this.getRelativeUrl('media') + '/' + path;
                 } else {
+                    this.application.logger.warn('Could not find media file: ' + fileName);
                     return match;
                 }
             });


### PR DESCRIPTION
Currently if typedoc can not find the file, specified with [[include:]] "pragma" it basically ignores the error and does not give any feedback to the user. This makes hard to debug the relative paths, which starts with many directory switches, like `../../../`. A warning is very helpful for debugging this problem.