### PR TITLE
feat(category): add option to read more categories from doc

### DIFF
--- a/src/lib/converter/plugins/CategoryPlugin.ts
+++ b/src/lib/converter/plugins/CategoryPlugin.ts
@@ -161,7 +161,7 @@ export class CategoryPlugin extends ConverterComponent {
                 let category = categories.find((cat) => cat.title === childCat);
                 if (category) {
                     category.children.push(child);
-                    return;
+                    continue;
                 }
                 category = new ReflectionCategory(childCat);
                 category.children.push(child);

--- a/src/lib/converter/plugins/CategoryPlugin.ts
+++ b/src/lib/converter/plugins/CategoryPlugin.ts
@@ -187,7 +187,11 @@ export class CategoryPlugin extends ConverterComponent {
                     commentTags.push(tag);
                     return;
                 }
-                categories.push(tag.text.trim());
+                const text = tag.text.trim();
+                if (!text) {
+                    return;
+                }
+                categories.push(text);
             });
             comment.tags = commentTags;
             return categories;
@@ -204,8 +208,9 @@ export class CategoryPlugin extends ConverterComponent {
                     if (!signature.comment) {
                         return categories;
                     }
-                    categories.push(...extractCategoryTag(signature.comment));
-                    return categories;
+                    return categories.concat(
+                        extractCategoryTag(signature.comment)
+                    );
                 },
                 []
             );

--- a/src/test/converter/class/class.ts
+++ b/src/test/converter/class/class.ts
@@ -35,11 +35,14 @@ export class TestClass {
     /**
      * protectedMethod short text.
      * @category Test
+     * @category AnotherTest
      */
     protected protectedMethod() {}
 
     /**
      * privateMethod short text.
+     *
+     * @category AnotherTest
      */
     private privateMethod() {}
 

--- a/src/test/converter/class/class.ts
+++ b/src/test/converter/class/class.ts
@@ -28,6 +28,7 @@ export class TestClass {
 
     /**
      * publicMethod short text.
+     * @category AnotherTest
      * @category Test
      */
     public publicMethod() {}

--- a/src/test/converter/class/specs-with-lump-categories.json
+++ b/src/test/converter/class/specs-with-lump-categories.json
@@ -909,7 +909,8 @@
                 "title": "AnotherTest",
                 "children": [
                     32,
-                    30
+                    30,
+                    28
                 ]
             },
             {

--- a/src/test/converter/class/specs-with-lump-categories.json
+++ b/src/test/converter/class/specs-with-lump-categories.json
@@ -906,6 +906,13 @@
           ],
           "categories": [
             {
+                "title": "AnotherTest",
+                "children": [
+                    32,
+                    30
+                ]
+            },
+            {
               "title": "Other",
               "children": [
                 24,
@@ -913,7 +920,6 @@
                 26,
                 21,
                 34,
-                32,
                 22
               ]
             },

--- a/src/test/converter/class/specs.json
+++ b/src/test/converter/class/specs.json
@@ -907,7 +907,8 @@
                     "title": "AnotherTest",
                     "children": [
                         32,
-                        30
+                        30,
+                        28
                     ]
                 },
                 {

--- a/src/test/converter/class/specs.json
+++ b/src/test/converter/class/specs.json
@@ -904,10 +904,16 @@
               ],
               "categories": [
                 {
+                    "title": "AnotherTest",
+                    "children": [
+                        32,
+                        30
+                    ]
+                },
+                {
                   "title": "Other",
                   "children": [
                     34,
-                    32,
                     22
                   ]
                 },


### PR DESCRIPTION
Closes #1158 

Added a possibility to put more `@category` in the doc.

It is extracting the categories but the output is wrong. I added `AnotherTest` category to `TestClass` `publicMethod`, `protectedMethod` and `privateMethod` and changed the `spec.json` and `specs-with-lump-categories.json` according to my understanding what the output should be.
It always outputs the method to a category if its the first category in the comments. But for the second category (and the consecutive ones) it outputs a method only if its the first time output of the category.
Here are classes I was testing with:
```ts
/**
 * @category MyAnotherCategory
 * @category MyCategory
 */
export class MyClass {
    /**
     * @category MyMethodCategory
     * @category MyAnotherMethodCategory
     */
    public someMethod() {
        return 1;
    }
}
/**
 * @category MyCategory
 * @category MyAnotherCategory
 */
export class MyAnotherClass {
    public constructor() {
    }
}
/**
 * @category MyAnotherCategory
 * @category MyCategory
 */
export class MyThirdClass {
    public constructor() {
    }
}
/**
 * @category MyCategory
 * @category MyAnotherCategory
 */
export class MyFourthClass {
    public constructor() {
    }
}
```

And here is the output:
![Screenshot 2021-01-14 at 10 25 02](https://user-images.githubusercontent.com/10399339/104570945-cce81180-5652-11eb-921f-28ecd24b1c62.png)


@Gerrit0 Could you point me to where can I fix the output? I was searching through but could not find anything.