### PR TITLE
Allow overriding tsconfig options from within tsconfig.json

### DIFF
--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -110,6 +110,7 @@ export interface TypeDocOptionMap {
     logger: unknown; // string | Function
     logLevel: typeof LogLevel;
     markedOptions: unknown;
+    compilerOptions: unknown;
 
     // Validation
     treatWarningsAsErrors: boolean;

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -328,7 +328,12 @@ export class Options {
     fixCompilerOptions(
         options: Readonly<ts.CompilerOptions>
     ): ts.CompilerOptions {
+        const overrides = this.getValue("compilerOptions");
         const result = { ...options };
+
+        if (overrides) {
+            Object.assign(result, overrides);
+        }
 
         if (
             this.getValue("emit") !== "both" &&

--- a/src/lib/utils/options/sources/typedoc.ts
+++ b/src/lib/utils/options/sources/typedoc.ts
@@ -327,6 +327,22 @@ export function addTypeDocOptions(options: Pick<Options, "addDeclaration">) {
             }
         },
     });
+    options.addDeclaration({
+        name: "compilerOptions",
+        help: "Selectively override the TypeScript compiler options used by TypeDoc.",
+        type: ParameterType.Mixed,
+        validate(value) {
+            if (
+                typeof value !== "object" ||
+                Array.isArray(value) ||
+                value == null
+            ) {
+                throw new Error(
+                    "The 'compilerOptions' option must be a non-array object."
+                );
+            }
+        },
+    });
 
     options.addDeclaration({
         name: "treatWarningsAsErrors",

--- a/src/test/utils/options/default-options.test.ts
+++ b/src/test/utils/options/default-options.test.ts
@@ -55,6 +55,14 @@ describe("Default Options", () => {
         });
     });
 
+    describe("compilerOptions", () => {
+        it("Errors if given a non-object", () => {
+            throws(() => opts.setValue("markedOptions", null));
+            throws(() => opts.setValue("markedOptions", "bad"));
+            throws(() => opts.setValue("markedOptions", []));
+        });
+    });
+
     describe("requiredToBeDocumented", () => {
         it("Works with valid values", () => {
             doesNotThrow(() =>


### PR DESCRIPTION
**What this pull request contains**
- full lint/test compliance
- implementation

**What this pull request does**
This pull request implements a new TypeDoc option: `compilerOptions`. By employing this option, one may selectively override some fields of the `tsconfig.json` used by TypeDoc.

**An example**
Let's take the following (trimmed-down) `tsconfig.json`:
```json
{
  "compilerOptions": {
    // Enforce strictness
    "noUnusedLocals": true,
    "noUnusedParameters": true,
    "strict": true,
  },

  "typedocOptions": {
    // Abandon strictness
    "compilerOptions": {
      "noUnusedLocals": false,
      "noUnusedParameters": false,
      "strict": false
    }
  }
}
```
With this configuration, TypeScript `strict`ness will be enforced throughout the codebase. But when running `typedoc`, the strictness will be dropped by patching the original `compilerOptions` with the provided `typedocOptions.compilerOptions`.

**Motivation**
When working with abstracted TypeScript tooling (e.g. not using `tsc` directly, but [`rollup-plugin-typescript2`](https://www.npmjs.com/package/rollup-plugin-typescript2)), the handling and transpilation of source code within a project may differ between those abstracted tools and `tsc` (and therefore TypeDoc). Allowing the user to override parts of the `tsconfig.json` for TypeDoc from within *the same* `tsconfig.json` seems to be a quite well scoped way to tackle these differences (without throwing yet another `tsconfig.typedoc.json` into the project and polluting the scene further).

**Real world motivation**
As an anecdotic example, I recently added a library to a project I'm currently working on and everything went well. Until I tried to build the documentation for said project. ... Because the libary distributes TypeScript source files instead of declaration files (`.ts` instead of `.d.ts`) the `--skipLibCheck` option of TypeScript does not catch those files and `tsc` keeps insisting on type-checking those sources within the `node_modules` folder, which throw errors. And as the library was built without having the TypeScript `strict`-mode enabled, I now cannot get `tsc` to run on my project anymore, while `rollup-plugin-typescript2` happily transpiles my codebase and creates valid TypeScript definitions. To stress this, there are many, many examples of other people having the same issue and trying to get the TypeScript maintainers to implement a way around such behavior:
- https://github.com/microsoft/TypeScript/issues/19573
- https://github.com/microsoft/TypeScript/issues/40426
- https://github.com/microsoft/TypeScript/issues/41883

Meanwhile, Deno even implemented a [CLI flag](https://deno.com/blog/v1.17#--no-checkremote-flag) for exactly this.

**Full disclosure**
I know, I know, I could just create something like `tsconfig.typedoc.json` and manually override my desired preferences within this extending TypeScript configuration file. But, as stated above, I _really_ don't like to clutter up my repository with "unnecessary" files. And to me it feels like a good practice to have the TypeScript configuration, the `typedocOptions` and the `compilerOptions` overrides all in one place: A single `tsconfig.json`! :smile: