### PR TITLE
Increase `git ls-files` maxBuffer to 10MB

### DIFF
--- a/src/lib/converter/plugins/GitHubPlugin.ts
+++ b/src/lib/converter/plugins/GitHubPlugin.ts
@@ -9,8 +9,14 @@ import type { Context } from "../context";
 import { BindOption } from "../../utils";
 import { RepositoryType } from "../../models";
 
+const TEN_MEGABYTES: number = 1024 * 10000;
+
 function git(...args: string[]) {
-    return spawnSync("git", args, { encoding: "utf-8", windowsHide: true });
+    return spawnSync("git", args, {
+        encoding: "utf-8",
+        windowsHide: true,
+        maxBuffer: TEN_MEGABYTES,
+    });
 }
 
 /**


### PR DESCRIPTION
[This line](https://github.com/TypeStrong/typedoc/blob/master/src/lib/converter/plugins/GitHubPlugin.ts#L97) in GitHubPlugin throws an error (`Error: spawnSync git ENOBUFS`) for my repo, which has 19K tracked files. If I add `"*.?s"` to ls-files, I still have 14.5K files and the same error.

By increasing the buffer, this feature will work for very large repos