### PR TITLE
Fix for Yarn's "incorrect peer dependency" issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typedoc-default-themes": "^0.12.10"
   },
   "peerDependencies": {
-    "typescript": "3.9.x || 4.0.x || 4.1.x || 4.2.x"
+    "typescript": "^3.9 || ^4.0 || ^4.1 || ^4.2"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.11",


### PR DESCRIPTION
This is the most minor of pull requests, but given that TypeDoc is the only package in my project that displays a warning on package installation, it's been a bother for me.

When I perform the following command:

``` text
yarn add --dev typedoc
```

I get the following warning from Yarn:

``` text
warning " > typedoc@0.20.36" has incorrect peer dependency "typescript@3.9.x || 4.0.x || 4.1.x || 4.2.x".
```

I haven't really found the specific reason for this warning, given that combining range of semantic versions seems to be valid, but it might have something to do with it being specified in peerDependencies. I tried various different solutions, from hyphenated ranges (`3.9 - 4.2`) to simpler combining ranges (`>=3.9 <4.3`). The only solution that seemed to work to suppress the warning was switching to caret syntax.

Importantly, under testing, this fix does not allow TypeScript 4.3 as a peer dependency. I know TypeDoc is still working on fully supporting the changes in TypeScript 4.3 and I didn't want to accidentally include this range.

Yarn version: 1.22.10
Platform: macOS 11.4
TypeDoc version: 0.20.36