### PR TITLE
Fixed gap after footer

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -641,6 +641,10 @@ footer {
     border-top: 1px solid var(--color-panel-divider);
     background-color: var(--color-panel);
 }
+footer:after {
+    content: "";
+    display: table;
+}
 footer.with-border-bottom {
     border-bottom: 1px solid var(--color-panel-divider);
 }


### PR DESCRIPTION
This fixes #1749. The screenshot in the expected section actually uses this fix. 

The problem was that the margin of the last `<p>` went outside the footer.

![image](https://user-images.githubusercontent.com/20878432/138114604-1b1089e9-14a0-41c4-8ab4-aba06f6433f8.png)


![image](https://user-images.githubusercontent.com/20878432/138114292-7b307cfa-1f0f-4b97-a349-1487843dc5e1.png)

This PR adds an invisible pseudo-element to fix that.

![image](https://user-images.githubusercontent.com/20878432/138114706-cb9cf669-c3a1-4204-9f21-a66b88624f5b.png)
