### PR TITLE
Automatically add .nojekyll file to support GitHub Pages

### DIFF
--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -1,0 +1,15 @@
+export * from "./access";
+export * from "./classes";
+export * from "./default-export";
+export * from "./enumerations";
+export * from "./flattened";
+export * from "./functions";
+export * from "./generics";
+export * from "./hidden";
+export * from "./markdown";
+export * from "./mixin";
+export * from "./mod";
+export * from "./mod2";
+export * from "./modules";
+export { default as SingleExportedClass } from "./single-export";
+export * from "./weird-names";

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -5,7 +5,8 @@
         "jsx": "react",
         "experimentalDecorators": true,
         "resolveJsonModule": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "esModuleInterop": true
     },
     "include": ["."]
 }

--- a/src/lib/output/plugins/index.ts
+++ b/src/lib/output/plugins/index.ts
@@ -1,5 +1,5 @@
 export { AssetsPlugin } from "./AssetsPlugin";
 export { JavascriptIndexPlugin } from "./JavascriptIndexPlugin";
 export { MarkedLinksPlugin } from "./MarkedLinksPlugin";
-export { MarkedPlugin as MarkedPlugin } from "../themes/MarkedPlugin";
+export { MarkedPlugin } from "../themes/MarkedPlugin";
 export { LegendPlugin } from "./LegendPlugin";

--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -8,6 +8,7 @@
  */
 import type * as ts from "typescript";
 import * as fs from "fs";
+import * as path from "path";
 
 import type { Application } from "../application";
 import type { Theme } from "./theme";
@@ -94,6 +95,10 @@ export class Renderer extends ChildableComponent<
     /** @internal */
     @BindOption("gaSite")
     gaSite!: string;
+
+    /** @internal */
+    @BindOption("githubPages")
+    githubPages!: boolean;
 
     /** @internal */
     @BindOption("hideGenerator")
@@ -301,9 +306,25 @@ export class Renderer extends ChildableComponent<
             fs.mkdirSync(directory, { recursive: true });
         } catch (error) {
             this.application.logger.error(
-                `Could not create output directory ${directory}`
+                `Could not create output directory ${directory}.`
             );
             return false;
+        }
+
+        if (this.githubPages) {
+            try {
+                const text =
+                    "TypeDoc added this file to prevent GitHub Pages from " +
+                    "using Jekyll. You can turn off this behavior by setting " +
+                    "the `githubPages` option to false.";
+
+                fs.writeFileSync(path.join(directory, ".nojekyll"), text);
+            } catch (error) {
+                this.application.logger.warn(
+                    "Could not create .nojekyll file."
+                );
+                return false;
+            }
         }
 
         return true;

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -86,6 +86,7 @@ export interface TypeDocOptionMap {
     gitRemote: string;
     gaID: string;
     gaSite: string;
+    githubPages: boolean;
     hideGenerator: boolean;
     hideLegend: boolean;
     cleanOutputDir: boolean;

--- a/src/lib/utils/options/sources/typedoc.ts
+++ b/src/lib/utils/options/sources/typedoc.ts
@@ -249,6 +249,12 @@ export function addTypeDocOptions(options: Pick<Options, "addDeclaration">) {
         defaultValue: "auto",
     });
     options.addDeclaration({
+        name: "githubPages",
+        help: "Generate a .nojekyll file to prevent 404 errors in GitHub Pages. Defaults to `true`.",
+        type: ParameterType.Boolean,
+        defaultValue: true,
+    });
+    options.addDeclaration({
         name: "hideGenerator",
         help: "Do not print the TypeDoc link at the end of the page.",
         type: ParameterType.Boolean,


### PR DESCRIPTION
* Fix `examples/basic` by adding an `index.ts` file that exports everything. Fixes #1692.
* Automatically add `.nojekyll` file to support GitHub Pages. This behavior is controlled by the new `githubPages` option which defaults to true. Fixes #1680.
    * Will submit PR to documentation site once this is merged!