### PR TITLE
Fix category boosts

### DIFF
--- a/src/lib/converter/plugins/CategoryPlugin.ts
+++ b/src/lib/converter/plugins/CategoryPlugin.ts
@@ -183,7 +183,7 @@ export class CategoryPlugin extends ConverterComponent {
             for (const childCat of childCategories) {
                 let category = categories.find((cat) => cat.title === childCat);
 
-                const catBoost = categorySearchBoosts[category?.title ?? -1];
+                const catBoost = categorySearchBoosts[childCat ?? -1];
                 if (catBoost != undefined) {
                     child.relevanceBoost =
                         (child.relevanceBoost ?? 1) * catBoost;


### PR DESCRIPTION
When walking over the child categories for a reflection, we were looking up category information in the `categories` collection, but this doesn't get written to until the end of the block, so there was no guarantee it would be found. Most straightforward fix seems to be to just use the raw category name when checking for boosts.