### PR TITLE
Changed how index is loaded to improve performance

### DIFF
--- a/src/lib/output/plugins/JavascriptIndexPlugin.ts
+++ b/src/lib/output/plugins/JavascriptIndexPlugin.ts
@@ -106,6 +106,9 @@ export class JavascriptIndexPlugin extends RendererComponent {
             index,
         });
 
-        writeFileSync(jsonFileName, `window.searchData = ${jsonData}`);
+        writeFileSync(
+            jsonFileName,
+            `window.searchData = JSON.parse(${JSON.stringify(jsonData)});`
+        );
     }
 }


### PR DESCRIPTION
This PR fixes #1825. Using `JSON.parse` ensures faster loading as the grammar for JSON is much simpler, so parsing JSON instead of JavaScript will be much faster (1s vs 7s in out use case)

We could consider JSON imports at a later date when that proposal reaches stage 4. 