### PR TITLE
fix: do not show random search results when query is empty

### DIFF
--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -152,7 +152,9 @@ function updateResults(
     const searchText = query.value.trim();
 
     // Perform a wildcard search
-    const res = state.index.search(`*${searchText}*`);
+    // Set empty `res` to prevent getting random results with wildcard search
+    // when the `searchText` is empty.
+    const res = searchText ? state.index.search(`*${searchText}*`) : [];
 
     for (let i = 0, c = Math.min(10, res.length); i < c; i++) {
         const row = state.data.rows[Number(res[i].ref)];


### PR DESCRIPTION
This change should fix the problem where random search results are showing when the search text is empty/ cleared and would address https://github.com/TypeStrong/typedoc/issues/1881.

Before:
![search_actual](https://user-images.githubusercontent.com/101419436/157914503-1734a728-5fb7-424a-8b93-c39bd2ded7cc.gif)

After:
![search_expected](https://user-images.githubusercontent.com/101419436/157914535-cd253483-5a7a-404a-9394-9dddf890abf5.gif)

