### PR TITLE
Add validation function to declaration options

### DIFF
--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -174,6 +174,7 @@ export interface StringDeclarationOption extends DeclarationOptionBase {
 
     /**
      * An optional validation function that validates a potential value of this option.
+     * The function must throw an Error if the validation fails and should do nothing otherwise.
      */
     validate?: (value: string) => void;
 }
@@ -198,6 +199,7 @@ export interface NumberDeclarationOption extends DeclarationOptionBase {
 
     /**
      * An optional validation function that validates a potential value of this option.
+     * The function must throw an Error if the validation fails and should do nothing otherwise.
      */
     validate?: (value: number) => void;
 }
@@ -212,6 +214,7 @@ export interface BooleanDeclarationOption extends DeclarationOptionBase {
 
     /**
      * An optional validation function that validates a potential value of this option.
+     * The function must throw an Error if the validation fails and should do nothing otherwise.
      */
     validate?: (value: boolean) => void;
 }
@@ -226,6 +229,7 @@ export interface ArrayDeclarationOption extends DeclarationOptionBase {
 
     /**
      * An optional validation function that validates a potential value of this option.
+     * The function must throw an Error if the validation fails and should do nothing otherwise.
      */
     validate?: (value: string[]) => void;
 }
@@ -240,6 +244,7 @@ export interface MixedDeclarationOption extends DeclarationOptionBase {
 
     /**
      * An optional validation function that validates a potential value of this option.
+     * The function must throw an Error if the validation fails and should do nothing otherwise.
      */
     validate?: (value: unknown) => void;
 }
