### PR TITLE
Support TypeScript 4.7

### DIFF
--- a/.config/.prettierignore
+++ b/.config/.prettierignore
@@ -11,3 +11,4 @@
 
 # Turn this back on once supported by Prettier
 ../src/test/converter2/behavior/instantiationExpressions.ts
+../src/test/converter/types/general.ts

--- a/.config/.prettierignore
+++ b/.config/.prettierignore
@@ -8,3 +8,6 @@
 ../src/test/renderer/testProject
 ../static/main.js
 ../example/docs/
+
+# Turn this back on once supported by Prettier
+../src/test/converter2/behavior/instantiationExpressions.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+### Features
+
+-   Added support for TypeScript 4.7, #1935.
+
+### Bug Fixes
+
+-   Fixed invalid type output in some uncommon edge cases, TypeDoc also now renders fewer superfluous parenthesis when creating types.
+
 ## v0.22.15 (2022-04-10)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.22.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "glob": "^7.2.0",
+        "glob": "^8.0.3",
         "lunr": "^2.3.9",
         "marked": "^4.0.16",
         "minimatch": "^5.1.0",
@@ -1817,7 +1817,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
@@ -2013,6 +2014,26 @@
       },
       "engines": {
         "node": ">= 4.0"
+      }
+    },
+    "node_modules/cpx/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cpx/node_modules/glob-parent": {
@@ -4008,19 +4029,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4079,26 +4099,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/glob2base": {
@@ -6096,6 +6096,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/nyc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/nyc/node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -6124,6 +6134,38 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/nyc/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nyc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/nyc/node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -6698,6 +6740,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7379,6 +7422,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/reg-suit-util/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/reg-suit-util/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7412,6 +7465,38 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/reg-suit-util/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/reg-suit-util/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/reg-suit-util/node_modules/mkdirp": {
       "version": "1.0.4",
@@ -7697,6 +7782,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/run-async": {
@@ -8439,6 +8566,26 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
@@ -10591,7 +10738,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -10754,6 +10902,20 @@
           "requires": {
             "bindings": "^1.5.0",
             "nan": "^2.12.1"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-parent": {
@@ -12195,35 +12357,15 @@
       }
     },
     "glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       }
     },
     "glob-base": {
@@ -13757,6 +13899,16 @@
             "color-convert": "^2.0.1"
           }
         },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -13782,6 +13934,29 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -14213,7 +14388,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -14762,6 +14938,16 @@
             "color-convert": "^2.0.1"
           }
         },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -14786,6 +14972,29 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "mkdirp": {
           "version": "1.0.4",
@@ -14973,6 +15182,41 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "run-async": {
@@ -15559,6 +15803,20 @@
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.12",
-        "minimatch": "^5.0.1",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       },
       "bin": {
@@ -23,12 +23,12 @@
         "@types/lunr": "^2.3.4",
         "@types/marked": "^4.0.3",
         "@types/minimatch": "3.0.5",
-        "@types/mocha": "^9.1.0",
-        "@types/node": "^17.0.23",
-        "@typescript-eslint/eslint-plugin": "^5.18.0",
-        "@typescript-eslint/parser": "^5.18.0",
-        "esbuild": "^0.14.34",
-        "eslint": "^8.13.0",
+        "@types/mocha": "^9.1.1",
+        "@types/node": "^17.0.35",
+        "@typescript-eslint/eslint-plugin": "^5.26.0",
+        "@typescript-eslint/parser": "^5.26.0",
+        "esbuild": "^0.14.39",
+        "eslint": "^8.16.0",
         "mocha": "^9.2.1",
         "nyc": "^15.1.0",
         "prettier": "2.6.2",
@@ -37,14 +37,14 @@
         "reg-suit": "^0.11.1",
         "reg-suit-core": "^0.11.1",
         "reg-suit-interface": "^0.11.0",
-        "ts-node": "^10.7.0",
-        "typescript": "^4.6.3"
+        "ts-node": "^10.8.0",
+        "typescript": "^4.7.2"
       },
       "engines": {
         "node": ">= 12.10.0"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -297,41 +297,32 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
-        "globals": "^13.9.0",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -355,9 +346,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -470,6 +461,31 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -621,15 +637,15 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
       "dev": true
     },
     "node_modules/@types/pixelmatch": {
@@ -670,19 +686,19 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.18.0.tgz",
-      "integrity": "sha512-tzrmdGMJI/uii9/V6lurMo4/o+dMTKDH82LkNjhJ3adCW22YQydoRs5MwTiqxGF9CSYxPxQ7EYb4jLNlIs+E+A==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
+      "integrity": "sha512-oGCmo0PqnRZZndr+KwvvAUvD3kNE4AfyoGCwOZpoCncSh4MVD06JTE8XQa2u9u+NX5CsyZMBTEc2C72zx38eYA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.18.0",
-        "@typescript-eslint/type-utils": "5.18.0",
-        "@typescript-eslint/utils": "5.18.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/type-utils": "5.26.0",
+        "@typescript-eslint/utils": "5.26.0",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -702,16 +718,33 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.18.0.tgz",
-      "integrity": "sha512-+08nYfurBzSSPndngnHvFw/fniWYJ5ymOrn/63oMIbgomVQOvIDhBoJmYZ9lwQOCnQV9xHGvf88ze3jFGUYooQ==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.18.0",
-        "@typescript-eslint/types": "5.18.0",
-        "@typescript-eslint/typescript-estree": "5.18.0",
-        "debug": "^4.3.2"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.26.0.tgz",
+      "integrity": "sha512-n/IzU87ttzIdnAH5vQ4BBDnLPly7rC5VnjN3m0xBG82HK6rhRxnCb3w/GyWbNDghPd+NktJqB/wl6+YkzZ5T5Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/typescript-estree": "5.26.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -729,14 +762,31 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.18.0.tgz",
-      "integrity": "sha512-C0CZML6NyRDj+ZbMqh9FnPscg2PrzSaVQg3IpTmpe0NURMVBXlghGZgMYqBw07YW73i0MCqSDqv2SbywnCS8jQ==",
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.18.0",
-        "@typescript-eslint/visitor-keys": "5.18.0"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
+      "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/visitor-keys": "5.26.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -747,13 +797,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.18.0.tgz",
-      "integrity": "sha512-vcn9/6J5D6jtHxpEJrgK8FhaM8r6J1/ZiNu70ZUJN554Y3D9t3iovi6u7JF8l/e7FcBIxeuTEidZDR70UuCIfA==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.26.0.tgz",
+      "integrity": "sha512-7ccbUVWGLmcRDSA1+ADkDBl5fP87EJt0fnijsMFTVHXKGduYMgienC/i3QwoVhDADUAPoytgjbZbCOMj4TY55A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.18.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.26.0",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -772,10 +822,27 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.18.0.tgz",
-      "integrity": "sha512-bhV1+XjM+9bHMTmXi46p1Led5NP6iqQcsOxgx7fvk6gGiV48c6IynY0apQb7693twJDsXiVzNXTflhplmaiJaw==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
+      "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -786,17 +853,17 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.18.0.tgz",
-      "integrity": "sha512-wa+2VAhOPpZs1bVij9e5gyVu60ReMi/KuOx4LKjGx2Y3XTNUDJgQ+5f77D49pHtqef/klglf+mibuHs9TrPxdQ==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.26.0.tgz",
+      "integrity": "sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.18.0",
-        "@typescript-eslint/visitor-keys": "5.18.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/visitor-keys": "5.26.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -812,16 +879,33 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.18.0.tgz",
-      "integrity": "sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.26.0.tgz",
+      "integrity": "sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.18.0",
-        "@typescript-eslint/types": "5.18.0",
-        "@typescript-eslint/typescript-estree": "5.18.0",
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/typescript-estree": "5.26.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -837,13 +921,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.18.0.tgz",
-      "integrity": "sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
+      "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.18.0",
-        "eslint-visitor-keys": "^3.0.0"
+        "@typescript-eslint/types": "5.26.0",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -860,9 +944,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2665,9 +2749,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.34.tgz",
-      "integrity": "sha512-QIWdPT/gFF6hCaf4m7kP0cJ+JIuFkdHibI7vVFvu3eJS1HpVmYHWDulyN5WXwbRA0SX/7ZDaJ/1DH8SdY9xOJg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
+      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2677,32 +2761,32 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.34",
-        "esbuild-android-arm64": "0.14.34",
-        "esbuild-darwin-64": "0.14.34",
-        "esbuild-darwin-arm64": "0.14.34",
-        "esbuild-freebsd-64": "0.14.34",
-        "esbuild-freebsd-arm64": "0.14.34",
-        "esbuild-linux-32": "0.14.34",
-        "esbuild-linux-64": "0.14.34",
-        "esbuild-linux-arm": "0.14.34",
-        "esbuild-linux-arm64": "0.14.34",
-        "esbuild-linux-mips64le": "0.14.34",
-        "esbuild-linux-ppc64le": "0.14.34",
-        "esbuild-linux-riscv64": "0.14.34",
-        "esbuild-linux-s390x": "0.14.34",
-        "esbuild-netbsd-64": "0.14.34",
-        "esbuild-openbsd-64": "0.14.34",
-        "esbuild-sunos-64": "0.14.34",
-        "esbuild-windows-32": "0.14.34",
-        "esbuild-windows-64": "0.14.34",
-        "esbuild-windows-arm64": "0.14.34"
+        "esbuild-android-64": "0.14.39",
+        "esbuild-android-arm64": "0.14.39",
+        "esbuild-darwin-64": "0.14.39",
+        "esbuild-darwin-arm64": "0.14.39",
+        "esbuild-freebsd-64": "0.14.39",
+        "esbuild-freebsd-arm64": "0.14.39",
+        "esbuild-linux-32": "0.14.39",
+        "esbuild-linux-64": "0.14.39",
+        "esbuild-linux-arm": "0.14.39",
+        "esbuild-linux-arm64": "0.14.39",
+        "esbuild-linux-mips64le": "0.14.39",
+        "esbuild-linux-ppc64le": "0.14.39",
+        "esbuild-linux-riscv64": "0.14.39",
+        "esbuild-linux-s390x": "0.14.39",
+        "esbuild-netbsd-64": "0.14.39",
+        "esbuild-openbsd-64": "0.14.39",
+        "esbuild-sunos-64": "0.14.39",
+        "esbuild-windows-32": "0.14.39",
+        "esbuild-windows-64": "0.14.39",
+        "esbuild-windows-arm64": "0.14.39"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.34.tgz",
-      "integrity": "sha512-XfxcfJqmMYsT/LXqrptzFxmaR3GWzXHDLdFNIhm6S00zPaQF1TBBWm+9t0RZ6LRR7iwH57DPjaOeW20vMqI4Yw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
+      "integrity": "sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==",
       "cpu": [
         "x64"
       ],
@@ -2716,9 +2800,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.34.tgz",
-      "integrity": "sha512-T02+NXTmSRL1Mc6puz+R9CB54rSPICkXKq6+tw8B6vxZFnCPzbJxgwIX4kcluz9p8nYBjF3+lSilTGWb7+Xgew==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
+      "integrity": "sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==",
       "cpu": [
         "arm64"
       ],
@@ -2732,9 +2816,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.34.tgz",
-      "integrity": "sha512-pLRip2Bh4Ng7Bf6AMgCrSp3pPe/qZyf11h5Qo2mOfJqLWzSVjxrXW+CFRJfrOVP7TCnh/gmZSM2AFdCPB72vtw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
+      "integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
       "cpu": [
         "x64"
       ],
@@ -2748,9 +2832,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.34.tgz",
-      "integrity": "sha512-vpidSJEBxx6lf1NWgXC+DCmGqesJuZ5Y8aQVVsaoO4i8tRXbXb0whChRvop/zd3nfNM4dIl5EXAky0knRX5I6w==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+      "integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
       "cpu": [
         "arm64"
       ],
@@ -2764,9 +2848,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.34.tgz",
-      "integrity": "sha512-m0HBjePhe0hAQJgtMRMNV9kMgIyV4/qSnzPx42kRMQBcPhgjAq1JRu4Il26czC+9FgpMbFkUktb07f/Lwnc6CA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
+      "integrity": "sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==",
       "cpu": [
         "x64"
       ],
@@ -2780,9 +2864,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.34.tgz",
-      "integrity": "sha512-cpRc2B94L1KvMPPYB4D6G39jLqpKlD3noAMY4/e86iXXXkhUYJJEtTuyNFTa9JRpWM0xCAp4mxjHjoIiLuoCLA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
+      "integrity": "sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==",
       "cpu": [
         "arm64"
       ],
@@ -2796,9 +2880,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.34.tgz",
-      "integrity": "sha512-8nQaEaoW7MH/K/RlozJa+lE1ejHIr8fuPIHhc513UebRav7HtXgQvxHQ6VZRUkWtep23M6dd7UqhwO1tMOfzQQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
+      "integrity": "sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==",
       "cpu": [
         "ia32"
       ],
@@ -2812,9 +2896,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.34.tgz",
-      "integrity": "sha512-Y3of4qQoLLlAgf042MlrY1P+7PnN9zWj8nVtw9XQG5hcLOZLz7IKpU35oeu7n4wvyaZHwvQqDJ93gRLqdJekcQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
+      "integrity": "sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==",
       "cpu": [
         "x64"
       ],
@@ -2828,9 +2912,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.34.tgz",
-      "integrity": "sha512-9lpq1NcJqssAF7alCO6zL3gvBVVt/lKw4oetUM7OgNnRX0OWpB+ZIO9FwCrSj/dMdmgDhPLf+119zB8QxSMmAg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
+      "integrity": "sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==",
       "cpu": [
         "arm"
       ],
@@ -2844,9 +2928,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.34.tgz",
-      "integrity": "sha512-IlWaGtj9ir7+Nrume1DGcyzBDlK8GcnJq0ANKwcI9pVw8tqr+6GD0eqyF9SF1mR8UmAp+odrx1H5NdR2cHdFHA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
+      "integrity": "sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==",
       "cpu": [
         "arm64"
       ],
@@ -2860,9 +2944,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.34.tgz",
-      "integrity": "sha512-k3or+01Rska1AjUyNjA4buEwB51eyN/xPQAoOx1CjzAQC3l8rpjUDw55kXyL63O/1MUi4ISvtNtl8gLwdyEcxw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
+      "integrity": "sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==",
       "cpu": [
         "mips64el"
       ],
@@ -2876,9 +2960,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.34.tgz",
-      "integrity": "sha512-+qxb8M9FfM2CJaVU7GgYpJOHM1ngQOx+/VrtBjb4C8oVqaPcESCeg2anjl+HRZy8VpYc71q/iBYausPPbJ+Keg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
+      "integrity": "sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2892,9 +2976,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.34.tgz",
-      "integrity": "sha512-Y717ltBdQ5j5sZIHdy1DV9kieo0wMip0dCmVSTceowCPYSn1Cg33Kd6981+F/3b9FDMzNWldZFOBRILViENZSA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
+      "integrity": "sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==",
       "cpu": [
         "riscv64"
       ],
@@ -2908,9 +2992,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.34.tgz",
-      "integrity": "sha512-bDDgYO4LhL4+zPs+WcBkXph+AQoPcQRTv18FzZS0WhjfH8TZx2QqlVPGhmhZ6WidrY+jKthUqO6UhGyIb4MpmA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
+      "integrity": "sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==",
       "cpu": [
         "s390x"
       ],
@@ -2924,9 +3008,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.34.tgz",
-      "integrity": "sha512-cfaFGXdRt0+vHsjNPyF0POM4BVSHPSbhLPe8mppDc7GDDxjIl08mV1Zou14oDWMp/XZMjYN1kWYRSfftiD0vvQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
+      "integrity": "sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==",
       "cpu": [
         "x64"
       ],
@@ -2940,9 +3024,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.34.tgz",
-      "integrity": "sha512-vmy9DxXVnRiI14s8GKuYBtess+EVcDALkbpTqd5jw4XITutIzyB7n4x0Tj5utAkKsgZJB22lLWGekr0ABnSLow==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
+      "integrity": "sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==",
       "cpu": [
         "x64"
       ],
@@ -2956,9 +3040,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.34.tgz",
-      "integrity": "sha512-eNPVatNET1F7tRMhii7goL/eptfxc0ALRjrj9SPFNqp0zmxrehBFD6BaP3R4LjMn6DbMO0jOAnTLFKr8NqcJAA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
+      "integrity": "sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==",
       "cpu": [
         "x64"
       ],
@@ -2972,9 +3056,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.34.tgz",
-      "integrity": "sha512-EFhpXyHEcnqWYe2rAHFd8dRw8wkrd9U+9oqcyoEL84GbanAYjiiIjBZsnR8kl0sCQ5w6bLpk7vCEIA2VS32Vcg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
+      "integrity": "sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==",
       "cpu": [
         "ia32"
       ],
@@ -2988,9 +3072,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.34.tgz",
-      "integrity": "sha512-a8fbl8Ky7PxNEjf1aJmtxdDZj32/hC7S1OcA2ckEpCJRTjiKslI9vAdPpSjrKIWhws4Galpaawy0nB7fjHYf5Q==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
+      "integrity": "sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==",
       "cpu": [
         "x64"
       ],
@@ -3004,9 +3088,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.34.tgz",
-      "integrity": "sha512-EYvmKbSa2B3sPnpC28UEu9jBK5atGV4BaVRE7CYGUci2Hlz4AvtV/LML+TcDMT6gBgibnN2gcltWclab3UutMg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
+      "integrity": "sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==",
       "cpu": [
         "arm64"
       ],
@@ -3038,12 +3122,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
-      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.16.0.tgz",
+      "integrity": "sha512-MBndsoXY/PeVTDJeWsYj7kLZ5hQpJOfMYLsF6LicLHQWbRDG19lK5jOix4DPl8yY4SUFcE3txy86OzFLWT+yoA==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.1",
+        "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -3054,14 +3138,14 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -3070,7 +3154,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -3250,9 +3334,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3301,13 +3385,13 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -3541,9 +3625,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3553,7 +3637,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3924,14 +4008,14 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -4039,16 +4123,16 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -5347,6 +5431,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -5413,9 +5509,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
+      "integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5472,13 +5568,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -5515,9 +5611,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5659,6 +5755,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/has-flag": {
@@ -6623,9 +6739,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -7660,9 +7776,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -7673,24 +7789,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -8482,12 +8580,12 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
+      "integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -8498,7 +8596,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
@@ -8609,9 +8707,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8782,9 +8880,9 @@
       "dev": true
     },
     "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/validate-npm-package-license": {
@@ -9000,6 +9098,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -9332,35 +9436,29 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true
-    },
     "@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
-        "globals": "^13.9.0",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
@@ -9381,9 +9479,9 @@
           }
         },
         "globals": {
-          "version": "13.13.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+          "version": "13.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -9471,6 +9569,28 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -9612,15 +9732,15 @@
       }
     },
     "@types/mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
       "dev": true
     },
     "@types/pixelmatch": {
@@ -9661,98 +9781,142 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.18.0.tgz",
-      "integrity": "sha512-tzrmdGMJI/uii9/V6lurMo4/o+dMTKDH82LkNjhJ3adCW22YQydoRs5MwTiqxGF9CSYxPxQ7EYb4jLNlIs+E+A==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
+      "integrity": "sha512-oGCmo0PqnRZZndr+KwvvAUvD3kNE4AfyoGCwOZpoCncSh4MVD06JTE8XQa2u9u+NX5CsyZMBTEc2C72zx38eYA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.18.0",
-        "@typescript-eslint/type-utils": "5.18.0",
-        "@typescript-eslint/utils": "5.18.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/type-utils": "5.26.0",
+        "@typescript-eslint/utils": "5.26.0",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.18.0.tgz",
-      "integrity": "sha512-+08nYfurBzSSPndngnHvFw/fniWYJ5ymOrn/63oMIbgomVQOvIDhBoJmYZ9lwQOCnQV9xHGvf88ze3jFGUYooQ==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.26.0.tgz",
+      "integrity": "sha512-n/IzU87ttzIdnAH5vQ4BBDnLPly7rC5VnjN3m0xBG82HK6rhRxnCb3w/GyWbNDghPd+NktJqB/wl6+YkzZ5T5Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.18.0",
-        "@typescript-eslint/types": "5.18.0",
-        "@typescript-eslint/typescript-estree": "5.18.0",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/typescript-estree": "5.26.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.18.0.tgz",
-      "integrity": "sha512-C0CZML6NyRDj+ZbMqh9FnPscg2PrzSaVQg3IpTmpe0NURMVBXlghGZgMYqBw07YW73i0MCqSDqv2SbywnCS8jQ==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
+      "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.18.0",
-        "@typescript-eslint/visitor-keys": "5.18.0"
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/visitor-keys": "5.26.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.18.0.tgz",
-      "integrity": "sha512-vcn9/6J5D6jtHxpEJrgK8FhaM8r6J1/ZiNu70ZUJN554Y3D9t3iovi6u7JF8l/e7FcBIxeuTEidZDR70UuCIfA==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.26.0.tgz",
+      "integrity": "sha512-7ccbUVWGLmcRDSA1+ADkDBl5fP87EJt0fnijsMFTVHXKGduYMgienC/i3QwoVhDADUAPoytgjbZbCOMj4TY55A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.18.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.26.0",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.18.0.tgz",
-      "integrity": "sha512-bhV1+XjM+9bHMTmXi46p1Led5NP6iqQcsOxgx7fvk6gGiV48c6IynY0apQb7693twJDsXiVzNXTflhplmaiJaw==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
+      "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.18.0.tgz",
-      "integrity": "sha512-wa+2VAhOPpZs1bVij9e5gyVu60ReMi/KuOx4LKjGx2Y3XTNUDJgQ+5f77D49pHtqef/klglf+mibuHs9TrPxdQ==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.26.0.tgz",
+      "integrity": "sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.18.0",
-        "@typescript-eslint/visitor-keys": "5.18.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/visitor-keys": "5.26.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.18.0.tgz",
-      "integrity": "sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.26.0.tgz",
+      "integrity": "sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.18.0",
-        "@typescript-eslint/types": "5.18.0",
-        "@typescript-eslint/typescript-estree": "5.18.0",
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/typescript-estree": "5.26.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.18.0.tgz",
-      "integrity": "sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
+      "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.18.0",
-        "eslint-visitor-keys": "^3.0.0"
+        "@typescript-eslint/types": "5.26.0",
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "@ungap/promise-all-settled": {
@@ -9762,9 +9926,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true
     },
     "acorn-jsx": {
@@ -11188,170 +11352,170 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.34.tgz",
-      "integrity": "sha512-QIWdPT/gFF6hCaf4m7kP0cJ+JIuFkdHibI7vVFvu3eJS1HpVmYHWDulyN5WXwbRA0SX/7ZDaJ/1DH8SdY9xOJg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
+      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
       "dev": true,
       "requires": {
-        "esbuild-android-64": "0.14.34",
-        "esbuild-android-arm64": "0.14.34",
-        "esbuild-darwin-64": "0.14.34",
-        "esbuild-darwin-arm64": "0.14.34",
-        "esbuild-freebsd-64": "0.14.34",
-        "esbuild-freebsd-arm64": "0.14.34",
-        "esbuild-linux-32": "0.14.34",
-        "esbuild-linux-64": "0.14.34",
-        "esbuild-linux-arm": "0.14.34",
-        "esbuild-linux-arm64": "0.14.34",
-        "esbuild-linux-mips64le": "0.14.34",
-        "esbuild-linux-ppc64le": "0.14.34",
-        "esbuild-linux-riscv64": "0.14.34",
-        "esbuild-linux-s390x": "0.14.34",
-        "esbuild-netbsd-64": "0.14.34",
-        "esbuild-openbsd-64": "0.14.34",
-        "esbuild-sunos-64": "0.14.34",
-        "esbuild-windows-32": "0.14.34",
-        "esbuild-windows-64": "0.14.34",
-        "esbuild-windows-arm64": "0.14.34"
+        "esbuild-android-64": "0.14.39",
+        "esbuild-android-arm64": "0.14.39",
+        "esbuild-darwin-64": "0.14.39",
+        "esbuild-darwin-arm64": "0.14.39",
+        "esbuild-freebsd-64": "0.14.39",
+        "esbuild-freebsd-arm64": "0.14.39",
+        "esbuild-linux-32": "0.14.39",
+        "esbuild-linux-64": "0.14.39",
+        "esbuild-linux-arm": "0.14.39",
+        "esbuild-linux-arm64": "0.14.39",
+        "esbuild-linux-mips64le": "0.14.39",
+        "esbuild-linux-ppc64le": "0.14.39",
+        "esbuild-linux-riscv64": "0.14.39",
+        "esbuild-linux-s390x": "0.14.39",
+        "esbuild-netbsd-64": "0.14.39",
+        "esbuild-openbsd-64": "0.14.39",
+        "esbuild-sunos-64": "0.14.39",
+        "esbuild-windows-32": "0.14.39",
+        "esbuild-windows-64": "0.14.39",
+        "esbuild-windows-arm64": "0.14.39"
       }
     },
     "esbuild-android-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.34.tgz",
-      "integrity": "sha512-XfxcfJqmMYsT/LXqrptzFxmaR3GWzXHDLdFNIhm6S00zPaQF1TBBWm+9t0RZ6LRR7iwH57DPjaOeW20vMqI4Yw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
+      "integrity": "sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-android-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.34.tgz",
-      "integrity": "sha512-T02+NXTmSRL1Mc6puz+R9CB54rSPICkXKq6+tw8B6vxZFnCPzbJxgwIX4kcluz9p8nYBjF3+lSilTGWb7+Xgew==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
+      "integrity": "sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.34.tgz",
-      "integrity": "sha512-pLRip2Bh4Ng7Bf6AMgCrSp3pPe/qZyf11h5Qo2mOfJqLWzSVjxrXW+CFRJfrOVP7TCnh/gmZSM2AFdCPB72vtw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
+      "integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.34.tgz",
-      "integrity": "sha512-vpidSJEBxx6lf1NWgXC+DCmGqesJuZ5Y8aQVVsaoO4i8tRXbXb0whChRvop/zd3nfNM4dIl5EXAky0knRX5I6w==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+      "integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.34.tgz",
-      "integrity": "sha512-m0HBjePhe0hAQJgtMRMNV9kMgIyV4/qSnzPx42kRMQBcPhgjAq1JRu4Il26czC+9FgpMbFkUktb07f/Lwnc6CA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
+      "integrity": "sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.34.tgz",
-      "integrity": "sha512-cpRc2B94L1KvMPPYB4D6G39jLqpKlD3noAMY4/e86iXXXkhUYJJEtTuyNFTa9JRpWM0xCAp4mxjHjoIiLuoCLA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
+      "integrity": "sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.34.tgz",
-      "integrity": "sha512-8nQaEaoW7MH/K/RlozJa+lE1ejHIr8fuPIHhc513UebRav7HtXgQvxHQ6VZRUkWtep23M6dd7UqhwO1tMOfzQQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
+      "integrity": "sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.34.tgz",
-      "integrity": "sha512-Y3of4qQoLLlAgf042MlrY1P+7PnN9zWj8nVtw9XQG5hcLOZLz7IKpU35oeu7n4wvyaZHwvQqDJ93gRLqdJekcQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
+      "integrity": "sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.34.tgz",
-      "integrity": "sha512-9lpq1NcJqssAF7alCO6zL3gvBVVt/lKw4oetUM7OgNnRX0OWpB+ZIO9FwCrSj/dMdmgDhPLf+119zB8QxSMmAg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
+      "integrity": "sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.34.tgz",
-      "integrity": "sha512-IlWaGtj9ir7+Nrume1DGcyzBDlK8GcnJq0ANKwcI9pVw8tqr+6GD0eqyF9SF1mR8UmAp+odrx1H5NdR2cHdFHA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
+      "integrity": "sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.34.tgz",
-      "integrity": "sha512-k3or+01Rska1AjUyNjA4buEwB51eyN/xPQAoOx1CjzAQC3l8rpjUDw55kXyL63O/1MUi4ISvtNtl8gLwdyEcxw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
+      "integrity": "sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.34.tgz",
-      "integrity": "sha512-+qxb8M9FfM2CJaVU7GgYpJOHM1ngQOx+/VrtBjb4C8oVqaPcESCeg2anjl+HRZy8VpYc71q/iBYausPPbJ+Keg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
+      "integrity": "sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-riscv64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.34.tgz",
-      "integrity": "sha512-Y717ltBdQ5j5sZIHdy1DV9kieo0wMip0dCmVSTceowCPYSn1Cg33Kd6981+F/3b9FDMzNWldZFOBRILViENZSA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
+      "integrity": "sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.34.tgz",
-      "integrity": "sha512-bDDgYO4LhL4+zPs+WcBkXph+AQoPcQRTv18FzZS0WhjfH8TZx2QqlVPGhmhZ6WidrY+jKthUqO6UhGyIb4MpmA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
+      "integrity": "sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.34.tgz",
-      "integrity": "sha512-cfaFGXdRt0+vHsjNPyF0POM4BVSHPSbhLPe8mppDc7GDDxjIl08mV1Zou14oDWMp/XZMjYN1kWYRSfftiD0vvQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
+      "integrity": "sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==",
       "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.34.tgz",
-      "integrity": "sha512-vmy9DxXVnRiI14s8GKuYBtess+EVcDALkbpTqd5jw4XITutIzyB7n4x0Tj5utAkKsgZJB22lLWGekr0ABnSLow==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
+      "integrity": "sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.34.tgz",
-      "integrity": "sha512-eNPVatNET1F7tRMhii7goL/eptfxc0ALRjrj9SPFNqp0zmxrehBFD6BaP3R4LjMn6DbMO0jOAnTLFKr8NqcJAA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
+      "integrity": "sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.34.tgz",
-      "integrity": "sha512-EFhpXyHEcnqWYe2rAHFd8dRw8wkrd9U+9oqcyoEL84GbanAYjiiIjBZsnR8kl0sCQ5w6bLpk7vCEIA2VS32Vcg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
+      "integrity": "sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.34.tgz",
-      "integrity": "sha512-a8fbl8Ky7PxNEjf1aJmtxdDZj32/hC7S1OcA2ckEpCJRTjiKslI9vAdPpSjrKIWhws4Galpaawy0nB7fjHYf5Q==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
+      "integrity": "sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.34.tgz",
-      "integrity": "sha512-EYvmKbSa2B3sPnpC28UEu9jBK5atGV4BaVRE7CYGUci2Hlz4AvtV/LML+TcDMT6gBgibnN2gcltWclab3UutMg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
+      "integrity": "sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==",
       "dev": true,
       "optional": true
     },
