### PR TITLE
Add support for TS entry points in monorepo configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ typedoc package1/index.ts package2/index.ts
 ### Monorepos / Workspaces
 
 If your codebase is comprised of one or more npm packages, you can pass the paths to these
-packages and TypeDoc will attempt to determine entry points from your `package.json`'s `main`
-property (or its default value `index.js`).
+packages and TypeDoc will attempt to determine entry points based on `package.json`'s `main`
+property (with default value `index.js`) and if it wasn't found, based on `types` property.
 If any of the packages given are the root of an [npm Workspace](https://docs.npmjs.com/cli/v7/using-npm/workspaces)
 or a [Yarn Workspace](https://classic.yarnpkg.com/en/docs/workspaces/) TypeDoc will find all
 the `workspaces` defined in the `package.json`.
 This mode requires sourcemaps in your JS entry points, in order to find the TS entry points.
 Supports wildcard paths in the same fashion as those found in npm or Yarn workspaces.
+
+:warning: In opposition to project entry points, package entry points are determined relatively to options file if provided.
 
 #### Single npm module
 

--- a/src/lib/utils/package-manifest.ts
+++ b/src/lib/utils/package-manifest.ts
@@ -241,7 +241,7 @@ export function getTsEntryPointForPackage(
         if (e.code !== "MODULE_NOT_FOUND") {
             throw e;
         } else {
-            let tsEntryPointPath = resolve(
+            const tsEntryPointPath = resolve(
                 packageJsonPath,
                 "..",
                 packageTypes ?? packageMain

--- a/src/test/packages.test.ts
+++ b/src/test/packages.test.ts
@@ -14,7 +14,11 @@ describe("Packages support", () => {
         const project = app.convert();
         equal(
             project?.children?.map((r) => r.name),
-            ["typedoc-multi-package-bar", "typedoc-multi-package-foo"]
+            [
+                "typedoc-multi-package-bar",
+                "typedoc-multi-package-baz",
+                "typedoc-multi-package-foo",
+            ]
         );
     });
 

--- a/src/test/packages/multi-package/packages/bar/dist/index.js
+++ b/src/test/packages/multi-package/packages/bar/dist/index.js
@@ -1,6 +1,0 @@
-"use strict";
-exports.__esModule = true;
-exports.bar = void 0;
-function bar() { }
-exports.bar = bar;
-//# sourceMappingURL=index.js.map

--- a/src/test/packages/multi-package/packages/bar/dist/index.js.map
+++ b/src/test/packages/multi-package/packages/bar/dist/index.js.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../index.ts"],"names":[],"mappings":";;;AAAA,SAAgB,GAAG,KAAI,CAAC;AAAxB,kBAAwB"}

--- a/src/test/packages/multi-package/packages/bar/index.d.ts
+++ b/src/test/packages/multi-package/packages/bar/index.d.ts
@@ -1,0 +1,1 @@
+export function bar(): void;

--- a/src/test/packages/multi-package/packages/bar/index.ts
+++ b/src/test/packages/multi-package/packages/bar/index.ts
@@ -1,1 +1,0 @@
-export function bar() {}

--- a/src/test/packages/multi-package/packages/bar/package.json
+++ b/src/test/packages/multi-package/packages/bar/package.json
@@ -1,5 +1,5 @@
 {
   "name": "typedoc-multi-package-bar",
   "version": "1.0.0",
-  "main": "dist/index"
+  "types": "index.d.ts"
 }

--- a/src/test/packages/multi-package/packages/baz/index.ts
+++ b/src/test/packages/multi-package/packages/baz/index.ts
@@ -1,0 +1,1 @@
+export function baz() {}

--- a/src/test/packages/multi-package/packages/baz/package.json
+++ b/src/test/packages/multi-package/packages/baz/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "typedoc-multi-package-baz",
+  "version": "1.0.0",
+  "main": "index.ts"
+}

--- a/src/test/packages/multi-package/packages/baz/tsconfig.json
+++ b/src/test/packages/multi-package/packages/baz/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "sourceMap": false,
+        "inlineSourceMap": true
+    }
+}


### PR DESCRIPTION
Firstly, thank you @efokschaner and @Gerrit0 for implementing packages entry points 😃

I've added it as we talked about it in #1567, for now TS files must have extension set explicitly, otherwise they won't be "fetched".

If it's fine as-is, it would be nice to get it released in beta channel ASAP.
