### PR TITLE
Grammar fix in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For a complete list of the command line arguments run `typedoc --help` or visit 
 -   `--options`<br>
     Specify a json option file that should be loaded. If not specified TypeDoc will look for 'typedoc.json' in the current directory.
 -   `--json <path/to/output.json>`<br>
-    Specifies the location and file name a json file describing the project is written to. When specified no documentation will be generated.
+    Specifies the location and file name of a json file describing the project is written to. When specified no documentation will be generated.
 -   `--ignoreCompilerErrors`<br>
     Allows TypeDoc to still generate documentation pages even after the compiler has returned errors.
 


### PR DESCRIPTION
Edit in readme.md:

Changed - 
`Specifies the location and file name a json file describing the project is written to.`

to - 
`Specifies the location and file name of a json file describing the project is written to.`