### PR TITLE
Removed empty source element

### DIFF
--- a/src/lib/output/themes/default/partials/member.sources.tsx
+++ b/src/lib/output/themes/default/partials/member.sources.tsx
@@ -6,46 +6,56 @@ export const memberSources = (
     context: DefaultThemeRenderContext,
     props: SignatureReflection | DeclarationReflection
 ) => {
-    const element = (
-        <aside class="tsd-sources">
-            {!!props.implementationOf && (
-                <p>
-                    {"Implementation of "}
-                    {context.typeAndParent(props.implementationOf)}
-                </p>
-            )}
-            {!!props.inheritedFrom && (
-                <p>
-                    {"Inherited from "}
-                    {context.typeAndParent(props.inheritedFrom)}
-                </p>
-            )}
-            {!!props.overwrites && (
-                <p>
-                    {"Overrides "}
-                    {context.typeAndParent(props.overwrites)}
-                </p>
-            )}
-            {!!props.sources && (
-                <ul>
-                    {props.sources.map((item) =>
-                        item.url ? (
-                            <li>
-                                {"Defined in "}
-                                <a href={item.url}>
-                                    {item.fileName}:{item.line}
-                                </a>
-                            </li>
-                        ) : (
-                            <li>
-                                Defined in {item.fileName}:{item.line}
-                            </li>
-                        )
-                    )}
-                </ul>
-            )}
-        </aside>
-    );
+    const sources: JSX.Element[] = [];
 
-    return <>{element.children.some((c) => !!c) && element}</>;
+    if (props.implementationOf) {
+        sources.push(
+            <p>
+                {"Implementation of "}
+                {context.typeAndParent(props.implementationOf)}
+            </p>
+        );
+    }
+    if (props.inheritedFrom) {
+        sources.push(
+            <p>
+                {"Inherited from "}
+                {context.typeAndParent(props.inheritedFrom)}
+            </p>
+        );
+    }
+    if (props.overwrites) {
+        sources.push(
+            <p>
+                {"Overrides "}
+                {context.typeAndParent(props.overwrites)}
+            </p>
+        );
+    }
+    if (props.sources) {
+        sources.push(
+            <ul>
+                {props.sources.map((item) =>
+                    item.url ? (
+                        <li>
+                            {"Defined in "}
+                            <a href={item.url}>
+                                {item.fileName}:{item.line}
+                            </a>
+                        </li>
+                    ) : (
+                        <li>
+                            Defined in {item.fileName}:{item.line}
+                        </li>
+                    )
+                )}
+            </ul>
+        );
+    }
+
+    if (sources.length === 0) {
+        return <></>;
+    }
+
+    return <aside class="tsd-sources">{sources}</aside>;
 };


### PR DESCRIPTION
I noticed that a lot of my members had an empty `<aside>` element. This was annoying because the empty element still took up space because of its margin.

### Examples

With empty `<aside>`:
![image](https://user-images.githubusercontent.com/20878432/138271449-e7a41722-27ee-4c93-84b1-1cc46756ba36.png)
![image](https://user-images.githubusercontent.com/20878432/138271507-4b4abbb6-93b9-45d7-8db5-711830ed8bac.png)

Without:
![image](https://user-images.githubusercontent.com/20878432/138271583-911abffd-3a2c-4a1b-a82b-5b514d989c9b.png)
