### PR TITLE
Allow usage of the JSDoc `@example` caption

### DIFF
--- a/src/lib/converter/factories/comment.ts
+++ b/src/lib/converter/factories/comment.ts
@@ -224,6 +224,9 @@ export function parseComment(
         if (tagName === "return") {
             tagName = "returns";
         }
+        if (tagName === "example") {
+            line = line.replace(/<\/?caption>/g, "");
+        }
         if (
             tagName === "param" ||
             tagName === "typeparam" ||


### PR DESCRIPTION
**What this pull request contains**
- full lint/test compliance
- implementation ([here](https://github.com/schlusslicht/typedoc/blob/feat/jsdoc-example-caption/src/lib/converter/factories/comment.ts#L227-L229))

**What this pull request impacts**
- runtime of the parsing process will increase per `tagLine` (`@anyTag` occurences) by one `if`-condition, evaluating strict string equality (`tagName === "example"`)
  - `if` an `@example` is met, a RegEx-replacement will be executed on the whole line (`line.replace(/<\/?caption>/g, "")`).

**What this pull request does**
Strip `<caption></caption>` tags from `@example` headings (inside the comment convertor factory).
My use-case and motivation as follows.

So, I'm brewing my own small TypeScript library to season my JavaScript client with. And, of course, I want to document the exposed API to give hints inline and on some nice kitchen table like `home-brewed-soup.github.io`. As I'm trying to conform to standards, I choose the adequate `*doc` format, which turns out to be TSDoc. Then I look for a nice tool to extract some nice kitchen table-ready HTML from my TSDoc comments and here I am (thank You! :heart:). As time files by, I'm getting ready to actually enrich my documentation with some nitty-gritty `@example`s (recipes) and immediately hit the VSCode vs. TSDoc wall regarding the `@example` (block) formatting:
- https://github.com/microsoft/TypeScript-TmLanguage/issues/693
- https://github.com/microsoft/tsdoc/issues/147
- https://github.com/mjbvz/vscode-jsdoc-markdown-highlighting/issues/2

To demonstrate what I'm refering to, here's what happenes when applying a title to an `@example` block in VSCode (v1.59.1#3866c35):
![not-tasty](https://user-images.githubusercontent.com/1932900/132571093-c15455ea-23f1-42c4-90b6-14b7d79fa77a.png)

Dissapointing inline-experience. But `typedoc` does render this correctly, so no issue there. Still, I want the VSCode inline-experience to be `tasty`. So I looked around, ate some more soup, and found out, that [JSDoc](https://jsdoc.app/tags-example.html#examples) (in contrast to [TSDoc](https://tsdoc.org/pages/tags/example/#example-b)) forbits the usage of captions in `@example` headings. *Unless!* One may use the `<caption></caption>` tags, to specify the `@example` caption. Opened VSCode, tried this out, et voila:
![tasty](https://user-images.githubusercontent.com/1932900/132571132-aa1f9b33-fc6a-490d-b08a-7542e64a0b59.png)

Very nice VSCode inline-experience, right there. And then I gave `typedoc` a go:
![unpatched](https://user-images.githubusercontent.com/1932900/132571146-bcca3abb-2457-4060-b802-07d6a29884ec.png)

Damn, the markdown isn't rendered (`:-(`). I did not dig through *all* Your code, but as I can see the `<caption></caption>` tags being rendered 1:1 into the HTML output, I'd guess strings enclosed in HTML tags are considered to be pre-rendered and therefore aren't piped through the markdown parser? Which seems correnct, in any other case. But nevermind, I *did* dig through Your code enough to be able to provide this tiny pull request, which just adds an `if`-clause [at the right place](https://github.com/schlusslicht/typedoc/blob/feat/jsdoc-example-caption/src/lib/converter/factories/comment.ts#L227-L229) to strip `<caption></caption>` tags from `@example` `tagLine`s. After applying the patch:
![patched](https://user-images.githubusercontent.com/1932900/132571162-f82bc336-ff56-4b84-ad7e-25b5edeb642d.png)

**Yummy!** `:-)`