### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "typedoc",
       "version": "0.22.6",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
npm automatically makes this change everytime I run `npm install`. 

I'm assuming this doesn't happen when you install @Gerrit0? I'm on the latest npm (8.1.1) and Node 14. Maybe it's because I'm on Windows...