### PR TITLE
Highlight type parameters consistently

### DIFF
--- a/src/lib/output/themes/default/partials/member.declaration.tsx
+++ b/src/lib/output/themes/default/partials/member.declaration.tsx
@@ -1,14 +1,13 @@
 import { DeclarationReflection, ReflectionType } from "../../../../models";
 import { JSX } from "../../../../utils";
-import { wbr } from "../../lib";
+import { renderTypeParametersSignature, wbr } from "../../lib";
 import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext";
-import { typeParameterSignatureList } from "./member.signature.title";
 
 export const memberDeclaration = (context: DefaultThemeRenderContext, props: DeclarationReflection) => (
     <>
         <div class="tsd-signature tsd-kind-icon">
             {wbr(props.name)}
-            {typeParameterSignatureList(props.typeParameters)}
+            {renderTypeParametersSignature(props.typeParameters)}
             {props.type && (
                 <>
                     <span class="tsd-signature-symbol">{!!props.flags.isOptional && "?"}:</span>{" "}

--- a/src/lib/output/themes/default/partials/member.signature.title.tsx
+++ b/src/lib/output/themes/default/partials/member.signature.title.tsx
@@ -1,23 +1,7 @@
-import { join, wbr } from "../../lib";
+import { join, renderTypeParametersSignature, wbr } from "../../lib";
 import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext";
 import { JSX } from "../../../../utils";
-import type { SignatureReflection, TypeParameterReflection } from "../../../../models";
-
-export const typeParameterSignatureList = (typeParameters: readonly TypeParameterReflection[] | undefined): JSX.Element => (
-    <>
-        {!!typeParameters && typeParameters.length > 0 && (
-            <>
-                <span class="tsd-signature-symbol">{"<"}</span>
-                {join(<span class="tsd-signature-symbol">{", "}</span>, typeParameters, (item) => (
-                    <span class="tsd-signature-type" data-tsd-kind={item.kindString}>
-                        {item.name}
-                    </span>
-                ))}
-                <span class="tsd-signature-symbol">{">"}</span>
-            </>
-        )}
-    </>
-);
+import type { SignatureReflection } from "../../../../models";
 
 export const memberSignatureTitle = (
     context: DefaultThemeRenderContext,
@@ -37,7 +21,7 @@ export const memberSignatureTitle = (
                 )}
             </>
         )}
-        {typeParameterSignatureList(props.typeParameters)}
+        {renderTypeParametersSignature(props.typeParameters)}
         <span class="tsd-signature-symbol">(</span>
         {join(", ", props.parameters ?? [], (item) => (
             <>

--- a/src/lib/output/themes/lib.tsx
+++ b/src/lib/output/themes/lib.tsx
@@ -78,3 +78,23 @@ export function hasTypeParameters(
     }
     return false;
 }
+
+export function renderTypeParametersSignature(
+    typeParameters: readonly TypeParameterReflection[] | undefined
+): JSX.Element {
+    return (
+        <>
+            {!!typeParameters && typeParameters.length > 0 && (
+                <>
+                    <span class="tsd-signature-symbol">{"<"}</span>
+                    {join(<span class="tsd-signature-symbol">{", "}</span>, typeParameters, (item) => (
+                        <span class="tsd-signature-type" data-tsd-kind={item.kindString}>
+                            {item.name}
+                        </span>
+                    ))}
+                    <span class="tsd-signature-symbol">{">"}</span>
+                </>
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
This fixes #1746.

I left the "Type Parameters" section untouched, only signatures changed.

The whole thing is implemented via the `renderTypeParametersSignature` function. ~Frankly, I didn't know where to put this function since both member declarations and signatures need access to it. I would appreciate some guidance on this one.~ I placed into `themes/lib.tsx` because it seems like it fits in there.