### PR TITLE
Pin `marked` dependency to 2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "lunr": "^2.3.9",
-    "marked": "^2.0.3",
+    "marked": "~2.0.3",
     "minimatch": "^3.0.0",
     "progress": "^2.0.3",
     "shelljs": "^0.8.4",


### PR DESCRIPTION
Allows installation to complete successfully on Node 10.8.0

Fixes #1601