### PR TITLE
Upgrade dependencies of example

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,21 +9,21 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/lodash": "^4.14.175",
-        "@types/react": "^17.0.26",
-        "@types/react-dom": "^17.0.9",
+        "@types/lodash": "^4.14.177",
+        "@types/react": "^17.0.37",
+        "@types/react-dom": "^17.0.11",
         "lodash": "^4.17.21",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
-        "typescript": "^4.4.3"
+        "typescript": "^4.5.2"
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.175",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
-      "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
+      "version": "4.14.177",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
@@ -31,9 +31,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "node_modules/@types/react": {
-      "version": "17.0.26",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.26.tgz",
-      "integrity": "sha512-MXxuXrH2xOcv5cp/su4oz69dNQnSA90JjFw5HBd5wifw6Ihi94j7dRJm7qNsB30tnruXSCPc9qmlhGop4nh9Hw==",
+      "version": "17.0.37",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
+      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
-      "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
+      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -137,9 +137,9 @@
   },
   "dependencies": {
     "@types/lodash": {
-      "version": "4.14.175",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
-      "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
+      "version": "4.14.177",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
     },
     "@types/prop-types": {
       "version": "15.7.4",
@@ -147,9 +147,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.26",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.26.tgz",
-      "integrity": "sha512-MXxuXrH2xOcv5cp/su4oz69dNQnSA90JjFw5HBd5wifw6Ihi94j7dRJm7qNsB30tnruXSCPc9qmlhGop4nh9Hw==",
+      "version": "17.0.37",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
+      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -157,9 +157,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
-      "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
+      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "requires": {
         "@types/react": "*"
       }
@@ -226,9 +226,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true
     }
   }

--- a/example/package.json
+++ b/example/package.json
@@ -11,14 +11,14 @@
     "typedoc": "node ../bin/typedoc"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.175",
-    "@types/react": "^17.0.26",
-    "@types/react-dom": "^17.0.9",
+    "@types/lodash": "^4.14.177",
+    "@types/react": "^17.0.37",
+    "@types/react-dom": "^17.0.11",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "typescript": "^4.4.3"
+    "typescript": "^4.5.2"
   }
 }


### PR DESCRIPTION
This fixes a compilation error in the example. The example was updated to use the `Awaited` type introduced in TypeScript 4.5, but the example's `package-lock.json` was still referencing TypeScript 4.4.