### PR TITLE
Set line-height of all headings to 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   If file exports a symbol both under it's real name and as `default`, the `default` export will now always be the renamed symbol, #1795.
 -   TypeDoc will no longer crash if a symbol is defined both as a normal class (and optional interface) and as a property, as is used for global Node types in older `@types/node` versions, Gerrit0/typedoc-plugin-missing-exports#5.
+-   Fixed line height of `h1` and `h2` elements being too low, #1796.
 
 ## v0.22.9 (2021-11-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+### Bug Fixes
+
+-   Fixed line height of `h1` and `h2` elements being too low, #1796.
+
 ## v0.22.10 (2021-11-25)
 
 ### Features
@@ -10,7 +14,6 @@
 
 -   If file exports a symbol both under it's real name and as `default`, the `default` export will now always be the renamed symbol, #1795.
 -   TypeDoc will no longer crash if a symbol is defined both as a normal class (and optional interface) and as a property, as is used for global Node types in older `@types/node` versions, Gerrit0/typedoc-plugin-missing-exports#5.
--   Fixed line height of `h1` and `h2` elements being too low, #1796.
 
 ## v0.22.9 (2021-11-14)
 

--- a/static/style.css
+++ b/static/style.css
@@ -152,6 +152,15 @@ body.dark {
     --external-icon: var(--dark-external-icon);
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    line-height: 1.2;
+}
+
 h1 {
     font-size: 2em;
     margin: 0.67em 0;


### PR DESCRIPTION
Closes #1796. I chose 1.2 because this is what Bootstrap uses.