### PR TITLE
Fix recursive visitor in order to call intersection callback

### DIFF
--- a/src/lib/models/types.ts
+++ b/src/lib/models/types.ts
@@ -89,6 +89,7 @@ export function makeRecursiveVisitor(
             visitor.inferred?.(type);
         },
         intersection(type) {
+            visitor.intersection?.(type);
             type.types.forEach((t) => t.visit(recursiveVisitor));
         },
         intrinsic(type) {


### PR DESCRIPTION
Hi 

While using `makeRecursiveVisitor`, I noticed the `intersection` callback wasn't called as expected.
This PR fixes the problem.

Cheers.