### PR TITLE
fix: GithubPlugin: read correct remote when multiple github repos exist

### DIFF
--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -133,13 +133,13 @@ export class Repository {
     static tryCreateRepository(path: string, gitRevision: string, gitRemote: string): Repository | undefined {
         ShellJS.pushd(path);
         const out = <ShellJS.ExecOutputReturnValue> ShellJS.exec('git rev-parse --show-toplevel', {silent: true});
+        const remotesOutput = <ShellJS.ExecOutputReturnValue> ShellJS.exec(`git remote get-url ${gitRemote}`, {silent: true});
         ShellJS.popd();
 
-        if (!out || out.code !== 0) {
+        if (!out || out.code !== 0 || !remotesOutput || remotesOutput.code !== 0) {
             return;
         }
 
-        const remotesOutput = <ShellJS.ExecOutputReturnValue> ShellJS.exec(`git remote get-url ${gitRemote}`, {silent: true});
         let remotes: string[] = (remotesOutput.code === 0) ? remotesOutput.stdout.split('\n') : [];
 
         return new Repository(BasePath.normalize(out.stdout.replace('\n', '')), gitRevision, remotes);


### PR DESCRIPTION
When a typedoc project includes multiple github repositories, the remote URL is always set to the root repository's url:

Say you have sources like this with repo1 including a git submodule of repo2:

```
src - https://github.com/user/repo1.git
+- sourcefile.ts
+- submodule - https://github.com/user/repo2.git
  +- src
    +- sourcefile_in_other_repo.ts
```

Today, the plugin will:

- pushd into `/src/submodule/src`
- get the path to the repo root
- popd back to `/src` _(whoops)_
- get the remote of `/src` _when it should be getting the remote of `/src/submodule/src` instead_

This PR ensures the remote is fetched before the popd happens.