### PR TITLE
Handle language aliases

### DIFF
--- a/src/lib/utils/highlighter.ts
+++ b/src/lib/utils/highlighter.ts
@@ -2,11 +2,11 @@ import { ok as assert } from "assert";
 import * as shiki from "shiki";
 import { unique } from "./array";
 
-type MapKey  = [string, string[] | undefined];
+type MapKey = [string, string[] | undefined];
 type RMapKey = [string, string];
 
 function rM_zipIdWithAliases(bl: shiki.ILanguageRegistration): MapKey {
-    return [ bl.id, bl.aliases ];
+    return [bl.id, bl.aliases];
 }
 
 function rM_nonEmptyRow(row: MapKey): boolean {
@@ -14,24 +14,22 @@ function rM_nonEmptyRow(row: MapKey): boolean {
 }
 
 function rM_remapAliasToId([base, al]: MapKey): RMapKey[] {
-    return (al || []).map(a => [a, base]);
+    return (al || []).map((a) => [a, base]);
 }
 
-const reverseMapping: RMapKey[][] =
-    [
-        [ ['text', 'text'] ],
-        ... shiki.BUNDLED_LANGUAGES
-            .map(rM_zipIdWithAliases)
-            .filter(rM_nonEmptyRow)
-            .map(rM_remapAliasToId)
-  ]
+const reverseMapping: RMapKey[][] = [
+    [["text", "text"]],
+    ...shiki.BUNDLED_LANGUAGES.map(rM_zipIdWithAliases)
+        .filter(rM_nonEmptyRow)
+        .map(rM_remapAliasToId),
+];
 
-const aliases = new Map<string, string>( reverseMapping.flat() );
+const aliases = new Map<string, string>(reverseMapping.flat());
 
 const supportedLanguages = unique([
     "text",
     ...aliases.keys(),
-    ...shiki.BUNDLED_LANGUAGES.map((lang) => lang.id)
+    ...shiki.BUNDLED_LANGUAGES.map((lang) => lang.id),
 ]).sort();
 
 let highlighter: shiki.Highlighter | undefined;

--- a/src/test/utils/languageAliases.test.ts
+++ b/src/test/utils/languageAliases.test.ts
@@ -1,35 +1,63 @@
 import { deepStrictEqual as equal } from "assert";
-import { isSupportedLanguage } from '../../lib/utils/highlighter';
+import { isSupportedLanguage } from "../../lib/utils/highlighter";
 
 describe("Language aliases", () => {
-
     describe("Original language aliases", () => {
-        it("js is present",   () => { equal(isSupportedLanguage('js'),   true); });
-        it("ts is present",   () => { equal(isSupportedLanguage('ts'),   true); });
-        it("sh is present",   () => { equal(isSupportedLanguage('sh'),   true); });
-        it("bash is present", () => { equal(isSupportedLanguage('bash'), true); });
-        it("zsh is present",  () => { equal(isSupportedLanguage('zsh'),  true); });
-        it("text is present", () => { equal(isSupportedLanguage('text'), true); });
+        it("js is present", () => {
+            equal(isSupportedLanguage("js"), true);
+        });
+        it("ts is present", () => {
+            equal(isSupportedLanguage("ts"), true);
+        });
+        it("sh is present", () => {
+            equal(isSupportedLanguage("sh"), true);
+        });
+        it("bash is present", () => {
+            equal(isSupportedLanguage("bash"), true);
+        });
+        it("zsh is present", () => {
+            equal(isSupportedLanguage("zsh"), true);
+        });
+        it("text is present", () => {
+            equal(isSupportedLanguage("text"), true);
+        });
     });
 
     // non-exhaustive, just shows that some of the uncovered ones are now covered
     describe("Extended language aliases", () => {
-        it("rb is present",   () => { equal(isSupportedLanguage('rb'),   true); });
-        it("py is present",   () => { equal(isSupportedLanguage('py'),   true); });
-        it("jssm is present", () => { equal(isSupportedLanguage('jssm'), true); });
+        it("rb is present", () => {
+            equal(isSupportedLanguage("rb"), true);
+        });
+        it("py is present", () => {
+            equal(isSupportedLanguage("py"), true);
+        });
+        it("jssm is present", () => {
+            equal(isSupportedLanguage("jssm"), true);
+        });
     });
 
     // non-exhaustive, just shows that the basic names are upheld too
     describe("Basic ids", () => {
-        it("ruby is present",       () => { equal(isSupportedLanguage('ruby'),       true); });
-        it("python is present",     () => { equal(isSupportedLanguage('python'),     true); });
-        it("javascript is present", () => { equal(isSupportedLanguage('javascript'), true); });
-        it("typescript is present", () => { equal(isSupportedLanguage('typescript'), true); });
-        it("fsl is present",        () => { equal(isSupportedLanguage('fsl'),        true); });
+        it("ruby is present", () => {
+            equal(isSupportedLanguage("ruby"), true);
+        });
+        it("python is present", () => {
+            equal(isSupportedLanguage("python"), true);
+        });
+        it("javascript is present", () => {
+            equal(isSupportedLanguage("javascript"), true);
+        });
+        it("typescript is present", () => {
+            equal(isSupportedLanguage("typescript"), true);
+        });
+        it("fsl is present", () => {
+            equal(isSupportedLanguage("fsl"), true);
+        });
     });
 
     describe("Improper language aliases", () => {
-        it("js2 is not present", () => { equal(isSupportedLanguage('js2'), false); });
+        it("js2 is not present", () => {
+            equal(isSupportedLanguage("js2"), false);
+        });
     });
-
 });

--- a/src/test/utils/languageAliases.test.ts
+++ b/src/test/utils/languageAliases.test.ts
@@ -1,0 +1,35 @@
+import { deepStrictEqual as equal } from "assert";
+import { isSupportedLanguage } from '../../lib/utils/highlighter';
+
+describe("Language aliases", () => {
+
+    describe("Original language aliases", () => {
+        it("js is present",   () => { equal(isSupportedLanguage('js'),   true); });
+        it("ts is present",   () => { equal(isSupportedLanguage('ts'),   true); });
+        it("sh is present",   () => { equal(isSupportedLanguage('sh'),   true); });
+        it("bash is present", () => { equal(isSupportedLanguage('bash'), true); });
+        it("zsh is present",  () => { equal(isSupportedLanguage('zsh'),  true); });
+        it("text is present", () => { equal(isSupportedLanguage('text'), true); });
+    });
+
+    // non-exhaustive, just shows that some of the uncovered ones are now covered
+    describe("Extended language aliases", () => {
+        it("rb is present",   () => { equal(isSupportedLanguage('rb'),   true); });
+        it("py is present",   () => { equal(isSupportedLanguage('py'),   true); });
+        it("jssm is present", () => { equal(isSupportedLanguage('jssm'), true); });
+    });
+
+    // non-exhaustive, just shows that the basic names are upheld too
+    describe("Basic ids", () => {
+        it("ruby is present",       () => { equal(isSupportedLanguage('ruby'),       true); });
+        it("python is present",     () => { equal(isSupportedLanguage('python'),     true); });
+        it("javascript is present", () => { equal(isSupportedLanguage('javascript'), true); });
+        it("typescript is present", () => { equal(isSupportedLanguage('typescript'), true); });
+        it("fsl is present",        () => { equal(isSupportedLanguage('fsl'),        true); });
+    });
+
+    describe("Improper language aliases", () => {
+        it("js2 is not present", () => { equal(isSupportedLanguage('js2'), false); });
+    });
+
+});


### PR DESCRIPTION
TypeDoc previously manually loaded synonyms for ts, js, bash, zsh, sh.

These can be sourced from the `aliases` field, with some juggling.

Juggling and test cases provided

Fixes #1672 