### PR TITLE
Ensure meta charSet is within first 1024 bytes

### DIFF
--- a/src/lib/output/themes/default/layouts/default.tsx
+++ b/src/lib/output/themes/default/layouts/default.tsx
@@ -6,8 +6,8 @@ import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext";
 export const defaultLayout = (context: DefaultThemeRenderContext, props: PageEvent<Reflection>) => (
     <html class="default">
         <head>
-            {context.hook("head.begin")}
             <meta charSet="utf-8" />
+            {context.hook("head.begin")}
             <meta http-equiv="x-ua-compatible" content="IE=edge" />
             <title>
                 {props.model.name === props.project.name


### PR DESCRIPTION
This fixes the problem I mentioned [here](https://github.com/TypeStrong/typedoc/commit/8c707b3d95cffc4fccff6e9b347b71306bdb0889#r59589758).

I choose not to document this. While the docs say "immediately after the opening `<head>` tag", I don't think plugin devs should be concerned with this minor implementation detail. 