### PR TITLE
Fix group boosts

### DIFF
--- a/src/lib/output/plugins/JavascriptIndexPlugin.ts
+++ b/src/lib/output/plugins/JavascriptIndexPlugin.ts
@@ -73,11 +73,11 @@ export class JavascriptIndexPlugin extends RendererComponent {
                 kinds[reflection.kind] = GroupPlugin.getKindSingular(
                     reflection.kind
                 );
+            }
 
-                const kindBoost = kindBoosts[kinds[reflection.kind] ?? ""];
-                if (kindBoost != undefined) {
-                    boost *= kindBoost;
-                }
+            const kindBoost = kindBoosts[kinds[reflection.kind] ?? ""];
+            if (kindBoost != undefined) {
+                boost *= kindBoost;
             }
 
             const row: any = {


### PR DESCRIPTION
Not sure how we got this mixed-up, but at some point we moved the code that computes boost inside the same logical block that computes human-readable group names. Long story short, only the first of a group type was having its boost computed.