### PR TITLE
Distinguish between block and other tags when parsing comments

### DIFF
--- a/src/test/converter2/issues/gh1807.ts
+++ b/src/test/converter2/issues/gh1807.ts
@@ -1,0 +1,50 @@
+/**
+ * This is a class.
+ */
+class BaseClass {}
+
+/**
+ * @class Class1
+ *
+ * This is another class.
+ */
+class Class1 {}
+
+/**
+ * @extends BaseClass
+ *
+ * This is yet another class.
+ */
+class Class2 extends BaseClass {}
+
+/**
+ * @class Class3
+ * @extends BaseClass
+ *
+ * Some docs.
+ */
+class Class3 extends BaseClass {}
+
+/**
+ * @class Class4
+ * @alpha
+ *
+ * This is a different class.
+ */
+class Class4 {}
+
+/**
+ * @class Class5
+ * @alpha
+ *
+ * This is a different class.
+ *
+ * @remarks
+ *
+ * This class has insightful remarks.
+ *
+ * They span multiple lines.
+ */
+class Class5 {}
+
+export { BaseClass, Class1, Class2, Class3, Class4, Class5 };

--- a/src/test/issueTests.ts
+++ b/src/test/issueTests.ts
@@ -290,4 +290,34 @@ export const issueTests: {
         ok(project.children![0].kind === ReflectionKind.Reference);
         ok(project.children![1].kind !== ReflectionKind.Reference);
     },
+
+    gh1807(project) {
+        const Class1 = query(project, "Class1");
+        ok(!Class1.comment?.hasTag("class"));
+        ok(Class1.comment?.shortText === "This is another class.");
+
+        const Class2 = query(project, "Class2");
+        ok(!Class2.comment?.hasTag("extends"));
+        ok(Class2.comment?.shortText === "This is yet another class.");
+
+        const Class3 = query(project, "Class3");
+        ok(!Class3.comment?.hasTag("class"));
+        ok(!Class3.comment?.hasTag("extends"));
+        ok(Class3.comment?.shortText === "Some docs.");
+
+        const Class4 = query(project, "Class4");
+        ok(!Class4.comment?.hasTag("class"));
+        ok(Class4.comment?.hasTag("alpha"));
+        ok(Class4.comment?.shortText === "This is a different class.");
+
+        const Class5 = query(project, "Class5");
+        ok(!Class5.comment?.hasTag("class"));
+        ok(Class5.comment?.hasTag("alpha"));
+        ok(Class5.comment?.hasTag("remarks"));
+        ok(
+            Class5.comment?.getTag("remarks")?.text ===
+                "\n\nThis class has insightful remarks.\n\nThey span multiple lines.\n"
+        );
+        ok(Class5.comment?.shortText === "This is a different class.");
+    },
 };


### PR DESCRIPTION
When parsing the contents of comments, TypeDoc treats all tags as block tags. That is, if it encounters a tag, it parses whatever follows it as tag contents, until it reaches the end of the comment or finds another tag.

According to [TSDoc standard](https://tsdoc.org/pages/spec/tag_kinds) this is correct behaviour for block tags but not for modifier or inline tags. This PR modifies the behaviour by ensuring that only block tags are parsed this way and that for modifier or inline tags parsing of tag content stops when we encounter an empty line.

As a side effect, when some JSDoc tags were used at the beginning of the comment (e.g. `@class`), the entire docstring was often removed. This is because TypeDoc also attempts to remove redundant JSDoc tags from the comments. Erroneous assignment of the entire comment as the tag content meant that everything was deleted. Following this fix, only the actual tag content (e.g. the class name for `@class` tag) will be removed.

Closes #1807.