### PR TITLE
Updated readme to remove minimal theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For a complete list of the command line arguments run `typedoc --help` or visit
 
 #### Theming
 
--   `--theme <default|minimal|path/to/theme>`<br>
+-   `--theme <default|path/to/theme>`<br>
     Specify the path to the theme that should be used.
 -   `--name <Documentation title>`<br>
     Set the name of the project that will be used in the header of the template.


### PR DESCRIPTION
I noticed that the minimal theme was still mentioned in the readme. [The website](https://typedoc.org/guides/options/#theme) has already been updated, so here is an update for the readme.