### PR TITLE
fix: Minimatch pattern assertion on Windows OS

### DIFF
--- a/src/test/utils/paths.test.ts
+++ b/src/test/utils/paths.test.ts
@@ -20,7 +20,7 @@ describe('Paths', () => {
     });
 
     it('Minimatch can match absolute paths expressions', () => {
-      const paths = ['/unix/absolute/**/path', '\\windows\\alternative\\absolute\\path', 'C:\\Windows\\absolute\\*\\path', '**/arbitrary/path/**'];
+      const paths = ['/unix/absolute/**/path', '\\windows\\alternative\\absolute\\path', '\\Windows\\absolute\\*\\path', '**/arbitrary/path/**'];
       const mms = createMinimatch(paths);
       const patterns = mms.map(({ pattern }) => pattern);
       const comparePaths = [


### PR DESCRIPTION
I'm not entirely sure if that does the job (doesn't come up with some repercussions), but I don't have experience with minimatch package.
You can experience an error on Windows, when you've your project on other drive than system drive. With the things how `absolutePath` expression works, you won't land magically on system drive like the comparison pattern expects you to, so I removed the `C:` from the beginning of the pattern.