### PR TITLE
Remove old options from basic example run & run.bat

### DIFF
--- a/examples/basic/run
+++ b/examples/basic/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd ${0%/*}
-node ../../bin/typedoc --module commonjs --includes inc/ --media media/ --target ES5 --json json.json --out doc/ src/
+node ../../bin/typedoc --includes inc/ --media media/ --json json.json --out doc/ src/

--- a/examples/basic/run.bat
+++ b/examples/basic/run.bat
@@ -2,6 +2,6 @@
 set curr_dir=%cd%
 chdir /D "%~dp0"
 
-node ..\..\bin\typedoc --module commonjs --includes inc\ --media media\ --target ES5 --noLib --out doc\ src\
+node ..\..\bin\typedoc --includes inc\ --media media\ --json json.json --out doc\ src\
 
 chdir /D "%curr_dir%"


### PR DESCRIPTION
Looks like the `--module` and `--target` options were removed in a previous release.