### PR TITLE
Add support for non .com gh enterprise domains

### DIFF
--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -58,7 +58,7 @@ export class Repository {
         ShellJS.pushd(path);
 
         for (let i = 0, c = repoLinks.length; i < c; i++) {
-            const url = /(github(?:\.[a-z]+)*\.com)[:/]([^/]+)\/(.*)/.exec(
+            const url = /(github(?:\.[a-z]+)*\.[a-z]{2,})[:/]([^/]+)\/(.*)/.exec(
                 repoLinks[i]
             );
 


### PR DESCRIPTION
We have an instance of GitHub Enterprise on domain non `.com` domain (`github.*.*.tools`) so file links could not be generated due to fixed `.com` TLD in the regex pattern.

This PR will fix this fixed TLD limitation.