### PR TITLE
Preserve intendation in code blocks

### DIFF
--- a/src/lib/converter/factories/comment.ts
+++ b/src/lib/converter/factories/comment.ts
@@ -258,6 +258,7 @@ export function parseComment(
     let inFencedCode = false;
     function readLine(line: string) {
         line = line.replace(/^\s*\*? ?/, "");
+        const rawLine = line;
         line = line.replace(/\s*$/, "");
 
         if (CODE_FENCE.test(line)) {
@@ -271,7 +272,12 @@ export function parseComment(
                 return readTagLine(line, tag);
             }
         }
-        readBareLine(line);
+        if (inFencedCode) {
+            // This will not include code blocks declared with four spaces
+            readBareLine(rawLine);
+        } else {
+            readBareLine(line);
+        }
     }
 
     text = text.replace(/^\s*\/\*+/, "");

--- a/src/test/converter/comment/comment4.ts
+++ b/src/test/converter/comment/comment4.ts
@@ -1,0 +1,13 @@
+/**
+ * This is a comment containing a multiline code block
+ * ```ts
+ * export function multiply(a: number, b: number) {
+ *   return a * b;
+ * }
+ * ```
+ * @module
+ */
+
+export function multiply(a: number, b: number) {
+    return a * b;
+}

--- a/src/test/converter/comment/specs.json
+++ b/src/test/converter/comment/specs.json
@@ -380,6 +380,71 @@
           ]
         }
       ]
+    },
+    {
+      "id": 42,
+      "name": "comment4",
+      "kind": 1,
+      "kindString": "Module",
+      "flags": {},
+      "comment": {
+        "shortText": "This is a comment containing a multiline code block\n```ts\nexport function multiply(a: number, b: number) {\n  return a * b;\n}\n```"
+      },
+      "children": [
+        {
+          "id": 43,
+          "name": "multiply",
+          "kind": 64,
+          "kindString": "Function",
+          "flags": {},
+          "signatures": [
+            {
+              "id": 44,
+              "name": "multiply",
+              "kind": 4096,
+              "kindString": "Call signature",
+              "flags": {},
+              "parameters": [
+                {
+                  "id": 45,
+                  "name": "a",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                },
+                {
+                  "id": 46,
+                  "name": "b",
+                  "kind": 32768,
+                  "kindString": "Parameter",
+                  "flags": {},
+                  "type": {
+                    "type": "intrinsic",
+                    "name": "number"
+                  }
+                }
+              ],
+              "type": {
+                "type": "intrinsic",
+                "name": "number"
+              }
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "title": "Functions",
+          "kind": 64,
+          "children": [
+            43
+          ]
+        }
+      ]
     }
   ],
   "groups": [
@@ -389,7 +454,8 @@
       "children": [
         1,
         32,
-        37
+        37,
+        42
       ]
     }
   ]


### PR DESCRIPTION
The generated code blocks do not have any intendation which makes it hard to read.
With this change, the intendation is preserved in the case that the code block is defined with `