@@ -11368,12 +11532,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
-      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.16.0.tgz",
+      "integrity": "sha512-MBndsoXY/PeVTDJeWsYj7kLZ5hQpJOfMYLsF6LicLHQWbRDG19lK5jOix4DPl8yY4SUFcE3txy86OzFLWT+yoA==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.1",
+        "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -11384,14 +11548,14 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -11400,7 +11564,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -11492,9 +11656,9 @@
           }
         },
         "globals": {
-          "version": "13.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+          "version": "13.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -11560,13 +11724,13 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "requires": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -11744,9 +11908,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -12031,14 +12195,14 @@
       }
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -12123,16 +12287,16 @@
       "dev": true
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
     },
@@ -13096,6 +13260,15 @@
         "signal-exit": "^3.0.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -13146,9 +13319,9 @@
       }
     },
     "marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
+      "integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA=="
     },
     "math-random": {
       "version": "1.0.4",
@@ -13187,13 +13360,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime-db": {
@@ -13218,9 +13391,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }
@@ -13329,6 +13502,20 @@
           "requires": {
             "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -14059,9 +14246,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pify": {
@@ -14834,29 +15021,12 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
       }
     },
     "serialize-javascript": {
@@ -15510,12 +15680,12 @@
       "dev": true
     },
     "ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
