### PR TITLE
feat(inheritDoc): Add support for copying item’s documentation by copying it from another API item

### DIFF
--- a/src/lib/converter/factories/comment.ts
+++ b/src/lib/converter/factories/comment.ts
@@ -209,7 +209,8 @@ export function parseComment(
         if (
             tagName === "param" ||
             tagName === "typeparam" ||
-            tagName === "template"
+            tagName === "template" ||
+            tagName === "inheritdoc"
         ) {
             line = consumeTypeData(line);
             const param = /[^\s]+/.exec(line);

--- a/src/lib/converter/plugins/ImplementsPlugin.ts
+++ b/src/lib/converter/plugins/ImplementsPlugin.ts
@@ -1,5 +1,4 @@
 import {
-    Reflection,
     ReflectionKind,
     DeclarationReflection,
     SignatureReflection,
@@ -8,8 +7,8 @@ import { Type, ReferenceType } from "../../models/types/index";
 import { Component, ConverterComponent } from "../components";
 import { Converter } from "../converter";
 import { Context } from "../context";
-import { Comment } from "../../models/comments/comment";
 import { zip } from "../../utils/array";
+import { copyComment } from "../utils/reflections";
 
 /**
  * A plugin that detects interface implementations of functions and
@@ -82,7 +81,7 @@ export class ImplementsPlugin extends ConverterComponent {
                     interfaceMember,
                     context.project
                 );
-                this.copyComment(classMember, interfaceMember);
+                copyComment(classMember, interfaceMember);
 
                 if (
                     interfaceMember.kindOf(ReflectionKind.FunctionOrMethod) &&
@@ -105,7 +104,7 @@ export class ImplementsPlugin extends ConverterComponent {
                                             interfaceSignature,
                                             context.project
                                         );
-                                        this.copyComment(
+                                        copyComment(
                                             classSignature,
                                             interfaceSignature
                                         );
@@ -117,46 +116,6 @@ export class ImplementsPlugin extends ConverterComponent {
                 }
             }
         );
-    }
-
-    /**
-     * Copy the comment of the source reflection to the target reflection.
-     *
-     * @param target
-     * @param source
-     */
-    private copyComment(target: Reflection, source: Reflection) {
-        if (
-            target.comment &&
-            source.comment &&
-            target.comment.hasTag("inheritdoc")
-        ) {
-            target.comment.copyFrom(source.comment);
-
-            if (
-                target instanceof SignatureReflection &&
-                target.parameters &&
-                source instanceof SignatureReflection &&
-                source.parameters
-            ) {
-                for (
-                    let index = 0, count = target.parameters.length;
-                    index < count;
-                    index++
-                ) {
-                    const sourceParameter = source.parameters[index];
-                    if (sourceParameter && sourceParameter.comment) {
-                        const targetParameter = target.parameters[index];
-                        if (!targetParameter.comment) {
-                            targetParameter.comment = new Comment();
-                            targetParameter.comment.copyFrom(
-                                sourceParameter.comment
-                            );
-                        }
-                    }
-                }
-            }
-        }
     }
 
     private analyzeInheritance(
@@ -201,7 +160,7 @@ export class ImplementsPlugin extends ConverterComponent {
                         parentMember,
                         context.project
                     );
-                    this.copyComment(child, parentMember);
+                    copyComment(child, parentMember);
                 }
             }
         }

--- a/src/lib/converter/plugins/InheritDocPlugin.ts
+++ b/src/lib/converter/plugins/InheritDocPlugin.ts
@@ -1,0 +1,88 @@
+import {
+    ContainerReflection,
+    DeclarationReflection,
+    ReflectionKind,
+    SignatureReflection,
+    Type,
+} from "../../models";
+import { Component, ConverterComponent } from "../components";
+import { Converter } from "../converter";
+import { Context } from "../context";
+import { copyComment } from "../utils/reflections";
+import {
+    Reflection,
+    TraverseCallback,
+} from "../../models/reflections/abstract";
+
+/**
+ * A plugin that handles `inheritDoc` by copying documentation from another API item.
+ *
+ * What gets copied:
+ * - short text
+ * - text
+ * - `@remarks` block
+ * - `@params` block
+ * - `@typeParam` block
+ * - `@return` block
+ */
+@Component({ name: "inheritDoc" })
+export class InheritDocPlugin extends ConverterComponent {
+    /**
+     * Create a new InheritDocPlugin instance.
+     */
+    initialize() {
+        this.listenTo(
+            this.owner,
+            {
+                [Converter.EVENT_RESOLVE]: this.onResolve,
+            },
+            undefined,
+            -200
+        );
+    }
+
+    /**
+     * Triggered when the converter resolves a reflection.
+     *
+     * Traverse through reflection descendant to check for `inheritDoc` tag.
+     * If encountered, the parameter of the tag iss used to determine a source reflection
+     * that will provide actual comment.
+     *
+     * @param context  The context object describing the current state the converter is in.
+     * @param reflection  The reflection that is currently resolved.
+     */
+    private onResolve(_context: Context, reflection: DeclarationReflection) {
+        if (reflection instanceof ContainerReflection) {
+            const descendantsCallback: TraverseCallback = (item) => {
+                item.traverse(descendantsCallback);
+                const inheritDoc = item.comment?.getTag("inheritdoc")
+                    ?.paramName;
+                const source =
+                    inheritDoc && reflection.findReflectionByName(inheritDoc);
+                let referencedReflection = source;
+                if (
+                    source instanceof DeclarationReflection &&
+                    item instanceof SignatureReflection
+                ) {
+                    const isFunction = source?.kindOf(
+                        ReflectionKind.FunctionOrMethod
+                    );
+                    if (isFunction) {
+                        referencedReflection =
+                            source.signatures?.find((signature) => {
+                                return Type.isTypeListEqual(
+                                    signature.getParameterTypes(),
+                                    item.getParameterTypes()
+                                );
+                            }) ?? source.signatures?.[0];
+                    }
+                }
+
+                if (referencedReflection instanceof Reflection) {
+                    copyComment(item, referencedReflection);
+                }
+            };
+            reflection.traverse(descendantsCallback);
+        }
+    }
+}

--- a/src/lib/converter/plugins/index.ts
+++ b/src/lib/converter/plugins/index.ts
@@ -8,3 +8,4 @@ export { ImplementsPlugin } from "./ImplementsPlugin";
 export { PackagePlugin } from "./PackagePlugin";
 export { SourcePlugin } from "./SourcePlugin";
 export { TypePlugin } from "./TypePlugin";
+export { InheritDocPlugin } from "./InheritDocPlugin";

--- a/src/lib/converter/utils/reflections.ts
+++ b/src/lib/converter/utils/reflections.ts
@@ -1,4 +1,12 @@
-import { IntrinsicType, Type, UnionType } from "../../models";
+import {
+    Comment,
+    DeclarationReflection,
+    IntrinsicType,
+    Reflection,
+    SignatureReflection,
+    Type,
+    UnionType,
+} from "../../models";
 
 export function removeUndefined(type: Type) {
     if (type instanceof UnionType) {
@@ -12,4 +20,74 @@ export function removeUndefined(type: Type) {
         return type;
     }
     return type;
+}
+
+/**
+ * Copy the comment of the source reflection to the target reflection.
+ *
+ * @param target - Reflection with comment containing `inheritdoc` tag
+ * @param source - Referenced reflection
+ */
+export function copyComment(target: Reflection, source: Reflection) {
+    if (
+        target.comment &&
+        source.comment &&
+        target.comment.hasTag("inheritdoc")
+    ) {
+        if (
+            target instanceof DeclarationReflection &&
+            source instanceof DeclarationReflection
+        ) {
+            target.typeParameters = source.typeParameters;
+        }
+        if (
+            target instanceof SignatureReflection &&
+            source instanceof SignatureReflection
+        ) {
+            target.typeParameters = source.typeParameters;
+            /**
+             * TSDoc overrides existing parameters entirely with inherited ones, while
+             * existing implementation merges them.
+             * To avoid breaking things, `inheritDoc` tag is additionally checked for the parameter,
+             * so the previous behaviour will continue to work.
+             *
+             * TODO: When breaking change becomes acceptable remove legacy implementation
+             */
+            if (target.comment.getTag("inheritdoc")?.paramName) {
+                target.parameters = source.parameters;
+            } else {
+                legacyCopyImplementation(target, source);
+            }
+        }
+        target.comment.removeTags("inheritdoc");
+        target.comment.copyFrom(source.comment);
+    }
+}
+
+/**
+ * Copy comments from source reflection to target reflection, parameters are merged.
+ *
+ * @param target - Reflection with comment containing `inheritdoc` tag
+ * @param source - Parent reflection
+ */
+function legacyCopyImplementation(
+    target: SignatureReflection,
+    source: SignatureReflection
+) {
+    if (target.parameters && source.parameters) {
+        for (
+            let index = 0, count = target.parameters.length;
+            index < count;
+            index++
+        ) {
+            const sourceParameter = source.parameters[index];
+            if (sourceParameter && sourceParameter.comment) {
+                const targetParameter = target.parameters[index];
+                if (!targetParameter.comment) {
+                    targetParameter.comment = new Comment();
+                    targetParameter.comment.copyFrom(sourceParameter.comment);
+                }
+            }
+        }
+    }
 }

--- a/src/lib/models/comments/comment.ts
+++ b/src/lib/models/comments/comment.ts
@@ -1,6 +1,8 @@
 import { removeIf } from "../../utils";
 import { CommentTag } from "./tag";
 
+const COPIED_TAGS = ["remarks"];
+
 /**
  * A model that represents a comment.
  *
@@ -85,14 +87,27 @@ export class Comment {
     /**
      * Copy the data of the given comment into this comment.
      *
-     * @param comment
+     * `shortText`, `text`, `returns` and tags from `COPIED_TAGS` are copied;
+     * other instance tags left unchanged.
+     *
+     * @param comment - Source comment to copy from
      */
     copyFrom(comment: Comment) {
         this.shortText = comment.shortText;
         this.text = comment.text;
         this.returns = comment.returns;
-        this.tags = comment.tags.map(
-            (tag) => new CommentTag(tag.tagName, tag.paramName, tag.text)
-        );
+        const overrideTags: CommentTag[] = comment.tags
+            .filter((tag) => COPIED_TAGS.includes(tag.tagName))
+            .map((tag) => new CommentTag(tag.tagName, tag.paramName, tag.text));
+        this.tags.forEach((tag, index) => {
+            const matchingTag = overrideTags.find(
+                (matchingOverride) => matchingOverride?.tagName === tag.tagName
+            );
+            if (matchingTag) {
+                this.tags[index] = matchingTag;
+                overrideTags.splice(overrideTags.indexOf(matchingTag), 1);
+            }
+        });
+        this.tags = [...this.tags, ...overrideTags];
     }
 }

--- a/src/test/converter/inheritance/inherit-doc.ts
+++ b/src/test/converter/inheritance/inherit-doc.ts
@@ -1,0 +1,87 @@
+/**
+ * Source interface summary
+ *
+ * @typeParam T - Source interface type parameter
+ */
+export interface InterfaceSource<T> {
+    /**
+     * Source interface property description
+     *
+     * @typeParam T - Source interface type parameter
+     */
+    property: T;
+
+    /**
+     * Source interface method description
+     *
+     * @param arg
+     */
+    someMethod(arg: number): T;
+}
+
+/**
+ * @inheritDoc InterfaceSource
+ *
+ */
+export interface InterfaceTarget<T> {
+    /**
+     * @inheritDoc InterfaceSource.property
+     */
+    property: T;
+
+    /**
+     * @inheritDoc InterfaceSource.someMethod
+     *
+     * @param arg
+     */
+    someMethod(arg: number): T;
+}
+
+/**
+ * Function summary
+ *
+ * This part of the commentary will be inherited by other entities
+ *
+ * @remarks
+ *
+ * Remarks will be inherited
+ *
+ * @example
+ *
+ * This part of the commentary will not be inherited
+ *
+ * @typeParam T - Type of arguments
+ * @param arg1 - First argument
+ * @param arg2 - Second argument
+ * @returns Stringified sum or concatenation of numeric arguments
+ */
+export function functionSource<T>(arg1: T, arg2: T): string {
+    if (typeof arg1 === "number" && typeof arg2 === "number") {
+        return `${arg1 + arg2}`;
+    }
+    return `${arg1}${arg2}`;
+}
+
+/**
+ * @inheritDoc SubClassA.printName
+ */
+export function functionTargetGlobal() {
+    return "";
+}
+
+/**
+ * @inheritDoc functionSource
+ *
+ * @example
+ *
+ * This function inherited commentary from the `functionSource` function
+ *
+ * @typeParam T - This will be inherited
+ * @param arg1 - This will be inherited
+ * @param arg2 - This will be inherited
+ * @returns This will be inherited
+ *
+ */
+export function functionTargetLocal<T>(arg1: T, arg2: T) {
+    return "";
+}

--- a/src/test/converter/inheritance/specs.json
+++ b/src/test/converter/inheritance/specs.json
@@ -1,0 +1,404 @@
+{
+  "id": 0,
+  "name": "typedoc",
+  "kind": 0,
+  "kindString": "Project",
+  "flags": {},
+  "children": [
+    {
+      "id": 13,
+      "name": "InterfaceSource",
+      "kind": 256,
+      "kindString": "Interface",
+      "flags": {},
+      "comment": {
+        "shortText": "Source interface summary"
+      },
+      "children": [
+        {
+          "id": 14,
+          "name": "property",
+          "kind": 1024,
+          "kindString": "Property",
+          "flags": {},
+          "comment": {
+            "shortText": "Source interface property description",
+            "tags": [
+              {
+                "tag": "typeparam",
+                "text": "Source interface type parameter\n",
+                "param": "T"
+              }
+            ]
+          },
+          "type": {
+            "type": "reference",
+            "name": "T"
+          }
+        },
+        {
+          "id": 15,
+          "name": "someMethod",
+          "kind": 2048,
+          "kindString": "Method",
+          "flags": {},
+          "signatures": [
+            {
+              "id": 16,
+              "name": "someMethod",
+              "kind": 4096,
+              "kindString": "Call signature",
+              "flags": {},
+              "comment": {
+                "shortText": "Source interface method description"
+              },
+              "parameters": [
+                {
+                  "id": 17,
+                  "name": "arg",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "comment": {
+                    "text": "\n"
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "T"
+              }
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Properties",
+          "kind": 1024,
+          "children": [
+            14
+          ]
+        },
+        {
+          "title": "Methods",
+          "kind": 2048,
+          "children": [
+            15
+          ]
+        }
+      ],
+      "typeParameter": [
+        {
+          "id": 18,
+          "name": "T",
+          "kind": 131072,
+          "kindString": "Type parameter",
+          "flags": {},
+          "comment": {
+            "shortText": "Source interface type parameter\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "name": "InterfaceTarget",
+      "kind": 256,
+      "kindString": "Interface",
+      "flags": {},
+      "comment": {
+        "shortText": "Source interface summary"
+      },
+      "children": [
+        {
+          "id": 20,
+          "name": "property",
+          "kind": 1024,
+          "kindString": "Property",
+          "flags": {},
+          "comment": {
+            "shortText": "Source interface property description"
+          },
+          "type": {
+            "type": "reference",
+            "name": "T"
+          }
+        },
+        {
+          "id": 21,
+          "name": "someMethod",
+          "kind": 2048,
+          "kindString": "Method",
+          "flags": {},
+          "signatures": [
+            {
+              "id": 22,
+              "name": "someMethod",
+              "kind": 4096,
+              "kindString": "Call signature",
+              "flags": {},
+              "comment": {
+                "shortText": "Source interface method description"
+              },
+              "parameters": [
+                {
+                  "id": 17,
+                  "name": "arg",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "comment": {
+                    "text": "\n"
+                  },
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "type": {
+                "type": "reference",
+                "name": "T"
+              }
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Properties",
+          "kind": 1024,
+          "children": [
+            20
+          ]
+        },
+        {
+          "title": "Methods",
+          "kind": 2048,
+          "children": [
+            21
+          ]
+        }
+      ],
+      "typeParameter": [
+        {
+          "id": 18,
+          "name": "T",
+          "kind": 131072,
+          "kindString": "Type parameter",
+          "flags": {},
+          "comment": {
+            "shortText": "Source interface type parameter\n"
+          }
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "functionSource",
+      "kind": 64,
+      "kindString": "Function",
+      "flags": {},
+      "signatures": [
+        {
+          "id": 2,
+          "name": "functionSource",
+          "kind": 4096,
+          "kindString": "Call signature",
+          "flags": {},
+          "comment": {
+            "shortText": "Function summary",
+            "text": "This part of the commentary will be inherited by other entities\n",
+            "returns": "Stringified sum or concatenation of numeric arguments\n",
+            "tags": [
+              {
+                "tag": "remarks",
+                "text": "\n\nRemarks will be inherited\n"
+              },
+              {
+                "tag": "example",
+                "text": "\n\nThis part of the commentary will not be inherited\n"
+              }
+            ]
+          },
+          "typeParameter": [
+            {
+              "id": 3,
+              "name": "T",
+              "kind": 131072,
+              "kindString": "Type parameter",
+              "flags": {},
+              "comment": {
+                "text": "Type of arguments"
+              }
+            }
+          ],
+          "parameters": [
+            {
+              "id": 4,
+              "name": "arg1",
+              "kind": 32768,
+              "kindString": "Parameter",
+              "flags": {},
+              "comment": {
+                "text": "First argument"
+              },
+              "type": {
+                "type": "reference",
+                "name": "T"
+              }
+            },
+            {
+              "id": 5,
+              "name": "arg2",
+              "kind": 32768,
+              "kindString": "Parameter",
+              "flags": {},
+              "comment": {
+                "text": "Second argument"
+              },
+              "type": {
+                "type": "reference",
+                "name": "T"
+              }
+            }
+          ],
+          "type": {
+            "type": "intrinsic",
+            "name": "string"
+          }
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "name": "functionTargetGlobal",
+      "kind": 64,
+      "kindString": "Function",
+      "flags": {},
+      "signatures": [
+        {
+          "id": 7,
+          "name": "functionTargetGlobal",
+          "kind": 4096,
+          "kindString": "Call signature",
+          "flags": {},
+          "comment": {
+            "tags": [
+              {
+                "tag": "inheritdoc",
+                "text": "\n",
+                "param": "SubClassA.printName"
+              }
+            ]
+          },
+          "type": {
+            "type": "intrinsic",
+            "name": "string"
+          }
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "name": "functionTargetLocal",
+      "kind": 64,
+      "kindString": "Function",
+      "flags": {},
+      "signatures": [
+        {
+          "id": 9,
+          "name": "functionTargetLocal",
+          "kind": 4096,
+          "kindString": "Call signature",
+          "flags": {},
+          "comment": {
+            "shortText": "Function summary",
+            "text": "This part of the commentary will be inherited by other entities\n",
+            "returns": "This will be inherited\n\n",
+            "tags": [
+              {
+                "tag": "example",
+                "text": "\n\nThis function inherited commentary from the `functionSource` function\n"
+              },
+              {
+                "tag": "remarks",
+                "text": "\n\nRemarks will be inherited\n"
+              }
+            ]
+          },
+          "typeParameter": [
+            {
+              "id": 3,
+              "name": "T",
+              "kind": 131072,
+              "kindString": "Type parameter",
+              "flags": {},
+              "comment": {
+                "text": "Type of arguments"
+              }
+            }
+          ],
+          "parameters": [
+            {
+              "id": 4,
+              "name": "arg1",
+              "kind": 32768,
+              "kindString": "Parameter",
+              "flags": {},
+              "comment": {
+                "text": "First argument"
+              },
+              "type": {
+                "type": "reference",
+                "name": "T"
+              }
+            },
+            {
+              "id": 5,
+              "name": "arg2",
+              "kind": 32768,
+              "kindString": "Parameter",
+              "flags": {},
+              "comment": {
+                "text": "Second argument"
+              },
+              "type": {
+                "type": "reference",
+                "name": "T"
+              }
+            }
+          ],
+          "type": {
+            "type": "intrinsic",
+            "name": "string"
+          }
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "title": "Interfaces",
+      "kind": 256,
+      "children": [
+        13,
+        19
+      ]
+    },
+    {
+      "title": "Functions",
+      "kind": 64,
+      "children": [
+        1,
+        6,
+        8
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hello! Thanks for your work, I really appreciate it.

Recently our team started to use Typedoc and we've come to the conclusion that we really do miss the support for `@inheritDoc`, which I believe is not currently implemented (see open issue #304) when we talk about inheriting from **unrelated** entities which is allowed in TSDoc, so I hope I can do something to make this feature a bit close.

I've prepared a really quick PoC and a demo 
```ts
/**
  * Original description
  *
  * @param arg1 Numeric argument 1
  * @param arg2 Numeric argument 2
  * @returns Stringified sum of arg1 and arg2
  */
export function sourceFunction(arg1: number, arg2: number): string {
    return `${arg1 + arg2}`
}

/**
 * @inheritDoc sourceFunction
 * @param argOne Numeric argument One
 * @param argTwo Numeric argument Two
 * @param argThree Numeric argument Three
 * @deprecated TODO: Remove
 */
export function targetFunction(argOne: number, argTwo: number, argThree: number): string {
    return `${argOne + argTwo + argThree}`
}
```
Demo for this snippet is here: https://dergash.github.io/typedoc/modules.html#targetfunction

When preparing this PoC I've come to some questions which I hope we can discuss before going further.

So this draft is majorly based around [ImplementsPlugin](https://github.com/TypeStrong/typedoc/blob/master/src/lib/converter/plugins/ImplementsPlugin.ts) which I believe contains initial but undocumented support for [TSDoc/inheritDoc](https://tsdoc.org/pages/tags/inheritdoc/).  
My understanding is that when some class implements an interface, methods from that interface can inherit some parts of documentation (shortText, text, `@returns` and  any tags which TypeDocs leaves without processing), to enable this feature `inheritDoc` must be specified:

```ts
export interface SomeInterface {
  /**
   * Some method
   *
   * @param someArg1 Some argument
   * @returns Some results
   */
  someMethod(someArg1: number): string
}

export class SomeInterfaceImplementation implements SomeInterface {
  /**
   * @inheritDoc
   */
  someMethod(someArg2: number) {
    return String(someArg2)
  }
}
```

Apparently [it works](https://dergash.github.io/typedoc/classes/someinterfaceimplementation.html#somemethod). Docs will not be inherited without the tag.

So thinking about the differences between this implementation and the one expected in #304 / TSDoc:

### Shoud current behavior of `ImplementsPlugin` be documented?

### Missing curly brackets
Apparently TSDoc treats `inhericDoc` as an `inline tag`, hence they [wrap it in curly bracers](https://github.com/microsoft/tsdoc/pull/76/files#diff-9ffacd4b38ec593eecd8cacce59be5405f282f0f7a63231016610f390d54b87aR109): 
```ts
// https://tsdoc.org/pages/tags/inheritdoc/
/**
* {@inheritDoc example-library#Serializer.writeFile}
* @deprecated Use {@link example-library#Serializer.writeFile} instead.
*/
public save(): void {
    . . .
}
```
`ImplementsPlugin` (and `InheritDocPlugin` from my PoC) are expecting no curly braces; the only tags moment stored in [MarkedLinksPlugin](https://github.com/TypeStrong/typedoc/blob/master/src/lib/output/plugins/MarkedLinksPlugin.ts#L16) and probably MarkedPlugin

### What gets copied
According to TSDoc page following things are copied:

* summary section
* `@remarks` block
* `@params` blocks
* `@typeParam` blocks
* `@returns` block

`summary` and `@remarks` confused me a bit; after reading both TSDoc and Typedoc docs I believe TSDoc `summary` equals to Typedoc [shortText](https://github.com/TypeStrong/typedoc/blob/84c649619b43dc8092a24c6c39f34e57d9de60fd/src/lib/models/comments/comment.ts#L15), but I might be wrong: Typedoc emphasize on shortText "being the first paragraph of text" and the `text` is the rest of the comment, while from TSDoc description and [API Exractor Overview](https://api-extractor.com/pages/tsdoc/doc_comment_syntax/) I've got the impression that summary is all text until the first block tag.  
So it probably works like this: Typedoc takes first paragraph into `shortText` and the rest of the text to `text`, when TSDoc tooks short text to `summary` and rest of the text shoul be in `remarks` tag.

So at the moment either `summary` and `@remarks` are already copied as per TSDoc, or they don't and can't be copied due to inconsistency in comment structure.

`@params` and `@typeParams` are not copied, but according to the TSDoc the should be.

`@returns` is copied.

Custom tags which are not processed by Typedoc are copied.

Should this be implemented both for inheritDoc and implements plugin?

### How exactly copying should be implemented?

At the moment inherited values override matching values on the target entity. Which seems consistent with [JSDoc](https://jsdoc.app/tags-inheritdoc.html) where `@inheritDoc` leads to ignoring all other tags. From TSDoc site and github I didn't quite get if it's override or merge. But if it is indeed override then `@inheritDoc` won't work for #304 where there is a need to inherit a comment by concating it with existing comment.

If this is the case, will you consider support for `@copyDoc`?

