### PR TITLE
Fix eslint no-unused-locals errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,8 +27,7 @@
         // Feel free to turn one of these back on and submit a PR!
         "@typescript-eslint/no-empty-function": 0,
         "@typescript-eslint/no-non-null-assertion": 0,
-        "@typescript-eslint/explicit-module-boundary-types": 0,
-        "@typescript-eslint/no-unused-vars": 0
+        "@typescript-eslint/explicit-module-boundary-types": 0
     },
     "overrides": [
         {

--- a/scripts/rebuild_specs.js
+++ b/scripts/rebuild_specs.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-const assert = require("assert");
 const fs = require("fs-extra");
 const path = require("path");
 const TypeDoc = require("..");

--- a/src/lib/converter/convert-expression.ts
+++ b/src/lib/converter/convert-expression.ts
@@ -1,5 +1,4 @@
 import * as ts from "typescript";
-import * as _ts from "../ts-internal";
 
 /**
  * Return the default value of the given node.

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -1,5 +1,4 @@
 import * as ts from "typescript";
-import * as _ts from "../ts-internal";
 import * as _ from "lodash";
 
 import { Application } from "../application";

--- a/src/lib/converter/nodes/class.ts
+++ b/src/lib/converter/nodes/class.ts
@@ -1,5 +1,4 @@
 import * as ts from "typescript";
-import * as _ts from "../../ts-internal";
 
 import {
     Reflection,

--- a/src/lib/converter/nodes/interface.ts
+++ b/src/lib/converter/nodes/interface.ts
@@ -1,5 +1,4 @@
 import * as ts from "typescript";
-import * as _ts from "../../ts-internal";
 
 import {
     Reflection,

--- a/src/lib/converter/nodes/variable.ts
+++ b/src/lib/converter/nodes/variable.ts
@@ -1,5 +1,4 @@
 import * as ts from "typescript";
-import * as _ts from "../../ts-internal";
 
 import {
     Reflection,

--- a/src/lib/converter/plugins/CategoryPlugin.ts
+++ b/src/lib/converter/plugins/CategoryPlugin.ts
@@ -48,10 +48,8 @@ export class CategoryPlugin extends ConverterComponent {
 
     /**
      * Triggered when the converter begins converting a project.
-     *
-     * @param context  The context object describing the current state the converter is in.
      */
-    private onBegin(context: Context) {
+    private onBegin() {
         // Set up static properties
         if (this.defaultCategory) {
             CategoryPlugin.defaultCategory = this.defaultCategory;

--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -148,10 +148,8 @@ export class CommentPlugin extends ConverterComponent {
 
     /**
      * Triggered when the converter begins converting a project.
-     *
-     * @param context  The context object describing the current state the converter is in.
      */
-    private onBegin(context: Context) {
+    private onBegin() {
         this.comments = {};
     }
 
@@ -160,12 +158,10 @@ export class CommentPlugin extends ConverterComponent {
      *
      * @param context  The context object describing the current state the converter is in.
      * @param reflection  The reflection that is currently processed.
-     * @param node  The node that is currently processed if available.
      */
     private onCreateTypeParameter(
         context: Context,
-        reflection: TypeParameterReflection,
-        node?: ts.Node
+        reflection: TypeParameterReflection
     ) {
         const comment = reflection.parent && reflection.parent.comment;
         if (comment) {

--- a/src/lib/converter/plugins/DecoratorPlugin.ts
+++ b/src/lib/converter/plugins/DecoratorPlugin.ts
@@ -1,5 +1,4 @@
 import * as ts from "typescript";
-import * as _ts from "../../ts-internal";
 
 import { ReferenceType } from "../../models/types/index";
 import { Reflection, Decorator } from "../../models/reflections/index";
@@ -58,10 +57,8 @@ export class DecoratorPlugin extends ConverterComponent {
 
     /**
      * Triggered when the converter begins converting a project.
-     *
-     * @param context  The context object describing the current state the converter is in.
      */
-    private onBegin(context: Context) {
+    private onBegin() {
         this.usages = {};
     }
 

--- a/src/lib/converter/plugins/DynamicModulePlugin.ts
+++ b/src/lib/converter/plugins/DynamicModulePlugin.ts
@@ -1,4 +1,3 @@
-import * as ts from "typescript";
 import * as Path from "path";
 
 import { Reflection, ReflectionKind } from "../../models/reflections/abstract";
@@ -54,13 +53,8 @@ export class DynamicModulePlugin extends ConverterComponent {
      *
      * @param context  The context object describing the current state the converter is in.
      * @param reflection  The reflection that is currently processed.
-     * @param node  The node that is currently processed if available.
      */
-    private onDeclaration(
-        context: Context,
-        reflection: Reflection,
-        node?: ts.Node
-    ) {
+    private onDeclaration(context: Context, reflection: Reflection) {
         if (reflection.kindOf(ReflectionKind.Module)) {
             let name = reflection.name;
             if (!name.includes("/")) {
@@ -75,10 +69,8 @@ export class DynamicModulePlugin extends ConverterComponent {
 
     /**
      * Triggered when the converter begins resolving a project.
-     *
-     * @param context  The context object describing the current state the converter is in.
      */
-    private onBeginResolve(context: Context) {
+    private onBeginResolve() {
         this.reflections.forEach((reflection) => {
             let name = reflection.name.replace(/"/g, "");
             name = name.substr(0, name.length - Path.extname(name).length);

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -57,10 +57,8 @@ export class PackagePlugin extends ConverterComponent {
 
     /**
      * Triggered when the converter begins converting a project.
-     *
-     * @param context  The context object describing the current state the converter is in.
      */
-    private onBegin(context: Context) {
+    private onBegin() {
         this.readmeFile = undefined;
         this.packageFile = undefined;
         this.visited = [];

--- a/src/lib/converter/plugins/SourcePlugin.ts
+++ b/src/lib/converter/plugins/SourcePlugin.ts
@@ -1,6 +1,5 @@
 import * as Path from "path";
 import * as ts from "typescript";
-import * as _ts from "../../ts-internal";
 
 import {
     Reflection,

--- a/src/lib/converter/plugins/TypePlugin.ts
+++ b/src/lib/converter/plugins/TypePlugin.ts
@@ -169,10 +169,8 @@ export class TypePlugin extends ConverterComponent {
 
     /**
      * Triggered when the converter has finished resolving a project.
-     *
-     * @param context  The context object describing the current state the converter is in.
      */
-    private onResolveEnd(context: Context) {
+    private onResolveEnd() {
         this.reflections.forEach((reflection) => {
             if (reflection.implementedBy) {
                 reflection.implementedBy.sort((a: Type, b: Type): number => {

--- a/src/lib/converter/types/this.ts
+++ b/src/lib/converter/types/this.ts
@@ -15,11 +15,7 @@ export class ThisConverter
     /**
      * Test whether this converter can handle the given TypeScript node.
      */
-    public supportsNode(
-        context: Context,
-        node: ts.ThisTypeNode,
-        type: ts.Type
-    ): boolean {
+    public supportsNode(context: Context, node: ts.ThisTypeNode): boolean {
         return node.kind === ts.SyntaxKind.ThisType;
     }
 
@@ -33,16 +29,9 @@ export class ThisConverter
      * const someValue:SomeClass;
      * ```
      *
-     * @param context  The context object describing the current state the converter is in.
-     * @param node  The type reference node that should be converted.
-     * @param type  The type of the type reference node.
      * @returns The type reflection representing the given reference node.
      */
-    public convertNode(
-        context: Context,
-        node: ts.ThisTypeNode,
-        type: ts.Type
-    ): Type {
+    public convertNode(): Type {
         return new IntrinsicType("this");
     }
 }

--- a/src/lib/converter/types/type-operator.ts
+++ b/src/lib/converter/types/type-operator.ts
@@ -31,11 +31,7 @@ export class TypeOperatorConverter
     /**
      * Test whether this converter can handle the given TypeScript node.
      */
-    supportsNode(
-        context: Context,
-        node: ts.TypeOperatorNode,
-        type: ts.Type
-    ): boolean {
+    supportsNode(context: Context, node: ts.TypeOperatorNode): boolean {
         return !!(node.kind === ts.SyntaxKind.TypeOperator);
     }
 

--- a/src/lib/converter/types/unknown.ts
+++ b/src/lib/converter/types/unknown.ts
@@ -21,7 +21,7 @@ export class UnknownConverter
     /**
      * Test whether this converter can handle the given TypeScript type.
      */
-    supportsType(context: Context, type: ts.Type): boolean {
+    supportsType(): boolean {
         return true;
     }
 

--- a/src/lib/models/reflections/abstract.ts
+++ b/src/lib/models/reflections/abstract.ts
@@ -569,6 +569,7 @@ export abstract class Reflection {
      *
      * @param callback  The callback function that should be applied for each child reflection.
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- This abstract class defines the interface.
     traverse(callback: TraverseCallback) {}
 
     /**

--- a/src/lib/models/types/abstract.ts
+++ b/src/lib/models/types/abstract.ts
@@ -22,6 +22,7 @@ export abstract class Type {
      * @param type  The type that should be checked for equality.
      * @returns TRUE if the given type equals this type, FALSE otherwise.
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- This abstract class defines the interface.
     equals(type: Type): boolean {
         return false;
     }

--- a/src/lib/output/plugins/MarkedLinksPlugin.ts
+++ b/src/lib/output/plugins/MarkedLinksPlugin.ts
@@ -163,7 +163,7 @@ export class MarkedLinksPlugin extends ContextAwareRendererComponent {
     /**
      * Triggered when [[Renderer]] is finished
      */
-    onEndRenderer(event: RendererEvent) {
+    onEndRenderer() {
         if (this.listInvalidSymbolLinks && this.warnings.length > 0) {
             this.application.logger.write("");
             this.application.logger.warn(

--- a/src/lib/serialization/serializers/comments/comment-tag.ts
+++ b/src/lib/serialization/serializers/comments/comment-tag.ts
@@ -13,7 +13,7 @@ export class CommentTagSerializer extends SerializerComponent<CommentTag> {
         return instance instanceof CommentTag;
     }
 
-    supports(t: unknown) {
+    supports() {
         return true;
     }
 

--- a/src/lib/serialization/serializers/comments/comment.ts
+++ b/src/lib/serialization/serializers/comments/comment.ts
@@ -13,7 +13,7 @@ export class CommentSerializer extends SerializerComponent<Comment> {
         return instance instanceof Comment;
     }
 
-    supports(t: unknown) {
+    supports() {
         return true;
     }
 

--- a/src/lib/serialization/serializers/decorator.ts
+++ b/src/lib/serialization/serializers/decorator.ts
@@ -14,7 +14,7 @@ export class DecoratorContainerSerializer extends SerializerComponent<
         return instance instanceof DecoratorWrapper;
     }
 
-    supports(_: unknown) {
+    supports() {
         return true;
     }
 

--- a/src/lib/serialization/serializers/reflection-group.ts
+++ b/src/lib/serialization/serializers/reflection-group.ts
@@ -15,7 +15,7 @@ export class ReflectionGroupSerializer extends SerializerComponent<
         return instance instanceof ReflectionGroup;
     }
 
-    supports(r: unknown) {
+    supports() {
         return true;
     }
 

--- a/src/lib/serialization/serializers/sources/source-reference.ts
+++ b/src/lib/serialization/serializers/sources/source-reference.ts
@@ -11,7 +11,7 @@ export class SourceReferenceContainerSerializer extends SerializerComponent<
         return instance instanceof SourceReferenceWrapper;
     }
 
-    supports(_: unknown) {
+    supports() {
         return true;
     }
 

--- a/src/lib/utils/loggers.ts
+++ b/src/lib/utils/loggers.ts
@@ -74,7 +74,7 @@ export class Logger {
      * @param args  The arguments that should be printed into the given message.
      */
     public writeln(text: string, ...args: string[]) {
-        this.log(Util.format(text, ...args), LogLevel.Info, true);
+        this.log(Util.format(text, ...args), LogLevel.Info);
     }
 
     /**
@@ -122,13 +122,8 @@ export class Logger {
      *
      * @param message  The message itself.
      * @param level  The urgency of the log message.
-     * @param newLine  Should the logger print a trailing whitespace?
      */
-    public log(
-        message: string,
-        level: LogLevel = LogLevel.Info,
-        newLine?: boolean
-    ) {
+    public log(message: string, level: LogLevel = LogLevel.Info) {
         if (level === LogLevel.Error) {
             this.errorCount += 1;
         }
@@ -207,7 +202,7 @@ export class ConsoleLogger extends Logger {
         level: LogLevel = LogLevel.Info,
         newLine?: boolean
     ) {
-        super.log(message, level, newLine);
+        super.log(message, level);
 
         let output = "";
         if (level === LogLevel.Error) {
@@ -259,7 +254,7 @@ export class CallbackLogger extends Logger {
         level: LogLevel = LogLevel.Info,
         newLine?: boolean
     ) {
-        super.log(message, level, newLine);
+        super.log(message, level);
 
         this.callback(message, level, newLine);
     }

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -1,4 +1,3 @@
-import * as _ from "lodash";
 import { CompilerOptions } from "typescript";
 import { IgnoredTsOptionKeys } from "./sources/typescript";
 

--- a/src/test/events.test.ts
+++ b/src/test/events.test.ts
@@ -919,7 +919,7 @@ describe("Events (customized)", function () {
             count++;
             e.stopPropagation();
         });
-        events.on("myEvent", function (e) {
+        events.on("myEvent", function () {
             count++;
             Assert(false);
         });
@@ -932,7 +932,7 @@ describe("Events (customized)", function () {
         const events = new Events();
         events.on(
             "myEvent",
-            function (e) {
+            function () {
                 Assert.equal(count, 1);
                 count++;
             },
@@ -941,7 +941,7 @@ describe("Events (customized)", function () {
         );
         events.on(
             "myEvent",
-            function (e) {
+            function () {
                 Assert.equal(count, 0);
                 count++;
             },

--- a/src/test/plugins/absolute.ts
+++ b/src/test/plugins/absolute.ts
@@ -1,3 +1,1 @@
-import { Application } from "../..";
-
-module.exports = (pluginHost: Application) => {};
+module.exports = () => {};

--- a/src/test/plugins/relative.ts
+++ b/src/test/plugins/relative.ts
@@ -1,3 +1,1 @@
-import { Application } from "../..";
-
-module.exports = (pluginHost: Application) => {};
+module.exports = () => {};

--- a/src/test/utils/array.test.ts
+++ b/src/test/utils/array.test.ts
@@ -66,7 +66,7 @@ describe("Array utils", () => {
 
         it("works with no partition", () => {
             equal(
-                binaryFindPartition([1, 2, 3], (n) => false),
+                binaryFindPartition([1, 2, 3], () => false),
                 -1
             );
         });


### PR DESCRIPTION
Enable ESLint "no-unused-locals" rule in the project.

I'm open to other suggestions on how to handle unneeded parameters of methods:

* Add an `eslint-disable` statement instead
* Remove them, but by commenting them out instead of simply deleting them