@@ -267,6 +272,7 @@ export interface MapDeclarationOption<T> extends DeclarationOptionBase {
 
     /**
      * An optional validation function that validates a potential value of this option.
+     * The function must throw an Error if the validation fails and should do nothing otherwise.
      */
     validate?: (value: T) => void;
 }

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -268,7 +268,7 @@ export interface MapDeclarationOption<T> extends DeclarationOptionBase {
     /**
      * An optional validation function that validates a potential value of this option.
      */
-    validate?: (value: unknown) => void;
+    validate?: (value: T) => void;
 }
 
 export type DeclarationOption =

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -363,23 +363,24 @@ export function convert(value: unknown, option: DeclarationOption): unknown {
         }
         case ParameterType.Map: {
             const key = String(value).toLowerCase();
-            let mapValue;
+            let mapValue: unknown;
+            let mapIncludesValue = false;
             if (option.map instanceof Map) {
                 if (option.map.has(key)) {
                     mapValue = option.map.get(key);
-                }
-                if ([...option.map.values()].includes(value)) {
+                    mapIncludesValue = true;
+                } else if ([...option.map.values()].includes(value)) {
                     mapValue = value;
+                    mapIncludesValue = true;
                 }
-            } else {
-                if (key in option.map) {
-                    mapValue = option.map[key];
-                }
-                if (Object.values(option.map).includes(value)) {
-                    mapValue = value;
-                }
+            } else if (key in option.map) {
+                mapValue = option.map[key];
+                mapIncludesValue = true;
+            } else if (Object.values(option.map).includes(value)) {
+                mapValue = value;
+                mapIncludesValue = true;
             }
-            if (mapValue == undefined) {
+            if (!mapIncludesValue) {
                 throw new Error(
                     option.mapError ?? getMapError(option.map, option.name)
                 );

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -6,7 +6,6 @@ import {
     convert,
     DeclarationOption,
     KeyToDeclaration,
-    MapDeclarationOption,
     ParameterScope,
     ParameterType,
     TypeDocAndTSOptions,
@@ -151,7 +150,7 @@ export class Options {
     /**
      * Adds an option declaration to the container with extra type checking to ensure that
      * the runtime type is consistent with the declared type.
-     * @param declaration
+     * @param declaration The option declaration that should be added.
      */
     addDeclaration<K extends keyof TypeDocOptions>(
         declaration: { name: K } & KeyToDeclaration<K>
@@ -159,14 +158,11 @@ export class Options {
 
     /**
      * Adds an option declaration to the container.
-     * @param declaration
+     * @param declaration The option declaration that should be added.
      */
     addDeclaration(
         declaration: NeverIfInternal<Readonly<DeclarationOption>>
     ): void;
-
-    addDeclaration<T>(declaration: Readonly<MapDeclarationOption<T>>): void;
-
     addDeclaration(declaration: Readonly<DeclarationOption>): void {
         const names = [declaration.name];
         if (declaration.short) {

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -165,9 +165,7 @@ export class Options {
         declaration: NeverIfInternal<Readonly<DeclarationOption>>
     ): void;
 
-    addDeclaration<T>(
-        declaration: Readonly<MapDeclarationOption<T>>
-    ): void;
+    addDeclaration<T>(declaration: Readonly<MapDeclarationOption<T>>): void;
 
     addDeclaration(declaration: Readonly<DeclarationOption>): void {
         const names = [declaration.name];

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -3,14 +3,15 @@ import * as _ from "lodash";
 import * as ts from "typescript";
 
 import {
+    convert,
     DeclarationOption,
+    KeyToDeclaration,
+    MapDeclarationOption,
     ParameterScope,
     ParameterType,
-    convert,
-    TypeDocOptions,
-    KeyToDeclaration,
     TypeDocAndTSOptions,
     TypeDocOptionMap,
+    TypeDocOptions,
 } from "./declaration";
 import { Logger } from "../loggers";
 import { insertPrioritySorted } from "../array";
@@ -162,6 +163,10 @@ export class Options {
      */
     addDeclaration(
         declaration: NeverIfInternal<Readonly<DeclarationOption>>
+    ): void;
+
+    addDeclaration<T>(
+        declaration: Readonly<MapDeclarationOption<T>>
     ): void;
 
     addDeclaration(declaration: Readonly<DeclarationOption>): void {

--- a/src/test/utils/options/declaration.test.ts
+++ b/src/test/utils/options/declaration.test.ts
@@ -1,15 +1,14 @@
+import { deepStrictEqual as equal, throws } from "assert";
 import {
-    convert,
     ArrayDeclarationOption,
-    BooleanDeclarationOption,
+    convert,
     DeclarationOption,
-    ParameterType,
     MapDeclarationOption,
     MixedDeclarationOption,
     NumberDeclarationOption,
+    ParameterType,
     StringDeclarationOption,
 } from "../../../lib/utils/options/declaration";
-import { deepStrictEqual as equal, throws } from "assert";
 
 describe("Options - Default convert function", () => {
     const optionWithType = (type: ParameterType) =>
@@ -155,37 +154,6 @@ describe("Options - Default convert function", () => {
         equal(convert(false, optionWithType(ParameterType.Boolean)), false);
     });
 
-    it("Generates no error for a boolean option if the validation function doesn't throw one", () => {
-        const declaration: BooleanDeclarationOption = {
-            name: "test",
-            help: "",
-            type: ParameterType.Boolean,
-            validate: (value: boolean) => {
-                if (!value) {
-                    throw new Error("test must be true");
-                }
-            },
-        };
-        equal(convert(true, declaration), true);
-    });
-
-    it("Generates an error for a boolean option if the validation function throws one", () => {
-        const declaration: BooleanDeclarationOption = {
-            name: "test",
-            help: "",
-            type: ParameterType.Boolean,
-            validate: (value: boolean) => {
-                if (!value) {
-                    throw new Error("test must be true");
-                }
-            },
-        };
-        throws(
-            () => convert(false, declaration),
-            new Error("test must be true")
-        );
-    });
-
     it("Converts to arrays", () => {
         equal(convert("12,3", optionWithType(ParameterType.Array)), [
             "12",
@@ -306,47 +274,6 @@ describe("Options - Default convert function", () => {
         throws(
             () => convert("c", declaration),
             new Error("test must be one of a, b")
-        );
-    });
-
-    it("Generates no error for a mapped option if the validation function doesn't throw one", () => {
-        const declaration: MapDeclarationOption<number> = {
-            name: "test",
-            help: "",
-            type: ParameterType.Map,
-            map: new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            defaultValue: 1,
-            validate: (value: number) => {
-                if (value === 2) {
-                    throw new Error("test must not be b");
-                }
-            },
-        };
-        equal(convert("a", declaration), 1);
-    });
-
-    it("Generates an error for a mapped option if the validation function throws one", () => {
-        const declaration: MapDeclarationOption<number> = {
-            name: "test",
-            help: "",
-            type: ParameterType.Map,
-            map: new Map([
-                ["a", 1],
-                ["b", 2],
-            ]),
-            defaultValue: 1,
-            validate: (value: number) => {
-                if (value === 2) {
-                    throw new Error("test must not be b");
-                }
-            },
-        };
-        throws(
-            () => convert("b", declaration),
-            new Error("test must not be b")
         );
     });
 


### PR DESCRIPTION
Fixes #1316 

Overview:

* New `validate` property for declaration options
* New tests for the new properties

Please pay attention to line **279** in `src/lib/utils/options/declaration.ts`. I removed one of the signatures. This enables TS's type refinement and thence no more type assertion is required when accessing the option. I don't know if this breaks anything else.