### PR TITLE
Add support for a `typedocMain` field in package.json.

### DIFF
--- a/src/lib/utils/package-manifest.ts
+++ b/src/lib/utils/package-manifest.ts
@@ -207,6 +207,11 @@ export function getTsEntryPointForPackage(
     let packageMain = "index.js"; // The default, per the npm docs.
     let packageTypes = null;
     if (
+        hasOwnProperty(packageJson, "typedocMain") &&
+        typeof packageJson.typedocMain == "string"
+    ) {
+        packageMain = packageJson.typedocMain
+    } else if (
         hasOwnProperty(packageJson, "main") &&
         typeof packageJson.main == "string"
     ) {


### PR DESCRIPTION
This can be used to generate a tree of your source using `tsc` and point
at it to generate documentation outside your normal build process.

This takes a different tack and instead of falling back to the typings, this allows you to set a specific packageMain value that is built directly with TSC. This can act as an escape hatch for projects with weird builds that involve webpack / rollup / etc, and more complex typings setups with api-extractor to go along with the bundling.

For example, in our particular case, we use webpack 4 and api-extractor to bundle packages that are used at development time, but publicly are exposed as a single package. Therefore we bundle the TS via webpack and tsloader, and bundle the declaration files using an api-extractor rollup.

Resolves #1674.