### PR TITLE
Fix offset from top of screen on member anchor links

### DIFF
--- a/src/lib/output/themes/default/partials/member.tsx
+++ b/src/lib/output/themes/default/partials/member.tsx
@@ -5,7 +5,8 @@ import { DeclarationReflection, ReferenceReflection } from "../../../../models";
 import { anchorIcon } from "./anchor-icon";
 
 export const member = (context: DefaultThemeRenderContext, props: DeclarationReflection) => (
-    <section class={"tsd-panel tsd-member" + props.cssClasses} id={props.anchor}>
+    <section class={"tsd-panel tsd-member " + props.cssClasses}>
+        <a id={props.anchor} class="tsd-anchor"></a>
         {!!props.name && (
             <h3 class="tsd-anchor-link">
                 {renderFlags(props.flags)}


### PR DESCRIPTION
Follow up fix to https://github.com/TypeStrong/typedoc/pull/1843.

In the above PR, the anchor ID was moved to the member `<section>` tag, rather than the `<a>` tag within the section. This had the side-effect of removing the offset from the top of the screen upon clicking on the anchor link. This PR fixes this change by moving the anchor ID back inside of the `<section>` such that upon navigating to the anchor it will be `100px` from the top (as defined by the `.tsd-anchor` class) such that the member shows below the header.