### PR TITLE
Use data-theme attribute for themes on root element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "typedoc",
       "version": "0.22.4",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/lib/output/themes/default/assets/typedoc/Theme.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Theme.ts
@@ -13,17 +13,5 @@ export function initTheme(choices: HTMLOptionElement) {
 }
 
 function setTheme(theme: ThemeChoice) {
-    switch (theme) {
-        case "os":
-            document.body.classList.remove("light", "dark");
-            break;
-        case "light":
-            document.body.classList.remove("dark");
-            document.body.classList.add("light");
-            break;
-        case "dark":
-            document.body.classList.remove("light");
-            document.body.classList.add("dark");
-            break;
-    }
+    document.documentElement.dataset.theme = theme;
 }

--- a/src/lib/utils/highlighter.tsx
+++ b/src/lib/utils/highlighter.tsx
@@ -103,11 +103,11 @@ class DoubleHighlighter {
         style.push(...darkRules);
         style.push("} }", "");
 
-        style.push("body.light {");
+        style.push(":root[data-theme='light'] {");
         style.push(...lightRules);
         style.push("}", "");
 
-        style.push("body.dark {");
+        style.push(":root[data-theme='dark'] {");
         style.push(...darkRules);
         style.push("}", "");
 

--- a/static/style.css
+++ b/static/style.css
@@ -71,6 +71,7 @@
         --color-toolbar-text: var(--light-color-toolbar-text);
         --icon-filter: var(--light-icon-filter);
         --external-icon: var(--light-external-icon);
+        --color-scheme: light;
     }
 }
 
@@ -97,14 +98,19 @@
         --color-toolbar-text: var(--dark-color-toolbar-text);
         --icon-filter: var(--dark-icon-filter);
         --external-icon: var(--dark-external-icon);
+        --color-scheme: dark;
     }
+}
+
+html {
+    color-scheme: var(--color-scheme);
 }
 
 body {
     margin: 0;
 }
 
-body.light {
+:root[data-theme="light"] {
     --color-background: var(--light-color-background);
     --color-secondary-background: var(--light-color-secondary-background);
     --color-text: var(--light-color-text);
@@ -128,7 +134,7 @@ body.light {
     --external-icon: var(--light-external-icon);
 }
 
-body.dark {
+:root[data-theme="dark"] {
     --color-background: var(--dark-color-background);
     --color-secondary-background: var(--dark-color-secondary-background);
     --color-text: var(--dark-color-text);

--- a/static/style.css
+++ b/static/style.css
@@ -132,6 +132,7 @@ body {
     --color-toolbar-text: var(--light-color-toolbar-text);
     --icon-filter: var(--light-icon-filter);
     --external-icon: var(--light-external-icon);
+    --color-scheme: light;
 }
 
 :root[data-theme="dark"] {
@@ -156,6 +157,7 @@ body {
     --color-toolbar-text: var(--dark-color-toolbar-text);
     --icon-filter: var(--dark-icon-filter);
     --external-icon: var(--dark-external-icon);
+    --color-scheme: dark;
 }
 
 h1 {


### PR DESCRIPTION
**Use CSS color-scheme property**
This sets light/dark theme on scrollbars and form elements.

**Remove switch statement and directly apply theme in setTheme function**
This change allows additional themes added by a plugin to work without attaching a new listener to #theme element; also prevents rechecking of localStorage to add the custom theme to body.classList.