### PR TITLE
Check for `isNamedTupleMember` and `isIdentifierOrPrivateIdentifier` before calling to restore backward compatibility with typescript 3.7.5 and 3.9.7 respectively

### DIFF
--- a/src/lib/converter/context.ts
+++ b/src/lib/converter/context.ts
@@ -410,7 +410,7 @@ export class Context {
 
 function isNamedNode(node: ts.Node): node is ts.Node & { name: ts.Identifier | ts.PrivateIdentifier | ts.ComputedPropertyName } {
     return node['name'] && (
-        ts.isIdentifierOrPrivateIdentifier(node['name']) ||
+        ts.isIdentifierOrPrivateIdentifier && ts.isIdentifierOrPrivateIdentifier(node['name']) ||
         ts.isComputedPropertyName(node['name'])
     );
 }

--- a/src/lib/converter/types/tuple.ts
+++ b/src/lib/converter/types/tuple.ts
@@ -74,7 +74,7 @@ export class TupleConverter extends ConverterTypeComponent implements TypeConver
 @Component({ name: 'type:named-tuple-member' })
 export class NamedTupleMemberConverter extends ConverterTypeComponent implements TypeNodeConverter<ts.Type, ts.NamedTupleMember> {
     supportsNode(_context: Context, node: ts.Node) {
-        return ts.isNamedTupleMember(node);
+        return ts.isNamedTupleMember && ts.isNamedTupleMember(node);
     }
 
     convertNode(context: Context, node: ts.NamedTupleMember): NamedTupleMember | undefined {


### PR DESCRIPTION
Fix backward compatibility for typescript 3.7.5 and 3.9.7 by checking the existence of missing ts methods before calling them.
See https://github.com/TypeStrong/typedoc/issues/1362