### PR TITLE
ReferenceType.toString: Don't document type arguments if there are none

### DIFF
--- a/src/lib/models/types/reference.ts
+++ b/src/lib/models/types/reference.ts
@@ -103,7 +103,8 @@ export class ReferenceType extends Type {
     toString() {
         const name = this.reflection ? this.reflection.name : this.name;
         let typeArgs = "";
-        if (this.typeArguments) {
+
+        if (this.typeArguments && this.typeArguments.length > 0) {
             typeArgs += "<";
             typeArgs += this.typeArguments
                 .map((arg) => arg.toString())


### PR DESCRIPTION
Fixes #1450 