+      "integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -15526,7 +15696,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -15601,9 +15771,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true
     },
     "unbox-primitive": {
@@ -15739,9 +15909,9 @@
       "dev": true
     },
     "v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -15911,6 +16081,12 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">= 12.10.0"
   },
   "dependencies": {
-    "glob": "^7.2.0",
+    "glob": "^8.0.3",
     "lunr": "^2.3.9",
     "marked": "^4.0.16",
     "minimatch": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -23,24 +23,24 @@
   "dependencies": {
     "glob": "^7.2.0",
     "lunr": "^2.3.9",
-    "marked": "^4.0.12",
-    "minimatch": "^5.0.1",
+    "marked": "^4.0.16",
+    "minimatch": "^5.1.0",
     "shiki": "^0.10.1"
   },
   "peerDependencies": {
-    "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+    "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",
     "@types/lunr": "^2.3.4",
     "@types/marked": "^4.0.3",
     "@types/minimatch": "3.0.5",
-    "@types/mocha": "^9.1.0",
-    "@types/node": "^17.0.23",
-    "@typescript-eslint/eslint-plugin": "^5.18.0",
-    "@typescript-eslint/parser": "^5.18.0",
-    "esbuild": "^0.14.34",
-    "eslint": "^8.13.0",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "^17.0.35",
+    "@typescript-eslint/eslint-plugin": "^5.26.0",
+    "@typescript-eslint/parser": "^5.26.0",
+    "esbuild": "^0.14.39",
+    "eslint": "^8.16.0",
     "mocha": "^9.2.1",
     "nyc": "^15.1.0",
     "prettier": "2.6.2",
@@ -49,8 +49,8 @@
     "reg-suit": "^0.11.1",
     "reg-suit-core": "^0.11.1",
     "reg-suit-interface": "^0.11.0",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.6.3"
+    "ts-node": "^10.8.0",
+    "typescript": "^4.7.2"
   },
   "files": [
     "/bin",

--- a/src/lib/converter/factories/signature.ts
+++ b/src/lib/converter/factories/signature.ts
@@ -10,6 +10,7 @@ import {
     ReflectionKind,
     SignatureReflection,
     TypeParameterReflection,
+    VarianceModifier,
 } from "../../models";
 import type { Context } from "../context";
 import { ConverterEvents } from "../converter-events";
@@ -236,11 +237,20 @@ function convertTypeParameters(
         const defaultType = defaultT
             ? context.converter.convertType(context, defaultT)
             : void 0;
+
+        // There's no way to determine directly from a ts.TypeParameter what it's variance modifiers are
+        // so unfortunately we have to go back to the node for this...
+        const variance = getVariance(
+            param.getSymbol()?.declarations?.find(ts.isTypeParameterDeclaration)
+                ?.modifiers
+        );
+
         const paramRefl = new TypeParameterReflection(
             param.symbol.name,
             constraint,
             defaultType,
-            parent
+            parent,
+            variance
         );
         context.registerReflection(paramRefl, param.getSymbol());
         context.trigger(ConverterEvents.CREATE_TYPE_PARAMETER, paramRefl);
@@ -253,28 +263,54 @@ export function convertTypeParameterNodes(
     context: Context,
     parameters: readonly ts.TypeParameterDeclaration[] | undefined
 ) {
-    return parameters?.map((param) => {
-        const constraint = param.constraint
-            ? context.converter.convertType(context, param.constraint)
-            : void 0;
-        const defaultType = param.default
-            ? context.converter.convertType(context, param.default)
-            : void 0;
-        const paramRefl = new TypeParameterReflection(
-            param.name.text,
-            constraint,
-            defaultType,
-            context.scope
-        );
-        context.registerReflection(paramRefl, param.symbol);
-        context.trigger(
-            ConverterEvents.CREATE_TYPE_PARAMETER,
-            paramRefl,
-            param
-        );
+    return parameters?.map((param) =>
+        createTypeParamReflection(param, context)
+    );
+}
 
-        return paramRefl;
-    });
+export function createTypeParamReflection(
+    param: ts.TypeParameterDeclaration,
+    context: Context
+) {
+    const constraint = param.constraint
+        ? context.converter.convertType(context, param.constraint)
+        : void 0;
+    const defaultType = param.default
+        ? context.converter.convertType(context, param.default)
+        : void 0;
+    const paramRefl = new TypeParameterReflection(
+        param.name.text,
+        constraint,
+        defaultType,
+        context.scope,
+        getVariance(param.modifiers)
+    );
+    context.registerReflection(paramRefl, param.symbol);
+    context.trigger(ConverterEvents.CREATE_TYPE_PARAMETER, paramRefl, param);
+    return paramRefl;
+}
+
+function getVariance(
+    modifiers: ts.ModifiersArray | undefined
+): VarianceModifier | undefined {
+    const hasIn = modifiers?.some(
+        (mod) => mod.kind === ts.SyntaxKind.InKeyword
+    );
+    const hasOut = modifiers?.some(
+        (mod) => mod.kind === ts.SyntaxKind.OutKeyword
+    );
+
+    if (hasIn && hasOut) {
+        return VarianceModifier.inOut;
+    }
+
+    if (hasIn) {
+        return VarianceModifier.in;
+    }
+
+    if (hasOut) {
+        return VarianceModifier.out;
+    }
 }
 
 function convertPredicate(

--- a/src/lib/converter/symbols.ts
+++ b/src/lib/converter/symbols.ts
@@ -6,7 +6,6 @@ import {
     Reflection,
     ReflectionFlag,
     ReflectionKind,
-    TypeParameterReflection,
 } from "../models";
 import {
     getEnumFlags,
@@ -18,7 +17,10 @@ import type { Context } from "./context";
 import { convertDefaultValue } from "./convert-expression";
 import { ConverterEvents } from "./converter-events";
 import { convertIndexSignature } from "./factories/index-signature";
-import { createSignature } from "./factories/signature";
+import {
+    createSignature,
+    createTypeParamReflection,
+} from "./factories/signature";
 import { convertJsDocAlias, convertJsDocCallback } from "./jsdoc";
 import { getHeritageTypes } from "./utils/nodes";
 import { removeUndefined } from "./utils/reflections";
@@ -338,27 +340,6 @@ function convertTypeAlias(
     } else {
         convertJsDocCallback(context, symbol, declaration, exportSymbol);
     }
-}
-
-function createTypeParamReflection(
-    param: ts.TypeParameterDeclaration,
-    context: Context
-) {
-    const constraint = param.constraint
-        ? context.converter.convertType(context, param.constraint)
-        : void 0;
-    const defaultType = param.default
-        ? context.converter.convertType(context, param.default)
-        : void 0;
-    const paramRefl = new TypeParameterReflection(
-        param.name.text,
-        constraint,
-        defaultType,
-        context.scope
-    );
-    context.registerReflection(paramRefl, param.symbol);
-    context.trigger(ConverterEvents.CREATE_TYPE_PARAMETER, paramRefl, param);
-    return paramRefl;
 }
 
 function convertFunctionOrMethod(

--- a/src/lib/converter/types.ts
+++ b/src/lib/converter/types.ts
@@ -102,6 +102,17 @@ export function loadConverters() {
 // typed symbols which do not have type nodes. See the `recursive` symbol in the variables test.
 const seenTypeSymbols = new Set<ts.Symbol>();
 
+function maybeConvertType(
+    context: Context,
+    typeOrNode: ts.Type | ts.TypeNode | undefined
+): SomeType | undefined {
+    if (!typeOrNode) {
+        return;
+    }
+
+    return convertType(context, typeOrNode);
+}
+
 export function convertType(
     context: Context,
     typeOrNode: ts.Type | ts.TypeNode | undefined
@@ -399,11 +410,17 @@ const indexedAccessConverter: TypeConverter<
 
 const inferredConverter: TypeConverter<ts.InferTypeNode> = {
     kind: [ts.SyntaxKind.InferType],
-    convert(_context, node) {
-        return new InferredType(node.typeParameter.getText());
+    convert(context, node) {
+        return new InferredType(
+            node.typeParameter.name.text,
+            maybeConvertType(context, node.typeParameter.constraint)
+        );
     },
-    convertType(_context, type) {
-        return new InferredType(type.symbol.name);
+    convertType(context, type) {
+        return new InferredType(
+            type.symbol.name,
+            maybeConvertType(context, type.getConstraint())
+        );
     },
 };
 

--- a/src/lib/models/reflections/index.ts
+++ b/src/lib/models/reflections/index.ts
@@ -13,5 +13,5 @@ export { ParameterReflection } from "./parameter";
 export { ProjectReflection } from "./project";
 export { ReferenceReflection } from "./reference";
 export { SignatureReflection } from "./signature";
-export { TypeParameterReflection } from "./type-parameter";
+export { TypeParameterReflection, VarianceModifier } from "./type-parameter";
 export { splitUnquotedString } from "./utils";

--- a/src/lib/models/reflections/type-parameter.ts
+++ b/src/lib/models/reflections/type-parameter.ts
@@ -3,6 +3,18 @@ import { Reflection } from "./abstract";
 import type { DeclarationReflection } from "./declaration";
 import { ReflectionKind } from "./kind";
 
+/**
+ * Modifier flags for type parameters, added in TS 4.7
+ * @enum
+ */
+export const VarianceModifier = {
+    in: "in",
+    out: "out",
+    inOut: "in out",
+} as const;
+export type VarianceModifier =
+    typeof VarianceModifier[keyof typeof VarianceModifier];
+
 export class TypeParameterReflection extends Reflection {
     override parent?: DeclarationReflection;
 
@@ -10,17 +22,18 @@ export class TypeParameterReflection extends Reflection {
 
     default?: Type;
 
-    /**
-     * Create a new TypeParameterReflection instance.
-     */
+    varianceModifier?: VarianceModifier;
+
     constructor(
         name: string,
-        constraint?: Type,
-        defaultType?: Type,
-        parent?: Reflection
+        constraint: Type | undefined,
+        defaultType: Type | undefined,
+        parent: Reflection,
+        varianceModifier: VarianceModifier | undefined
     ) {
         super(name, ReflectionKind.TypeParameter, parent);
         this.type = constraint;
         this.default = defaultType;
+        this.varianceModifier = varianceModifier;
     }
 }

--- a/src/lib/models/types.ts
+++ b/src/lib/models/types.ts
@@ -270,11 +270,14 @@ export class IndexedAccessType extends Type {
 export class InferredType extends Type {
     override readonly type = "inferred";
 
-    constructor(public name: string) {
+    constructor(public name: string, public constraint?: SomeType) {
         super();
     }
 
     override toString() {
+        if (this.constraint) {
+            return `infer ${this.name} extends ${this.constraint}`;
+        }
         return `infer ${this.name}`;
     }
 }

--- a/src/lib/models/types.ts
+++ b/src/lib/models/types.ts
@@ -16,7 +16,9 @@ export abstract class Type {
     /**
      * Return a string representation of this type.
      */
-    abstract toString(): string;
+    toString(): string {
+        return this.stringify(TypeContext.none);
+    }
 
     /**
      * Visit this type, returning the value returned by the visitor.
@@ -26,6 +28,21 @@ export abstract class Type {
     visit(visitor: Partial<TypeVisitor<unknown>>): unknown {
         return visitor[this.type]?.(this as never);
     }
+
+    stringify(context: TypeContext) {
+        if (this.needsParenthesis(context)) {
+            return `(${this.getTypeString()})`;
+        }
+        return this.getTypeString();
+    }
+
+    abstract needsParenthesis(context: TypeContext): boolean;
+
+    /**
+     * Implementation method for `toString`. `needsParenthesis` will be used to determine if
+     * the returned string should be wrapped in parenthesis.
+     */
+    protected abstract getTypeString(): string;
 }
 
 export interface TypeKindMap {
@@ -87,6 +104,7 @@ export function makeRecursiveVisitor(
         },
         inferred(type) {
             visitor.inferred?.(type);
+            type.constraint?.visit(recursiveVisitor);
         },
         intersection(type) {
             visitor.intersection?.(type);
@@ -152,41 +170,37 @@ export type TypeKind = keyof TypeKindMap;
 
 export type SomeType = TypeKindMap[keyof TypeKindMap];
 
-// A lower binding power means that if contained within a type
-// with a higher binding power the type must be parenthesized.
-// 999 = never have parenthesis
-// -1 = always have parenthesis
-const BINDING_POWERS = {
-    array: 999,
-    conditional: 70,
-    conditionalCheckType: 150,
-    indexedAccess: 999,
-    inferred: 999,
-    intersection: 120,
-    intrinsic: 999,
-    literal: 999,
-    mapped: 999,
-    optional: 999,
-    predicate: 999,
-    query: 900,
-    reference: 999,
-    reflection: 999,
-    rest: 999,
-    "template-literal": 999,
-    tuple: 999,
-    "named-tuple-member": 999,
-    typeOperator: 900,
-    union: 100,
-    // We should always wrap these in parenthesis since we don't know what they contain.
-    unknown: -1,
-};
-
-function wrap(type: Type, bp: number) {
-    if (BINDING_POWERS[type.type] < bp) {
-        return `(${type})`;
-    }
-    return type.toString();
-}
+/**
+ * Enumeration that can be used when traversing types to track the location of recursion.
+ * Used by TypeDoc internally to track when to output parenthesis when rendering.
+ * @enum
+ */
+export const TypeContext = {
+    none: "none",
+    templateLiteralElement: "templateLiteralElement", // `${here}`
+    arrayElement: "arrayElement", // here[]
+    indexedAccessElement: "indexedAccessElement", // {}[here]
+    conditionalCheck: "conditionalCheck", // here extends 1 ? 2 : 3
+    conditionalExtends: "conditionalExtends", // 1 extends here ? 2 : 3
+    conditionalTrue: "conditionalTrue", // 1 extends 2 ? here : 3
+    conditionalFalse: "conditionalFalse", // 1 extends 2 ? 3 : here
+    indexedIndex: "indexedIndex", // {}[here]
+    indexedObject: "indexedObject", // here[1]
+    inferredConstraint: "inferredConstraint", // 1 extends infer X extends here ? 1 : 2
+    intersectionElement: "intersectionElement", // here & 1
+    mappedName: "mappedName", // { [k in string as here]: 1 }
+    mappedParameter: "mappedParameter", // { [k in here]: 1 }
+    mappedTemplate: "mappedTemplate", // { [k in string]: here }
+    optionalElement: "optionalElement", // [here?]
+    predicateTarget: "predicateTarget", // (): X is here
+    queryTypeTarget: "queryTypeTarget", // typeof here, can only ever be a ReferenceType
+    typeOperatorTarget: "typeOperatorTarget", // keyof here
+    referenceTypeArgument: "referenceTypeArgument", // X<here>
+    restElement: "restElement", // [...here]
+    tupleElement: "tupleElement", // [here]
+    unionElement: "unionElement", // here | 1
+} as const;
+export type TypeContext = typeof TypeContext[keyof typeof TypeContext];
 
 /**
  * Represents an array type.
@@ -208,8 +222,12 @@ export class ArrayType extends Type {
         this.elementType = elementType;
     }
 
-    override toString() {
-        return wrap(this.elementType, BINDING_POWERS.array) + "[]";
+    protected override getTypeString() {
+        return this.elementType.stringify(TypeContext.arrayElement) + "[]";
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -232,16 +250,46 @@ export class ConditionalType extends Type {
         super();
     }
 
-    override toString() {
+    protected override getTypeString() {
         return [
-            wrap(this.checkType, BINDING_POWERS.conditionalCheckType),
+            this.checkType.stringify(TypeContext.conditionalCheck),
             "extends",
-            this.extendsType, // no need to wrap
+            this.extendsType.stringify(TypeContext.conditionalExtends),
             "?",
-            this.trueType, // no need to wrap
+            this.trueType.stringify(TypeContext.conditionalTrue),
             ":",
-            this.falseType, // no need to wrap
+            this.falseType.stringify(TypeContext.conditionalFalse),
         ].join(" ");
+    }
+
+    override needsParenthesis(context: TypeContext): boolean {
+        const map: Record<TypeContext, boolean> = {
+            none: false,
+            templateLiteralElement: false,
+            arrayElement: true,
+            indexedAccessElement: false,
+            conditionalCheck: true,
+            conditionalExtends: true,
+            conditionalTrue: false,
+            conditionalFalse: false,
+            indexedIndex: false,
+            indexedObject: true,
+            inferredConstraint: true,
+            intersectionElement: true,
+            mappedName: false,
+            mappedParameter: false,
+            mappedTemplate: false,
+            optionalElement: true,
+            predicateTarget: false,
+            queryTypeTarget: false,
+            typeOperatorTarget: true,
+            referenceTypeArgument: false,
+            restElement: true,
+            tupleElement: false,
+            unionElement: true,
+        };
+
+        return map[context];
     }
 }
 
@@ -255,8 +303,17 @@ export class IndexedAccessType extends Type {
         super();
     }
 
-    override toString() {
-        return `${this.objectType}[${this.indexType}]`;
+    protected override getTypeString() {
+        return [
+            this.objectType.stringify(TypeContext.indexedObject),
+            "[",
+            this.indexType.stringify(TypeContext.indexedIndex),
+            "]",
+        ].join("");
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -274,11 +331,43 @@ export class InferredType extends Type {
         super();
     }
 
-    override toString() {
+    protected override getTypeString() {
         if (this.constraint) {
-            return `infer ${this.name} extends ${this.constraint}`;
+            return `infer ${this.name} extends ${this.constraint.stringify(
+                TypeContext.inferredConstraint
+            )}`;
         }
         return `infer ${this.name}`;
+    }
+
+    override needsParenthesis(context: TypeContext): boolean {
+        const map: Record<TypeContext, boolean> = {
+            none: false,
+            templateLiteralElement: false,
+            arrayElement: true,
+            indexedAccessElement: false,
+            conditionalCheck: false,
+            conditionalExtends: false,
+            conditionalTrue: false,
+            conditionalFalse: false,
+            indexedIndex: false,
+            indexedObject: true,
+            inferredConstraint: false,
+            intersectionElement: false,
+            mappedName: false,
+            mappedParameter: false,
+            mappedTemplate: false,
+            optionalElement: true,
+            predicateTarget: false,
+            queryTypeTarget: false,
+            typeOperatorTarget: false,
+            referenceTypeArgument: false,
+            restElement: true,
+            tupleElement: false,
+            unionElement: false,
+        };
+
+        return map[context];
     }
 }
 
@@ -296,10 +385,40 @@ export class IntersectionType extends Type {
         super();
     }
 
-    override toString() {
+    protected override getTypeString() {
         return this.types
-            .map((t) => wrap(t, BINDING_POWERS.intersection))
+            .map((t) => t.stringify(TypeContext.intersectionElement))
             .join(" & ");
+    }
+
+    override needsParenthesis(context: TypeContext): boolean {
+        const map: Record<TypeContext, boolean> = {
+            none: false,
+            templateLiteralElement: false,
+            arrayElement: true,
+            indexedAccessElement: false,
+            conditionalCheck: true,
+            conditionalExtends: false,
+            conditionalTrue: false,
+            conditionalFalse: false,
+            indexedIndex: false,
+            indexedObject: true,
+            inferredConstraint: false,
+            intersectionElement: false,
+            mappedName: false,
+            mappedParameter: false,
+            mappedTemplate: false,
+            optionalElement: true,
+            predicateTarget: false,
+            queryTypeTarget: false,
+            typeOperatorTarget: true,
+            referenceTypeArgument: false,
+            restElement: true,
+            tupleElement: false,
+            unionElement: false,
+        };
+
+        return map[context];
     }
 }
 
@@ -317,8 +436,12 @@ export class IntrinsicType extends Type {
         super();
     }
 
-    override toString() {
+    protected override getTypeString() {
         return this.name;
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -340,11 +463,15 @@ export class LiteralType extends Type {
     /**
      * Return a string representation of this type.
      */
-    override toString(): string {
+    protected override getTypeString(): string {
         if (typeof this.value === "bigint") {
             return this.value.toString() + "n";
         }
         return JSON.stringify(this.value);
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -352,7 +479,7 @@ export class LiteralType extends Type {
  * Represents a mapped type.
  *
  * ```ts
- * { -readonly [K in keyof U & string as `a${K}`]?: Foo }
+ * { -readonly [K in Parameter as Name]?: Template }
  * ```
  */
 export class MappedType extends Type {
@@ -369,7 +496,7 @@ export class MappedType extends Type {
         super();
     }
 
-    override toString(): string {
+    protected override getTypeString(): string {
         const read = {
             "+": "readonly ",
             "-": "-readonly ",
@@ -382,9 +509,31 @@ export class MappedType extends Type {
             "": "",
         }[this.optionalModifier ?? ""];
 
-        const name = this.nameType ? ` as ${this.nameType}` : "";
+        const parts = [
+            "{ ",
+            read,
+            "[",
+            this.parameter,
+            " in ",
+            this.parameterType.stringify(TypeContext.mappedParameter),
+        ];
 
-        return `{ ${read}[${this.parameter} in ${this.parameterType}${name}]${opt}: ${this.templateType} }`;
+        if (this.nameType) {
+            parts.push(" as ", this.nameType.stringify(TypeContext.mappedName));
+        }
+
+        parts.push(
+            "]",
+            opt,
+            ": ",
+            this.templateType.stringify(TypeContext.mappedTemplate),
+            " }"
+        );
+        return parts.join("");
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -405,8 +554,12 @@ export class OptionalType extends Type {
         this.elementType = elementType;
     }
 
-    override toString() {
-        return wrap(this.elementType, BINDING_POWERS.optional) + "?";
+    protected override getTypeString() {
+        return this.elementType.stringify(TypeContext.optionalElement) + "?";
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -452,13 +605,20 @@ export class PredicateType extends Type {
     /**
      * Return a string representation of this type.
      */
-    override toString() {
+    protected override getTypeString() {
         const out = this.asserts ? ["asserts", this.name] : [this.name];
         if (this.targetType) {
-            out.push("is", this.targetType.toString());
+            out.push(
+                "is",
+                this.targetType.stringify(TypeContext.predicateTarget)
+            );
         }
 
         return out.join(" ");
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -479,8 +639,20 @@ export class QueryType extends Type {
         this.queryType = reference;
     }
 
-    override toString() {
-        return `typeof ${this.queryType.toString()}`;
+    protected override getTypeString() {
+        return `typeof ${this.queryType.stringify(
+            TypeContext.queryTypeTarget
+        )}`;
+    }
+
+    /**
+     * @privateRemarks
+     * An argument could be made that this ought to return true for indexedObject
+     * since precedence is different than on the value side... if someone really cares
+     * they can easily use a custom theme to change this.
+     */
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -616,19 +788,23 @@ export class ReferenceType extends Type {
         return new ReferenceType(name, -1, project);
     }
 
-    override toString() {
+    protected override getTypeString() {
         const name = this.reflection ? this.reflection.name : this.name;
         let typeArgs = "";
 
         if (this.typeArguments && this.typeArguments.length > 0) {
             typeArgs += "<";
             typeArgs += this.typeArguments
-                .map((arg) => arg.toString())
+                .map((arg) => arg.stringify(TypeContext.referenceTypeArgument))
                 .join(", ");
             typeArgs += ">";
         }
 
         return name + typeArgs;
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -652,12 +828,19 @@ export class ReflectionType extends Type {
         this.declaration = declaration;
     }
 
-    override toString() {
+    // This really ought to do better, but I'm putting off investing effort here until
+    // I'm fully convinced that keeping this is a good idea. Currently, I'd much rather
+    // change object types to not create reflections.
+    protected override getTypeString() {
         if (!this.declaration.children && this.declaration.signatures) {
             return "Function";
         } else {
             return "Object";
         }
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -675,8 +858,12 @@ export class RestType extends Type {
         super();
     }
 
-    override toString() {
-        return `...${wrap(this.elementType, BINDING_POWERS.rest)}`;
+    protected override getTypeString() {
+        return `...${this.elementType.stringify(TypeContext.restElement)}`;
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -693,15 +880,24 @@ export class TemplateLiteralType extends Type {
         super();
     }
 
-    override toString() {
+    protected override getTypeString() {
         return [
             "`",
             this.head,
             ...this.tail.map(([type, text]) => {
-                return "${" + type + "}" + text;
+                return (
+                    "${" +
+                    type.stringify(TypeContext.templateLiteralElement) +
+                    "}" +
+                    text
+                );
             }),
             "`",
         ].join("");
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -725,8 +921,18 @@ export class TupleType extends Type {
         this.elements = elements;
     }
 
-    override toString() {
-        return "[" + this.elements.join(", ") + "]";
+    protected override getTypeString() {
+        return (
+            "[" +
+            this.elements
+                .map((t) => t.stringify(TypeContext.tupleElement))
+                .join(", ") +
+            "]"
+        );
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -751,8 +957,14 @@ export class NamedTupleMember extends Type {
     /**
      * Return a string representation of this type.
      */
-    override toString() {
-        return `${this.name}${this.isOptional ? "?" : ""}: ${this.element}`;
+    protected override getTypeString() {
+        return `${this.name}${
+            this.isOptional ? "?" : ""
+        }: ${this.element.stringify(TypeContext.tupleElement)}`;
+    }
+
+    override needsParenthesis(): boolean {
+        return false;
     }
 }
 
@@ -774,8 +986,40 @@ export class TypeOperatorType extends Type {
         super();
     }
 
-    override toString() {
-        return `${this.operator} ${this.target.toString()}`;
+    protected override getTypeString() {
+        return `${this.operator} ${this.target.stringify(
+            TypeContext.typeOperatorTarget
+        )}`;
+    }
+
+    override needsParenthesis(context: TypeContext): boolean {
+        const map: Record<TypeContext, boolean> = {
+            none: false,
+            templateLiteralElement: false,
+            arrayElement: true,
+            indexedAccessElement: false,
+            conditionalCheck: false,
+            conditionalExtends: false,
+            conditionalTrue: false,
+            conditionalFalse: false,
+            indexedIndex: false,
+            indexedObject: true,
+            inferredConstraint: false,
+            intersectionElement: false,
+            mappedName: false,
+            mappedParameter: false,
+            mappedTemplate: false,
+            optionalElement: true,
+            predicateTarget: false,
+            queryTypeTarget: false,
+            typeOperatorTarget: false,
+            referenceTypeArgument: false,
+            restElement: false,
+            tupleElement: false,
+            unionElement: false,
+        };
+
+        return map[context];
     }
 }
 
@@ -794,17 +1038,60 @@ export class UnionType extends Type {
         this.normalize();
     }
 
-    override toString(): string {
-        return this.types.map((t) => wrap(t, BINDING_POWERS.union)).join(" | ");
+    protected override getTypeString(): string {
+        return this.types
+            .map((t) => t.stringify(TypeContext.unionElement))
+            .join(" | ");
+    }
+
+    override needsParenthesis(context: TypeContext): boolean {
+        const map: Record<TypeContext, boolean> = {
+            none: false,
+            templateLiteralElement: false,
+            arrayElement: true,
+            indexedAccessElement: false,
+            conditionalCheck: true,
+            conditionalExtends: false,
+            conditionalTrue: false,
+            conditionalFalse: false,
+            indexedIndex: false,
+            indexedObject: true,
+            inferredConstraint: false,
+            intersectionElement: true,
+            mappedName: false,
+            mappedParameter: false,
+            mappedTemplate: false,
+            optionalElement: true,
+            predicateTarget: false,
+            queryTypeTarget: false,
+            typeOperatorTarget: true,
+            referenceTypeArgument: false,
+            restElement: false,
+            tupleElement: false,
+            unionElement: false,
+        };
+
+        return map[context];
     }
 
     private normalize() {
-        const trueIndex = this.types.findIndex(
-            (t) => t instanceof LiteralType && t.value === true
-        );
-        const falseIndex = this.types.findIndex(
-            (t) => t instanceof LiteralType && t.value === false
-        );
+        let trueIndex = -1;
+        let falseIndex = -1;
+        for (
+            let i = 0;
+            i < this.types.length && (trueIndex === -1 || falseIndex === -1);
+            i++
+        ) {
+            const t = this.types[i];
+            if (t instanceof LiteralType) {
+                if (t.value === true) {
+                    trueIndex = i;
+                }
+                if (t.value === false) {
+                    falseIndex = i;
+                }
+            }
+        }
 
         if (trueIndex !== -1 && falseIndex !== -1) {
             this.types.splice(Math.max(trueIndex, falseIndex), 1);
@@ -833,7 +1120,15 @@ export class UnknownType extends Type {
         this.name = name;
     }
 
-    override toString() {
+    protected override getTypeString() {
         return this.name;
+    }
+
+    /**
+     * Always returns true if not at the root level, we have no idea what's in here, so wrap it in parenthesis
+     * to be extra safe.
+     */
+    override needsParenthesis(context: TypeContext): boolean {
+        return context !== TypeContext.none;
     }
 }

--- a/src/lib/output/themes/default/partials/type.tsx
+++ b/src/lib/output/themes/default/partials/type.tsx
@@ -6,12 +6,11 @@ import {
     Reflection,
     ReflectionKind,
     Type,
+    TypeContext,
     TypeKindMap,
 } from "../../../../models";
 import { JSX } from "../../../../utils";
 import { join, stringify } from "../../lib";
-
-type TypeInlinePartialsOptions = { needsParens?: boolean };
 
 const EXPORTABLE: ReflectionKind =
     ReflectionKind.Class |
@@ -73,37 +72,31 @@ function renderUniquePath(context: DefaultThemeRenderContext, reflection: Reflec
 // 1 | 2[] !== (1 | 2)[]
 // () => 1 | 2 !== (() => 1) | 2
 const typeRenderers: {
-    [K in keyof TypeKindMap]: (
-        context: DefaultThemeRenderContext,
-        type: TypeKindMap[K],
-        options: TypeInlinePartialsOptions
-    ) => JSX.Element;
+    [K in keyof TypeKindMap]: (context: DefaultThemeRenderContext, type: TypeKindMap[K]) => JSX.Element;
 } = {
     array(context, type) {
         return (
             <>
-                {renderType(context, type.elementType, { needsParens: true })}
+                {renderType(context, type.elementType, TypeContext.arrayElement)}
                 <span class="tsd-signature-symbol">[]</span>
             </>
         );
     },
-    conditional(context, type, { needsParens }) {
+    conditional(context, type) {
         return (
             <>
-                {needsParens && <span class="tsd-signature-symbol">(</span>}
-                {renderType(context, type.checkType, { needsParens: true })}
+                {renderType(context, type.checkType, TypeContext.conditionalCheck)}
                 <span class="tsd-signature-symbol"> extends </span>
-                {renderType(context, type.extendsType)}
+                {renderType(context, type.extendsType, TypeContext.conditionalExtends)}
                 <span class="tsd-signature-symbol"> ? </span>
-                {renderType(context, type.trueType)}
+                {renderType(context, type.trueType, TypeContext.conditionalTrue)}
                 <span class="tsd-signature-symbol"> : </span>
-                {renderType(context, type.falseType)}
-                {needsParens && <span class="tsd-signature-symbol">)</span>}
+                {renderType(context, type.falseType, TypeContext.conditionalFalse)}
             </>
         );
     },
     indexedAccess(context, type) {
-        let indexType: JSX.Element = renderType(context, type.indexType);
+        let indexType: JSX.Element = renderType(context, type.indexType, TypeContext.indexedIndex);
 
         if (
             type.objectType instanceof ReferenceType &&
@@ -119,7 +112,7 @@ const typeRenderers: {
 
         return (
             <>
-                {renderType(context, type.objectType)}
+                {renderType(context, type.objectType, TypeContext.indexedObject)}
                 <span class="tsd-signature-symbol">[</span>
                 {indexType}
                 <span class="tsd-signature-symbol">]</span>
@@ -133,21 +126,15 @@ const typeRenderers: {
                 {type.constraint && (
                     <>
                         <span class="tsd-signature-symbol"> extends </span>
-                        {renderType(context, type.constraint)}
+                        {renderType(context, type.constraint, TypeContext.inferredConstraint)}
                     </>
                 )}
             </>
         );
     },
-    intersection(context, type, { needsParens }) {
-        return (
-            <>
-                {needsParens && <span class="tsd-signature-symbol">(</span>}
-                {join(<span class="tsd-signature-symbol"> & </span>, type.types, (item) =>
-                    renderType(context, item, { needsParens: true })
-                )}
-                {needsParens && <span class="tsd-signature-symbol">)</span>}
-            </>
+    intersection(context, type) {
+        return join(<span class="tsd-signature-symbol"> &amp; </span>, type.types, (item) =>
+            renderType(context, item, TypeContext.intersectionElement)
         );
     },
     intrinsic(_context, type) {
@@ -172,11 +159,14 @@ const typeRenderers: {
             <span class="tsd-signature-symbol">[ </span>,
             <span class="tsd-signature-type">{type.parameter}</span>,
             <span class="tsd-signature-symbol"> in </span>,
-            renderType(context, type.parameterType)
+            renderType(context, type.parameterType, TypeContext.mappedParameter)
         );
 
         if (type.nameType) {
-            children.push(<span class="tsd-signature-symbol"> as </span>, renderType(context, type.nameType));
+            children.push(
+                <span class="tsd-signature-symbol"> as </span>,
+                renderType(context, type.nameType, TypeContext.mappedName)
+            );
         }
 
         children.push(<span class="tsd-signature-symbol">]</span>);
@@ -192,7 +182,7 @@ const typeRenderers: {
                 children.push(<span class="tsd-signature-symbol">: </span>);
         }
 
-        children.push(renderType(context, type.templateType));
+        children.push(renderType(context, type.templateType, TypeContext.mappedTemplate));
 
         return (
             <>
@@ -210,14 +200,14 @@ const typeRenderers: {
                 ) : (
                     <span class="tsd-signature-symbol">: </span>
                 )}
-                {renderType(context, type.element)}
+                {renderType(context, type.element, TypeContext.tupleElement)}
             </>
         );
     },
     optional(context, type) {
         return (
             <>
-                {renderType(context, type.elementType)}
+                {renderType(context, type.elementType, TypeContext.optionalElement)}
                 <span class="tsd-signature-symbol">?</span>
             </>
         );
@@ -230,7 +220,7 @@ const typeRenderers: {
                 {!!type.targetType && (
                     <>
                         <span class="tsd-signature-symbol"> is </span>
-                        {renderType(context, type.targetType)}
+                        {renderType(context, type.targetType, TypeContext.predicateTarget)}
                     </>
                 )}
             </>
@@ -240,7 +230,7 @@ const typeRenderers: {
         return (
             <>
                 <span class="tsd-signature-symbol">typeof </span>
-                {renderType(context, type.queryType)}
+                {renderType(context, type.queryType, TypeContext.queryTypeTarget)}
             </>
         );
     },
@@ -279,7 +269,7 @@ const typeRenderers: {
                     {name}
                     <span class="tsd-signature-symbol">{"<"}</span>
                     {join(<span class="tsd-signature-symbol">, </span>, type.typeArguments, (item) =>
-                        renderType(context, item)
+                        renderType(context, item, TypeContext.referenceTypeArgument)
                     )}
                     <span class="tsd-signature-symbol">{">"}</span>
                 </>
@@ -288,7 +278,7 @@ const typeRenderers: {
 
         return name;
     },
-    reflection(context, type, { needsParens }) {
+    reflection(context, type) {
         if (type.declaration.children) {
             // Object literal
             return (
@@ -300,7 +290,7 @@ const typeRenderers: {
                                 <>
                                     {item.name}
                                     <span class="tsd-signature-symbol">: </span>
-                                    {renderType(context, item.getSignature.type)}
+                                    {renderType(context, item.getSignature.type, TypeContext.none)}
                                 </>
                             );
                         }
@@ -311,7 +301,7 @@ const typeRenderers: {
                                     <span class="tsd-signature-symbol">get </span>
                                     {item.name}
                                     <span class="tsd-signature-symbol">(): </span>
-                                    {renderType(context, item.getSignature.type)}
+                                    {renderType(context, item.getSignature.type, TypeContext.none)}
                                 </>
                             );
                         }
@@ -326,7 +316,7 @@ const typeRenderers: {
                                         <>
                                             {item.name}
                                             <span class="tsd-signature-symbol">: </span>
-                                            {renderType(context, item.type)}
+                                            {renderType(context, item.type, TypeContext.none)}
                                         </>
                                     ))}
                                     <span class="tsd-signature-symbol">)</span>
@@ -338,7 +328,7 @@ const typeRenderers: {
                             <>
                                 {item.name}
                                 <span class="tsd-signature-symbol">{item.flags.isOptional ? "?: " : ": "}</span>
-                                {renderType(context, item.type)}
+                                {renderType(context, item.type, TypeContext.none)}
                             </>
                         );
                     })}
@@ -350,12 +340,12 @@ const typeRenderers: {
         if (type.declaration.signatures?.length === 1) {
             return (
                 <>
-                    {needsParens && <span class="tsd-signature-symbol">(</span>}
+                    <span class="tsd-signature-symbol">(</span>
                     {context.memberSignatureTitle(type.declaration.signatures[0], {
                         hideName: true,
                         arrowStyle: true,
                     })}
-                    {needsParens && <span class="tsd-signature-symbol">)</span>}
+                    <span class="tsd-signature-symbol">)</span>
                 </>
             );
         }
@@ -378,7 +368,7 @@ const typeRenderers: {
         return (
             <>
                 <span class="tsd-signature-symbol">...</span>
-                {renderType(context, type.elementType)}
+                {renderType(context, type.elementType, TypeContext.restElement)}
             </>
         );
     },
@@ -390,7 +380,7 @@ const typeRenderers: {
                 {type.tail.map((item) => (
                     <>
                         <span class="tsd-signature-symbol">{"${"}</span>
-                        {renderType(context, item[0])}
+                        {renderType(context, item[0], TypeContext.templateLiteralElement)}
                         <span class="tsd-signature-symbol">{"}"}</span>
                         {item[1] && <span class="tsd-signature-type">{item[1]}</span>}
                     </>
@@ -403,7 +393,9 @@ const typeRenderers: {
         return (
             <>
                 <span class="tsd-signature-symbol">[</span>
-                {join(<span class="tsd-signature-symbol">, </span>, type.elements, (item) => renderType(context, item))}
+                {join(<span class="tsd-signature-symbol">, </span>, type.elements, (item) =>
+                    renderType(context, item, TypeContext.tupleElement)
+                )}
                 <span class="tsd-signature-symbol">]</span>
             </>
         );
@@ -412,19 +404,13 @@ const typeRenderers: {
         return (
             <>
                 <span class="tsd-signature-symbol">{type.operator} </span>
-                {renderType(context, type.target)}
+                {renderType(context, type.target, TypeContext.typeOperatorTarget)}
             </>
         );
     },
-    union(context, type, { needsParens }) {
-        return (
-            <>
-                {!!needsParens && <span class="tsd-signature-symbol">(</span>}
-                {join(<span class="tsd-signature-symbol"> | </span>, type.types, (item) =>
-                    renderType(context, item, { needsParens: true })
-                )}
-                {!!needsParens && <span class="tsd-signature-symbol">)</span>}
-            </>
+    union(context, type) {
+        return join(<span class="tsd-signature-symbol"> | </span>, type.types, (item) =>
+            renderType(context, item, TypeContext.unionElement)
         );
     },
     unknown(_context, type) {
@@ -432,15 +418,27 @@ const typeRenderers: {
     },
 };
 
-function renderType(context: DefaultThemeRenderContext, type: Type | undefined, options?: TypeInlinePartialsOptions) {
+function renderType(context: DefaultThemeRenderContext, type: Type | undefined, where: TypeContext) {
     if (!type) {
         return <span class="tsd-signature-type">any</span>;
     }
 
     const renderFn = typeRenderers[type.type];
-    return renderFn(context, type as never, options ?? {});
+    const rendered = renderFn(context, type as never);
+
+    if (type.needsParenthesis(where)) {
+        return (
+            <>
+                <span class="tsd-signature-symbol">(</span>
+                {rendered}
+                <span class="tsd-signature-symbol">)</span>
+            </>
+        );
+    }
+
+    return rendered;
 }
 
 export function type(context: DefaultThemeRenderContext, type: Type | undefined) {
-    return renderType(context, type, {});
+    return renderType(context, type, TypeContext.none);
 }

--- a/src/lib/output/themes/default/partials/type.tsx
+++ b/src/lib/output/themes/default/partials/type.tsx
@@ -126,10 +126,16 @@ const typeRenderers: {
             </>
         );
     },
-    inferred(_context, type) {
+    inferred(context, type) {
         return (
             <>
                 <span class="tsd-signature-symbol">infer </span> {type.name}
+                {type.constraint && (
+                    <>
+                        <span class="tsd-signature-symbol"> extends </span>
+                        {renderType(context, type.constraint)}
+                    </>
+                )}
             </>
         );
     },

--- a/src/lib/output/themes/default/partials/typeParameters.tsx
+++ b/src/lib/output/themes/default/partials/typeParameters.tsx
@@ -8,10 +8,11 @@ export function typeParameters(context: DefaultThemeRenderContext, typeParameter
             {typeParameters?.map((item) => (
                 <li>
                     <h4>
+                        {item.varianceModifier ? `${item.varianceModifier} ` : ""}
                         {item.name}
                         {!!item.type && (
                             <>
-                                <span class="tsd-signature-symbol">{": "}</span>
+                                <span class="tsd-signature-symbol"> extends </span>
                                 {context.type(item.type)}
                             </>
                         )}

--- a/src/lib/output/themes/lib.tsx
+++ b/src/lib/output/themes/lib.tsx
@@ -88,9 +88,12 @@ export function renderTypeParametersSignature(
                 <>
                     <span class="tsd-signature-symbol">{"<"}</span>
                     {join(<span class="tsd-signature-symbol">{", "}</span>, typeParameters, (item) => (
-                        <span class="tsd-signature-type" data-tsd-kind={item.kindString}>
-                            {item.name}
-                        </span>
+                        <>
+                            {item.varianceModifier ? `${item.varianceModifier} ` : ""}
+                            <span class="tsd-signature-type" data-tsd-kind={item.kindString}>
+                                {item.name}
+                            </span>
+                        </>
                     ))}
                     <span class="tsd-signature-symbol">{">"}</span>
                 </>

--- a/src/lib/serialization/schema.ts
+++ b/src/lib/serialization/schema.ts
@@ -165,7 +165,7 @@ export interface DeclarationReflection
 
 export interface TypeParameterReflection
     extends Reflection,
-        S<M.TypeParameterReflection, "type" | "default"> {}
+        S<M.TypeParameterReflection, "type" | "default" | "varianceModifier"> {}
 
 // Nothing extra yet.
 export interface ProjectReflection extends ContainerReflection {}

--- a/src/lib/serialization/schema.ts
+++ b/src/lib/serialization/schema.ts
@@ -248,7 +248,7 @@ export interface IndexedAccessType
 
 export interface InferredType
     extends Type,
-        S<M.InferredType, "type" | "name"> {}
+        S<M.InferredType, "type" | "name" | "constraint"> {}
 
 export interface IntersectionType
     extends Type,

--- a/src/lib/serialization/serializers/reflections/type-parameter.ts
+++ b/src/lib/serialization/serializers/reflections/type-parameter.ts
@@ -19,6 +19,7 @@ export class TypeParameterReflectionSerializer extends ReflectionSerializerCompo
             ...obj,
             type: this.owner.toObject(typeParameter.type),
             default: this.owner.toObject(typeParameter.default),
+            varianceModifier: typeParameter.varianceModifier,
         };
     }
 }

--- a/src/lib/serialization/serializers/types/inferred.ts
+++ b/src/lib/serialization/serializers/types/inferred.ts
@@ -18,6 +18,9 @@ export class InferredTypeSerializer extends TypeSerializerComponent<InferredType
         return {
             ...obj,
             name: inferred.name,
+            constraint: inferred.constraint
+                ? this.owner.toObject(inferred.constraint)
+                : undefined,
         };
     }
 }

--- a/src/lib/utils/entry-point.ts
+++ b/src/lib/utils/entry-point.ts
@@ -19,7 +19,7 @@ import { getCommonDirectory, normalizePath } from "./fs";
 export const EntryPointStrategy = {
     /**
      * The default behavior in v0.22+, expects all provided entry points as being part of a single program.
-     * Any directories included in the entry point list will result in `dir/index.[tj]sx?` being used.
+     * Any directories included in the entry point list will result in `dir/index.([cm][tj]s|[tj]sx?)` being used.
      */
     Resolve: "resolve",
     /**
@@ -119,7 +119,7 @@ export function getWatchEntryPoints(
 
 function getModuleName(fileName: string, baseDir: string) {
     return normalizePath(relative(baseDir, fileName)).replace(
-        /(\/index)?(\.d)?\.[tj]sx?$/,
+        /(\/index)?(\.d)?\.([cm][tj]s|[tj]sx?)$/,
         ""
     );
 }
@@ -139,11 +139,15 @@ function getEntryPointsForPaths(
 
     entryLoop: for (const fileOrDir of inputFiles.map(normalizePath)) {
         const toCheck = [fileOrDir];
-        if (!/\.[tj]sx?/.test(fileOrDir)) {
+        if (!/\.([cm][tj]s|[tj]sx?)$/.test(fileOrDir)) {
             toCheck.push(
                 `${fileOrDir}/index.ts`,
+                `${fileOrDir}/index.cts`,
+                `${fileOrDir}/index.mts`,
                 `${fileOrDir}/index.tsx`,
                 `${fileOrDir}/index.js`,
+                `${fileOrDir}/index.cjs`,
+                `${fileOrDir}/index.mjs`,
                 `${fileOrDir}/index.jsx`
             );
         }
@@ -236,8 +240,8 @@ function expandInputFiles(
 
     const supportedFileRegex =
         compilerOptions.allowJs || compilerOptions.checkJs
-            ? /\.[tj]sx?$/
-            : /\.tsx?$/;
+            ? /\.([cm][tj]s|[tj]sx?)$/
+            : /\.([cm]ts|tsx?)$/;
     function add(file: string, entryPoint: boolean) {
         let stats: FS.Stats;
         try {

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -310,7 +310,7 @@ export class Options {
         );
 
         if (declaration.type === ParameterType.Flags) {
-            Object.assign(this._values[declaration.name], converted);
+            Object.assign(this._values[declaration.name] as any, converted);
         } else {
             this._values[declaration.name] = converted;
         }

--- a/src/lib/utils/package-manifest.ts
+++ b/src/lib/utils/package-manifest.ts
@@ -5,7 +5,7 @@ import { dirname, join, resolve } from "path";
 import { existsSync } from "fs";
 import { flatMap } from "./array";
 
-import { readFile } from "./fs";
+import { normalizePath, readFile } from "./fs";
 import type { Logger } from "./loggers";
 
 /**
@@ -71,9 +71,12 @@ function getPackagePaths(
  * https://github.com/yarnpkg/yarn/blob/a4708b29ac74df97bac45365cba4f1d62537ceb7/src/config.js#L799
  */
 function globPackages(workspacePath: string, packageJsonDir: string): string[] {
-    return glob.sync(resolve(packageJsonDir, workspacePath, "package.json"), {
-        ignore: resolve(packageJsonDir, workspacePath, "node_modules"),
-    });
+    return glob.sync(
+        normalizePath(resolve(packageJsonDir, workspacePath, "package.json")),
+        {
+            ignore: resolve(packageJsonDir, workspacePath, "node_modules"),
+        }
+    );
 }
 
 /**

--- a/src/test/behaviorTests.ts
+++ b/src/test/behaviorTests.ts
@@ -92,6 +92,12 @@ export const behaviorTests: Record<
             'Record<"b", 1>',
         ]);
     },
+
+    instantiationExpressions(project) {
+        const ss = query(project, "StringSet");
+        equal(ss.kind, ReflectionKind.Variable);
+    },
+
     overloads(project) {
         const foo = query(project, "foo");
         equal(foo.signatures?.length, 2);

--- a/src/test/converter/types/general.ts
+++ b/src/test/converter/types/general.ts
@@ -13,3 +13,8 @@ export type BigIntAlias = bigint;
 
 export type NegativeOne = -1;
 export const negativeOne = -1;
+
+export type FirstIfString<T extends unknown[]> =
+    T extends [infer S extends string, ...unknown[]]
+        ? S
+        : never;

--- a/src/test/converter/types/specs.json
+++ b/src/test/converter/types/specs.json
@@ -37,6 +37,68 @@
           }
         },
         {
+          "id": 11,
+          "name": "FirstIfString",
+          "kind": 4194304,
+          "kindString": "Type alias",
+          "flags": {},
+          "typeParameter": [
+            {
+              "id": 12,
+              "name": "T",
+              "kind": 131072,
+              "kindString": "Type parameter",
+              "flags": {},
+              "type": {
+                "type": "array",
+                "elementType": {
+                  "type": "intrinsic",
+                  "name": "unknown"
+                }
+              }
+            }
+          ],
+          "type": {
+            "type": "conditional",
+            "checkType": {
+              "type": "reference",
+              "id": 12,
+              "name": "T"
+            },
+            "extendsType": {
+              "type": "tuple",
+              "elements": [
+                {
+                  "type": "inferred",
+                  "name": "S",
+                  "constraint": {
+                    "type": "intrinsic",
+                    "name": "string"
+                  }
+                },
+                {
+                  "type": "rest",
+                  "elementType": {
+                    "type": "array",
+                    "elementType": {
+                      "type": "intrinsic",
+                      "name": "unknown"
+                    }
+                  }
+                }
+              ]
+            },
+            "trueType": {
+              "type": "reference",
+              "name": "S"
+            },
+            "falseType": {
+              "type": "intrinsic",
+              "name": "never"
+            }
+          }
+        },
+        {
           "id": 4,
           "name": "NegativeBigIntLiteral",
           "kind": 4194304,
@@ -148,6 +210,7 @@
           "children": [
             8,
             2,
+            11,
             4,
             9,
             6
@@ -166,27 +229,27 @@
       ]
     },
     {
-      "id": 11,
+      "id": 13,
       "name": "index-signature",
       "kind": 2,
       "kindString": "Module",
       "flags": {},
       "children": [
         {
-          "id": 15,
+          "id": 17,
           "name": "PartialIndex",
           "kind": 256,
           "kindString": "Interface",
           "flags": {},
           "indexSignature": {
-            "id": 16,
+            "id": 18,
             "name": "__index",
             "kind": 8192,
             "kindString": "Index signature",
             "flags": {},
             "parameters": [
               {
-                "id": 17,
+                "id": 19,
                 "name": "optName",
                 "kind": 32768,
                 "flags": {},
@@ -212,20 +275,20 @@
           }
         },
         {
-          "id": 12,
+          "id": 14,
           "name": "SymbolIndex",
           "kind": 256,
           "kindString": "Interface",
           "flags": {},
           "indexSignature": {
-            "id": 13,
+            "id": 15,
             "name": "__index",
             "kind": 8192,
             "kindString": "Index signature",
             "flags": {},
             "parameters": [
               {
-                "id": 14,
+                "id": 16,
                 "name": "sym",
                 "kind": 32768,
                 "flags": {},
@@ -242,20 +305,20 @@
           }
         },
         {
-          "id": 18,
+          "id": 20,
           "name": "UnionIndex",
           "kind": 256,
           "kindString": "Interface",
           "flags": {},
           "indexSignature": {
-            "id": 19,
+            "id": 21,
             "name": "__index",
             "kind": 8192,
             "kindString": "Index signature",
             "flags": {},
             "parameters": [
               {
-                "id": 20,
+                "id": 22,
                 "name": "optName",
                 "kind": 32768,
                 "flags": {},
@@ -286,29 +349,29 @@
           "title": "Interfaces",
           "kind": 256,
           "children": [
-            15,
-            12,
-            18
+            17,
+            14,
+            20
           ]
         }
       ]
     },
     {
-      "id": 21,
+      "id": 23,
       "name": "mapped",
       "kind": 2,
       "kindString": "Module",
       "flags": {},
       "children": [
         {
-          "id": 32,
+          "id": 34,
           "name": "DoubleKey",
           "kind": 4194304,
           "kindString": "Type alias",
           "flags": {},
           "typeParameter": [
             {
-              "id": 33,
+              "id": 35,
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
@@ -326,7 +389,7 @@
                   "operator": "keyof",
                   "target": {
                     "type": "reference",
-                    "id": 33,
+                    "id": 35,
                     "name": "T"
                   }
                 },
@@ -344,7 +407,7 @@
               },
               "objectType": {
                 "type": "reference",
-                "id": 33,
+                "id": 35,
                 "name": "T"
               }
             },
@@ -371,14 +434,14 @@
           }
         },
         {
-          "id": 30,
+          "id": 32,
           "name": "Mappy",
           "kind": 4194304,
           "kindString": "Type alias",
           "flags": {},
           "typeParameter": [
             {
-              "id": 31,
+              "id": 33,
               "name": "T",
               "kind": 131072,
               "kindString": "Type parameter",
@@ -393,7 +456,7 @@
               "operator": "keyof",
               "target": {
                 "type": "reference",
-                "id": 31,
+                "id": 33,
                 "name": "T"
               }
             },
@@ -405,28 +468,28 @@
               },
               "objectType": {
                 "type": "reference",
-                "id": 31,
+                "id": 33,
                 "name": "T"
               }
             }
           }
         },
         {
-          "id": 26,
+          "id": 28,
           "name": "doubleKey",
           "kind": 64,
           "kindString": "Function",
           "flags": {},
           "signatures": [
             {
-              "id": 27,
+              "id": 29,
               "name": "doubleKey",
               "kind": 4096,
               "kindString": "Call signature",
               "flags": {},
               "typeParameter": [
                 {
-                  "id": 28,
+                  "id": 30,
                   "name": "T",
                   "kind": 131072,
                   "kindString": "Type parameter",
@@ -435,14 +498,14 @@
               ],
               "parameters": [
                 {
-                  "id": 29,
+                  "id": 31,
                   "name": "arg",
                   "kind": 32768,
                   "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "reference",
-                    "id": 28,
+                    "id": 30,
                     "name": "T"
                   }
                 }
@@ -462,7 +525,7 @@
                   },
                   "objectType": {
                     "type": "reference",
-                    "id": 28,
+                    "id": 30,
                     "name": "T"
                   }
                 },
@@ -491,21 +554,21 @@
           ]
         },
         {
-          "id": 22,
+          "id": 24,
           "name": "mapped",
           "kind": 64,
           "kindString": "Function",
           "flags": {},
           "signatures": [
             {
-              "id": 23,
+              "id": 25,
               "name": "mapped",
               "kind": 4096,
               "kindString": "Call signature",
               "flags": {},
               "typeParameter": [
                 {
-                  "id": 24,
+                  "id": 26,
                   "name": "T",
                   "kind": 131072,
                   "kindString": "Type parameter",
@@ -514,14 +577,14 @@
               ],
               "parameters": [
                 {
-                  "id": 25,
+                  "id": 27,
                   "name": "arg",
                   "kind": 32768,
                   "kindString": "Parameter",
                   "flags": {},
                   "type": {
                     "type": "reference",
-                    "id": 24,
+                    "id": 26,
                     "name": "T"
                   }
                 }
@@ -562,29 +625,29 @@
           "title": "Type aliases",
           "kind": 4194304,
           "children": [
-            32,
-            30
+            34,
+            32
           ]
         },
         {
           "title": "Functions",
           "kind": 64,
           "children": [
-            26,
-            22
+            28,
+            24
           ]
         }
       ]
     },
     {
-      "id": 34,
+      "id": 36,
       "name": "parens",
       "kind": 2,
       "kindString": "Module",
       "flags": {},
       "children": [
         {
-          "id": 35,
+          "id": 37,
           "name": "ZZ",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -599,14 +662,14 @@
               {
                 "type": "reflection",
                 "declaration": {
-                  "id": 36,
+                  "id": 38,
                   "name": "__type",
                   "kind": 65536,
                   "kindString": "Type literal",
                   "flags": {},
                   "children": [
                     {
-                      "id": 37,
+                      "id": 39,
                       "name": "a",
                       "kind": 1024,
                       "kindString": "Property",
@@ -622,7 +685,7 @@
                       "title": "Properties",
                       "kind": 1024,
                       "children": [
-                        37
+                        39
                       ]
                     }
                   ]
@@ -637,20 +700,20 @@
           "title": "Type aliases",
           "kind": 4194304,
           "children": [
-            35
+            37
           ]
         }
       ]
     },
     {
-      "id": 38,
+      "id": 40,
       "name": "query",
       "kind": 2,
       "kindString": "Module",
       "flags": {},
       "children": [
         {
-          "id": 40,
+          "id": 42,
           "name": "TypeOfX",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -659,13 +722,13 @@
             "type": "query",
             "queryType": {
               "type": "reference",
-              "id": 39,
+              "id": 41,
               "name": "x"
             }
           }
         },
         {
-          "id": 39,
+          "id": 41,
           "name": "x",
           "kind": 32,
           "kindString": "Variable",
@@ -684,27 +747,27 @@
           "title": "Type aliases",
           "kind": 4194304,
           "children": [
-            40
+            42
           ]
         },
         {
           "title": "Variables",
           "kind": 32,
           "children": [
-            39
+            41
           ]
         }
       ]
     },
     {
-      "id": 41,
+      "id": 43,
       "name": "tuple",
       "kind": 2,
       "kindString": "Module",
       "flags": {},
       "children": [
         {
-          "id": 50,
+          "id": 52,
           "name": "LeadingRest",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -730,7 +793,7 @@
           }
         },
         {
-          "id": 42,
+          "id": 44,
           "name": "NamedTuple",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -760,7 +823,7 @@
           }
         },
         {
-          "id": 48,
+          "id": 50,
           "name": "WithOptionalElements",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -790,7 +853,7 @@
           }
         },
         {
-          "id": 44,
+          "id": 46,
           "name": "WithRestType",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -816,7 +879,7 @@
           }
         },
         {
-          "id": 46,
+          "id": 48,
           "name": "WithRestTypeNames",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -849,7 +912,7 @@
           }
         },
         {
-          "id": 51,
+          "id": 53,
           "name": "leadingRest",
           "kind": 32,
           "kindString": "Variable",
@@ -878,7 +941,7 @@
           "defaultValue": "..."
         },
         {
-          "id": 43,
+          "id": 45,
           "name": "namedTuple",
           "kind": 32,
           "kindString": "Variable",
@@ -911,7 +974,7 @@
           "defaultValue": "..."
         },
         {
-          "id": 49,
+          "id": 51,
           "name": "withOptionalElements",
           "kind": 32,
           "kindString": "Variable",
@@ -944,7 +1007,7 @@
           "defaultValue": "..."
         },
         {
-          "id": 45,
+          "id": 47,
           "name": "withRestType",
           "kind": 32,
           "kindString": "Variable",
@@ -973,7 +1036,7 @@
           "defaultValue": "..."
         },
         {
-          "id": 47,
+          "id": 49,
           "name": "withRestTypeNames",
           "kind": 32,
           "kindString": "Variable",
@@ -1017,35 +1080,35 @@
           "title": "Type aliases",
           "kind": 4194304,
           "children": [
-            50,
-            42,
-            48,
+            52,
             44,
-            46
+            50,
+            46,
+            48
           ]
         },
         {
           "title": "Variables",
           "kind": 32,
           "children": [
-            51,
-            43,
-            49,
+            53,
             45,
-            47
+            51,
+            47,
+            49
           ]
         }
       ]
     },
     {
-      "id": 52,
+      "id": 54,
       "name": "type-operator",
       "kind": 2,
       "kindString": "Module",
       "flags": {},
       "children": [
         {
-          "id": 54,
+          "id": 56,
           "name": "B",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -1063,7 +1126,7 @@
           }
         },
         {
-          "id": 55,
+          "id": 57,
           "name": "C",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -1071,14 +1134,14 @@
           "type": {
             "type": "reflection",
             "declaration": {
-              "id": 56,
+              "id": 58,
               "name": "__type",
               "kind": 65536,
               "kindString": "Type literal",
               "flags": {},
               "children": [
                 {
-                  "id": 57,
+                  "id": 59,
                   "name": "prop1",
                   "kind": 1024,
                   "kindString": "Property",
@@ -1089,7 +1152,7 @@
                   }
                 },
                 {
-                  "id": 58,
+                  "id": 60,
                   "name": "prop2",
                   "kind": 1024,
                   "kindString": "Property",
@@ -1105,8 +1168,8 @@
                   "title": "Properties",
                   "kind": 1024,
                   "children": [
-                    57,
-                    58
+                    59,
+                    60
                   ]
                 }
               ]
@@ -1114,7 +1177,7 @@
           }
         },
         {
-          "id": 59,
+          "id": 61,
           "name": "D",
           "kind": 4194304,
           "kindString": "Type alias",
@@ -1124,13 +1187,13 @@
             "operator": "keyof",
             "target": {
               "type": "reference",
-              "id": 55,
+              "id": 57,
               "name": "C"
             }
           }
         },
         {
-          "id": 53,
+          "id": 55,
           "name": "a",
           "kind": 32,
           "kindString": "Variable",
@@ -1153,29 +1216,29 @@
           "title": "Type aliases",
           "kind": 4194304,
           "children": [
-            54,
-            55,
-            59
+            56,
+            57,
+            61
           ]
         },
         {
           "title": "Variables",
           "kind": 32,
           "children": [
-            53
+            55
           ]
         }
       ]
     },
     {
-      "id": 60,
+      "id": 62,
       "name": "union-or-intersection",
       "kind": 2,
       "kindString": "Module",
       "flags": {},
       "children": [
         {
-          "id": 61,
+          "id": 63,
           "name": "FirstType",
           "kind": 256,
           "kindString": "Interface",
@@ -1185,7 +1248,7 @@
           },
           "children": [
             {
-              "id": 62,
+              "id": 64,
               "name": "firstProperty",
               "kind": 1024,
               "kindString": "Property",
@@ -1204,13 +1267,13 @@
               "title": "Properties",
               "kind": 1024,
               "children": [
-                62
+                64
               ]
             }
           ]
         },
         {
-          "id": 63,
+          "id": 65,
           "name": "SecondType",
           "kind": 256,
           "kindString": "Interface",
@@ -1220,7 +1283,7 @@
           },
           "children": [
             {
-              "id": 64,
+              "id": 66,
               "name": "secondProperty",
               "kind": 1024,
               "kindString": "Property",
@@ -1239,13 +1302,13 @@
               "title": "Properties",
               "kind": 1024,
               "children": [
-                64
+                66
               ]
             }
           ]
         },
         {
-          "id": 65,
+          "id": 67,
           "name": "ThirdType",
           "kind": 256,
           "kindString": "Interface",
@@ -1255,7 +1318,7 @@
           },
           "children": [
             {
-              "id": 68,
+              "id": 70,
               "name": "thirdComplexProperty",
               "kind": 1024,
               "kindString": "Property",
@@ -1279,12 +1342,12 @@
                         "types": [
                           {
                             "type": "reference",
-                            "id": 61,
+                            "id": 63,
                             "name": "FirstType"
                           },
                           {
                             "type": "reference",
-                            "id": 63,
+                            "id": 65,
                             "name": "SecondType"
                           }
                         ]
@@ -1295,7 +1358,7 @@
               }
             },
             {
-              "id": 67,
+              "id": 69,
               "name": "thirdIntersectionProperty",
               "kind": 1024,
               "kindString": "Property",
@@ -1308,19 +1371,19 @@
                 "types": [
                   {
                     "type": "reference",
-                    "id": 61,
+                    "id": 63,
                     "name": "FirstType"
                   },
                   {
                     "type": "reference",
-                    "id": 65,
+                    "id": 67,
                     "name": "ThirdType"
                   }
                 ]
               }
             },
             {
-              "id": 66,
+              "id": 68,
               "name": "thirdUnionProperty",
               "kind": 1024,
               "kindString": "Property",
@@ -1333,12 +1396,12 @@
                 "types": [
                   {
                     "type": "reference",
-                    "id": 61,
+                    "id": 63,
                     "name": "FirstType"
                   },
                   {
                     "type": "reference",
-                    "id": 63,
+                    "id": 65,
                     "name": "SecondType"
                   }
                 ]
@@ -1350,9 +1413,9 @@
               "title": "Properties",
               "kind": 1024,
               "children": [
-                68,
-                67,
-                66
+                70,
+                69,
+                68
               ]
             }
           ]
@@ -1363,9 +1426,9 @@
           "title": "Interfaces",
           "kind": 256,
           "children": [
-            61,
             63,
-            65
+            65,
+            67
           ]
         }
       ]
@@ -1377,13 +1440,13 @@
       "kind": 2,
       "children": [
         1,
-        11,
-        21,
-        34,
-        38,
-        41,
-        52,
-        60
+        13,
+        23,
+        36,
+        40,
+        43,
+        54,
+        62
       ]
     }
   ]

--- a/src/test/converter2/behavior/instantiationExpressions.ts
+++ b/src/test/converter2/behavior/instantiationExpressions.ts
@@ -1,0 +1,10 @@
+/**
+ * Custom Set class, roughly equivalent to:
+ * ```ts
+ * export class StringSet extends Set<string> {}
+ * ```
+ *
+ * Not quite the same, since the instantiation expression does not cause
+ * a type to be created with the same name.
+ */
+export const StringSet = Set<string>

--- a/src/test/models/types.test.ts
+++ b/src/test/models/types.test.ts
@@ -160,6 +160,11 @@ describe("Type.toString", () => {
             const type = new T.InferredType("TFoo");
             equal(type.toString(), "infer TFoo");
         });
+
+        it("Renders with a constraint", () => {
+            const type = new T.InferredType("TFoo", new T.LiteralType(123));
+            equal(type.toString(), "infer TFoo extends 123");
+        });
     });
 
     describe("Mapped types", () => {
@@ -255,13 +260,22 @@ describe("Type.toString", () => {
             equal(type.toString(), "(keyof 1)?");
         });
 
-        it("Wraps type queries", () => {
+        it("Does not wrap type query", () => {
             const type = new T.OptionalType(
                 new T.QueryType(
                     T.ReferenceType.createResolvedReference("X", -1, null)
                 )
             );
-            equal(type.toString(), "(typeof X)?");
+            equal(type.toString(), "typeof X?");
+        });
+    });
+
+    describe("Tuple", () => {
+        it("Works with members", () => {
+            const type = new T.TupleType([
+                new T.OptionalType(new T.LiteralType(123)),
+            ]);
+            equal(type.toString(), "[123?]");
         });
     });
 
@@ -299,12 +313,6 @@ describe("Type.toString", () => {
             const type = new T.RestType(new T.ArrayType(new T.LiteralType(1)));
             equal(type.toString(), "...1[]");
         });
-        it("Wraps complex types", () => {
-            const type = new T.RestType(
-                new T.UnionType([new T.LiteralType(1), new T.LiteralType(2)])
-            );
-            equal(type.toString(), "...(1 | 2)");
-        });
     });
 
     describe("Template literal type", () => {
@@ -314,5 +322,16 @@ describe("Type.toString", () => {
             ]);
             equal(type.toString(), "`a${string}b`");
         });
+    });
+});
+
+describe("Union Types", () => {
+    it("Normalizes true | false to boolean", () => {
+        const type = new T.UnionType([
+            new T.LiteralType(true),
+            new T.LiteralType(123),
+            new T.LiteralType(false),
+        ]);
+        equal(type.toString(), "boolean | 123");
     });
 });

--- a/src/test/renderer/testProject/src/classes.ts
+++ b/src/test/renderer/testProject/src/classes.ts
@@ -334,3 +334,9 @@ export class NonGenericClass extends GenericClass<SubClassB> {}
 
 // TS 4.2
 export type AbstractMe = abstract new () => NonGenericClass;
+
+// TS 4.7
+export interface State<in out T> {
+    get: () => T;
+    set: (value: T) => void;
+}


### PR DESCRIPTION
- [x] Update globs which look for TS files to handle cts/mts
- [x] Add tests for code using instantiation expressions (don't think there's code changes necessary here, but...)
- [x] Add tests + support for extends constraints on infer type variables
- [x] Add support for variance annotations on type parameters (should be displayed in docs)

Future:
- [ ] Add support for exports/./import|require/types to packages mode (#1934)

Resolves #1935
Closes #1939 