### PR TITLE
fix: Closes #1628 by lowering node engines to 12.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node: ["12", "14", "16"]
+                node: ["12.10", "12", "14", "16"]
         name: Node ${{ matrix.node }}
         steps:
             - name: Checkout repository

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/TypeStrong/TypeDoc/issues"
   },
   "engines": {
-    "node": ">= 12.20.0"
+    "node": ">= 12.10.0"
   },
   "dependencies": {
     "glob": "^7.1.7",


### PR DESCRIPTION
This PR partially addresses #1628 by opening up the engines requirement back to Node 12.10.

Lower than 12.10 would require refactoring [src/lib/utils/fs.ts](https://github.com/TypeStrong/typedoc/blob/8ff7d32dc31dccd26b42d96ba4bebb5b430867f4/src/lib/utils/fs.ts#L145) to use something other than `fs.rmdir({ recursive: true })`, which was [introduced in 12.10 ](https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_rmdir_path_options_callback)