### PR TITLE
Support enum-like objects with numeric literal values

### DIFF
--- a/example/src/enums.ts
+++ b/example/src/enums.ts
@@ -51,3 +51,27 @@ export const EnumLikeObject = {
 
     Completed: "completed",
 } as const;
+
+/**
+ * Since TypeScript's `enum` can be inconvenient to work with, some packages define their own enum-like objects:
+ *
+ * ```
+ * export const EnumLikeObjectNumValues = {
+ *     Pending: 1,
+ *     InProgress: 2,
+ *     Completed: 3
+ * } as const
+ * ```
+ *
+ * Use the `@enum` tag to make TypeDoc document this object as an enum.
+ *
+ * @enum
+ */
+export const EnumLikeObjectNumValues = {
+    Pending: 1,
+
+    /** Indicates that a courier is en route delivering this order. */
+    InProgress: 2,
+
+    Completed: 3,
+} as const;

--- a/src/lib/converter/symbols.ts
+++ b/src/lib/converter/symbols.ts
@@ -881,7 +881,7 @@ function isEnumLike(checker: ts.TypeChecker, type: ts.Type, location: ts.Node) {
 
     return type.getProperties().every((prop) => {
         const propType = checker.getTypeOfSymbolAtLocation(prop, location);
-        return propType.isStringLiteral();
+        return propType.isStringLiteral() || propType.isNumberLiteral();
     });
 }
 
@@ -912,7 +912,7 @@ function convertVariableAsEnum(
             prop,
             declaration
         );
-        assert(propType.isStringLiteral());
+        assert(propType.isStringLiteral() || propType.isNumberLiteral());
 
         reflection.defaultValue = JSON.stringify(propType.value);
 

--- a/src/test/behaviorTests.ts
+++ b/src/test/behaviorTests.ts
@@ -39,6 +39,44 @@ export const behaviorTests: Record<
 
         const WithoutReadonly = query(project, "WithoutReadonly");
         equal(WithoutReadonly.kind, ReflectionKind.Enum, "WithoutReadonly");
+
+        const SomeEnumLikeNumeric = query(project, "SomeEnumLikeNumeric");
+        equal(
+            SomeEnumLikeNumeric.kind,
+            ReflectionKind.Variable,
+            "SomeEnumLikeNumeric"
+        );
+        const SomeEnumLikeTaggedNumeric = query(
+            project,
+            "SomeEnumLikeTaggedNumeric"
+        );
+        equal(
+            SomeEnumLikeTaggedNumeric.kind,
+            ReflectionKind.Enum,
+            "SomeEnumLikeTaggedNumeric"
+        );
+        const B = query(project, "SomeEnumLikeTaggedNumeric.b");
+        equal(B.defaultValue, "1");
+
+        const ManualEnumNumeric = query(project, "ManualEnumNumeric");
+        equal(ManualEnumNumeric.kind, ReflectionKind.Enum, "ManualEnumNumeric");
+
+        const ManualWithoutHelperNumeric = query(
+            project,
+            "ManualEnumHelperNumeric"
+        );
+        equal(
+            ManualWithoutHelperNumeric.kind,
+            ReflectionKind.Enum,
+            "ManualEnumHelperNumeric"
+        );
+
+        const WithoutReadonlyNumeric = query(project, "WithoutReadonlyNumeric");
+        equal(
+            WithoutReadonlyNumeric.kind,
+            ReflectionKind.Enum,
+            "WithoutReadonlyNumeric"
+        );
     },
     duplicateHeritageClauses(project) {
         const b = query(project, "B");

--- a/src/test/converter2/behavior/asConstEnum.ts
+++ b/src/test/converter2/behavior/asConstEnum.ts
@@ -1,3 +1,5 @@
+/* Enum-like objects with string literal values */
+
 export const SomeEnumLike = {
     a: "a",
     b: "b",
@@ -23,3 +25,31 @@ export const ManualEnumHelper: Readonly<{ a: "a" }> = {
 export const WithoutReadonly = {
     a: "a",
 } as { a: "a" };
+
+/* Enum-like objects with numeric literal values */
+
+export const SomeEnumLikeNumeric = {
+    a: 0,
+    b: 1,
+} as const;
+
+/** @enum */
+export const SomeEnumLikeTaggedNumeric = {
+    a: 0,
+    b: 1,
+} as const;
+
+/** @enum */
+export const ManualEnumNumeric: { readonly a: 0 } = {
+    a: 0,
+};
+
+/** @enum */
+export const ManualEnumHelperNumeric: Readonly<{ a: 0 }> = {
+    a: 0,
+};
+
+/** @enum */
+export const WithoutReadonlyNumeric = {
+    a: 0,
+} as { a: 0 };


### PR DESCRIPTION
TypeDoc already supports enum-like objects with string literal values
via #1675 and #1740. Enum-like objects with numeric literal values
should also be supported, as they are a popular choice for developers
wishing to avoid use of TypeScript enums.

This PR adds support for such objects. Tests and a new example have
been added to cover this type of object.

Resolves #1918.