### PR TITLE
Support githubprivate.com in GitHubPlugin

### DIFF
--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -72,6 +72,13 @@ export class Repository {
                     repoLinks[i]
                 );
 
+            // Github Enterprise
+            if (!match) {
+                match = /(\w+\.githubprivate.com)[:/]([^/]+)\/(.*)/.exec(
+                    repoLinks[i]
+                );
+            }
+
             if (!match) {
                 match = /(bitbucket.org)[:/]([^/]+)\/(.*)/.exec(repoLinks[i]);
             }

--- a/src/test/GitHubPlugin.test.ts
+++ b/src/test/GitHubPlugin.test.ts
@@ -33,6 +33,19 @@ describe("Repository", function () {
             equal(repository.type, RepositoryType.GitHub);
         });
 
+        it("handles a githubprivate.com URL", function () {
+            const mockRemotes = [
+                "ssh://org@bigcompany.githubprivate.com/joebloggs/foobar.git",
+            ];
+
+            const repository = new github.Repository("", "", mockRemotes);
+
+            equal(repository.hostname, "bigcompany.githubprivate.com");
+            equal(repository.user, "joebloggs");
+            equal(repository.project, "foobar");
+            equal(repository.type, RepositoryType.GitHub);
+        });
+
         it("handles a Bitbucket HTTPS URL", function () {
             const mockRemotes = [
                 "https://joebloggs@bitbucket.org/joebloggs/foobar.git",


### PR DESCRIPTION
Some Github Enterprise clients have a `githubprivate.com` domain, and this supports that