### PR TITLE
Improve support for `--entryPointStrategy Packages`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+### Features
+
+-   Improved support for `--entryPointStrategy Packages`. TypeDoc will now load package-specific configurations from `package.json` `typedoc` field. This configuration allows configuring a custom display name (`typedoc.displayName`) field, entry point (`typedoc.entryPoint` - this is equivalent and will override `typedocMain`), and path to a readme file to be rendered at the top of the package page (`typedoc.readmeFile`), #1658.
+-   The `--includeVersion` option will now be respected by `--entryPointStrategy Packages`. Also, for this combination, missing `version` field in the root `package.json` will not issue a warning.
+
 ## v0.23.5 (2022-07-02)
 
 ### Features

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -285,6 +285,9 @@ export class Converter extends ChildableComponent<
 
                 reflection.readme = comment.summary;
             }
+
+            reflection.version = entryPoint.version;
+
             context.finalizeDeclarationReflection(reflection);
             moduleContext = context.withScope(reflection);
         }

--- a/src/lib/converter/plugins/LinkResolverPlugin.ts
+++ b/src/lib/converter/plugins/LinkResolverPlugin.ts
@@ -10,6 +10,7 @@ import type {
     CommentDisplayPart,
     InlineTagDisplayPart,
 } from "../../models/comments";
+import { DeclarationReflection } from "../../models";
 
 const urlPrefix = /^(http|ftp)s?:\/\//;
 const brackets = /\[\[([^\]]+)\]\]/g;
@@ -135,6 +136,14 @@ export class LinkResolverPlugin extends ConverterComponent {
         comment.summary = this.processParts(reflection, comment.summary, warn);
         for (const tag of comment.blockTags) {
             tag.content = this.processParts(reflection, tag.content, warn);
+        }
+
+        if (reflection instanceof DeclarationReflection && reflection.readme) {
+            reflection.readme = this.processParts(
+                reflection,
+                reflection.readme,
+                warn
+            );
         }
     }
 

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -162,9 +162,13 @@ export class PackagePlugin extends ConverterComponent {
                 project.name = "Documentation";
             }
             if (this.includeVersion) {
-                context.logger.warn(
-                    "--includeVersion was specified, but no package.json was found. Not adding package version to the documentation."
-                );
+                // since not all monorepo specifies a meaningful version to the main package.json
+                // this warning should be optional
+                if (this.entryPointStrategy !== EntryPointStrategy.Packages) {
+                    context.logger.warn(
+                        "--includeVersion was specified, but no package.json was found. Not adding package version to the documentation."
+                    );
+                }
             }
         }
     }

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -4,7 +4,7 @@ import * as FS from "fs";
 import { Component, ConverterComponent } from "../components";
 import { Converter } from "../converter";
 import type { Context } from "../context";
-import { BindOption, readFile } from "../../utils";
+import { BindOption, EntryPointStrategy, readFile } from "../../utils";
 import { getCommonDirectory } from "../../utils/fs";
 import { nicePath } from "../../utils/paths";
 import { lexCommentString } from "../comments/rawLexer";
@@ -22,6 +22,9 @@ export class PackagePlugin extends ConverterComponent {
 
     @BindOption("includeVersion")
     includeVersion!: boolean;
+
+    @BindOption("entryPointStrategy")
+    entryPointStrategy!: EntryPointStrategy;
 
     /**
      * The file name of the found readme.md file.
@@ -140,9 +143,15 @@ export class PackagePlugin extends ConverterComponent {
                 if (packageInfo.version) {
                     project.name = `${project.name} - v${packageInfo.version}`;
                 } else {
-                    context.logger.warn(
-                        "--includeVersion was specified, but package.json does not specify a version."
-                    );
+                    // since not all monorepo specifies a meaningful version to the main package.json
+                    // this warning should be optional
+                    if (
+                        this.entryPointStrategy !== EntryPointStrategy.Packages
+                    ) {
+                        context.logger.warn(
+                            "--includeVersion was specified, but package.json does not specify a version."
+                        );
+                    }
                 }
             }
         } else {

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -131,9 +131,14 @@ export class DeclarationReflection extends ContainerReflection {
     typeHierarchy?: DeclarationHierarchy;
 
     /**
-     * The contents of the readme.md file of the module when found.
+     * The contents of the readme file of the module when found.
      */
     readme?: CommentDisplayPart[];
+
+    /**
+     * The version of the module when found.
+     */
+    version?: string;
 
     override hasGetterOrSetter(): boolean {
         return !!this.getSignature || !!this.setSignature;

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -5,6 +5,7 @@ import { ContainerReflection } from "./container";
 import type { SignatureReflection } from "./signature";
 import type { TypeParameterReflection } from "./type-parameter";
 import type { Serializer, JSONOutput } from "../../serialization";
+import type { CommentDisplayPart } from "../comments";
 
 /**
  * Stores hierarchical type data.
@@ -128,6 +129,11 @@ export class DeclarationReflection extends ContainerReflection {
      * rendered in templates.
      */
     typeHierarchy?: DeclarationHierarchy;
+
+    /**
+     * The contents of the readme.md file of the module when found.
+     */
+    readme?: CommentDisplayPart[];
 
     override hasGetterOrSetter(): boolean {
         return !!this.getSignature || !!this.setSignature;

--- a/src/lib/output/themes/default/partials/header.tsx
+++ b/src/lib/output/themes/default/partials/header.tsx
@@ -2,7 +2,7 @@ import { hasTypeParameters, join, renderFlags } from "../../lib";
 import { JSX } from "../../../../utils";
 import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext";
 import type { PageEvent } from "../../../events";
-import type { Reflection } from "../../../../models";
+import { DeclarationReflection, Reflection } from "../../../../models";
 
 export const header = (context: DefaultThemeRenderContext, props: PageEvent<Reflection>) => {
     const HeadingLevel = props.model.isProject() ? "h2" : "h1";
@@ -12,6 +12,9 @@ export const header = (context: DefaultThemeRenderContext, props: PageEvent<Refl
             <HeadingLevel>
                 {props.model.kindString !== "Project" && `${props.model.kindString ?? ""} `}
                 {props.model.name}
+                {props.model instanceof DeclarationReflection &&
+                    props.model.version !== undefined &&
+                    ` - v${props.model.version}`}
                 {hasTypeParameters(props.model) && (
                     <>
                         {"<"}

--- a/src/lib/output/themes/default/partials/index.tsx
+++ b/src/lib/output/themes/default/partials/index.tsx
@@ -1,7 +1,7 @@
-import { classNames, wbr } from "../../lib";
+import { classNames, displayPartsToMarkdown, wbr } from "../../lib";
 import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext";
-import { JSX } from "../../../../utils";
-import type { ContainerReflection, ReflectionCategory } from "../../../../models";
+import { JSX, Raw } from "../../../../utils";
+import { ContainerReflection, DeclarationReflection, ReflectionCategory, ReflectionKind } from "../../../../models";
 
 function renderCategory({ urlTo, icons }: DefaultThemeRenderContext, item: ReflectionCategory, prependName = "") {
     return (
@@ -67,8 +67,19 @@ export function index(context: DefaultThemeRenderContext, props: ContainerReflec
     }
 
     return (
-        <section class="tsd-panel-group tsd-index-group">
-            <section class="tsd-panel tsd-index-panel">{content}</section>
-        </section>
+        <>
+            {props instanceof DeclarationReflection &&
+                props.kind === ReflectionKind.Module &&
+                props.readme?.length !== 0 && (
+                    <section class="tsd-panel-group tsd-index-group">
+                        <section class="tsd-panel tsd-typography">
+                            <Raw html={context.markdown(displayPartsToMarkdown(props.readme || [], context.urlTo))} />
+                        </section>
+                    </section>
+                )}
+            <section class="tsd-panel-group tsd-index-group">
+                <section class="tsd-panel tsd-index-panel">{content}</section>
+            </section>
+        </>
     );
 }

--- a/src/lib/output/themes/default/partials/index.tsx
+++ b/src/lib/output/themes/default/partials/index.tsx
@@ -71,7 +71,7 @@ export function index(context: DefaultThemeRenderContext, props: ContainerReflec
             {props instanceof DeclarationReflection &&
                 props.kind === ReflectionKind.Module &&
                 props.readme?.length !== 0 && (
-                    <section class="tsd-panel-group tsd-index-group">
+                    <section class="tsd-panel-group">
                         <section class="tsd-panel tsd-typography">
                             <Raw html={context.markdown(displayPartsToMarkdown(props.readme || [], context.urlTo))} />
                         </section>

--- a/src/lib/output/themes/default/partials/navigation.tsx
+++ b/src/lib/output/themes/default/partials/navigation.tsx
@@ -121,7 +121,9 @@ function primaryNavigation(context: DefaultThemeRenderContext, props: PageEvent<
 
         return (
             <li class={classNames({ current, selected, deprecated: mod.isDeprecated() }, mod.cssClasses)}>
-                <a href={context.urlTo(mod)}>{wbr(mod.name)}</a>
+                <a href={context.urlTo(mod)}>
+                    {wbr(`${mod.name}${mod.version !== undefined ? ` - v${mod.version}` : ""}`)}
+                </a>
                 {childNav}
             </li>
         );

--- a/src/lib/utils/entry-point.ts
+++ b/src/lib/utils/entry-point.ts
@@ -396,7 +396,7 @@ function getEntryPointsForPackages(
                 // if displayName is not configured, use the package name (and version, if configured)
                 `${packageJson["name"]}${
                     includeVersion && packageJson["version"]
-                        ? `@${packageJson["version"]}`
+                        ? ` - v${packageJson["version"]}`
                         : ""
                 }`,
             readmeFile: typedocPackageConfig?.readmeFile

--- a/src/lib/utils/package-manifest.ts
+++ b/src/lib/utils/package-manifest.ts
@@ -6,7 +6,7 @@ import { existsSync } from "fs";
 import { readFile, glob } from "./fs";
 import type { Logger } from "./loggers";
 import type { IMinimatch } from "minimatch";
-import { matchesAny } from "./paths";
+import { matchesAny, nicePath } from "./paths";
 import { additionalProperties, Infer, optional, validate } from "./validation";
 
 /**
@@ -258,7 +258,9 @@ export function getTsEntryPointForPackage(
         typeof packageJson.typedocMain == "string"
     ) {
         logger.warn(
-            `Legacy typedoc entry point config (using "typedocMain" field) found for "${packageJsonPath}". Please update to use "typedoc": { "entryPoint": "..." } instead. In future upgrade, "typedocMain" field will be ignored.`
+            `Legacy typedoc entry point config (using "typedocMain" field) found for "${nicePath(
+                packageJsonPath
+            )}". Please update to use "typedoc": { "entryPoint": "..." } instead. In future upgrade, "typedocMain" field will be ignored.`
         );
         packageMain = packageJson.typedocMain;
     } else if (

--- a/src/test/packages.test.ts
+++ b/src/test/packages.test.ts
@@ -9,7 +9,7 @@ import {
 
 import { tempdirProject } from "@typestrong/fs-fixture-builder";
 import { TestLogger } from "./TestLogger";
-import { createMinimatch } from "../lib/utils/paths";
+import { createMinimatch, nicePath } from "../lib/utils/paths";
 
 describe("Packages support", () => {
     let project: ReturnType<typeof tempdirProject>;
@@ -178,9 +178,8 @@ describe("Packages support", () => {
 
         logger.discardDebugMessages();
         logger.expectMessage(
-            `warn: Legacy typedoc entry point config (using "typedocMain" field) found for "${join(
-                project.cwd,
-                "/packages/foo/package.json"
+            `warn: Legacy typedoc entry point config (using "typedocMain" field) found for "${nicePath(
+                join(project.cwd, "/packages/foo/package.json")
             )}". Please update to use "typedoc": { "entryPoint": "..." } instead. In future upgrade, "typedocMain" field will be ignored.`
         );
     });

--- a/src/test/packages.test.ts
+++ b/src/test/packages.test.ts
@@ -63,6 +63,19 @@ describe("Packages support", () => {
         });
         project.addJsonFile("packages/baz/tsconfig.json", childTsconfig);
 
+        // Bay, entry point with "typedoc.entryPoint"
+        project.addFile("packages/bay/dist/index.js", "module.exports = 123");
+        project.addFile("packages/bay/index.ts", "export function foo() {}");
+        project.addJsonFile("packages/bay/package.json", {
+            name: "typedoc-multi-package-bay",
+            version: "1.0.0",
+            main: "dist/index",
+            typedoc: {
+                entryPoint: "index.ts",
+            },
+        });
+        project.addJsonFile("packages/bay/tsconfig.json", childTsconfig);
+
         // Foo, entry point with "typedocMain"
         project.addFile("packages/foo/dist/index.js", "module.exports = 123");
         project.addFile("packages/foo/index.ts", "export function foo() {}");
@@ -98,6 +111,7 @@ describe("Packages support", () => {
             packages,
             [
                 join(project.cwd, "packages/bar"),
+                join(project.cwd, "packages/bay"),
                 join(project.cwd, "packages/baz"),
                 join(project.cwd, "packages/foo"),
             ].map(normalizePath)
@@ -114,6 +128,7 @@ describe("Packages support", () => {
 
         equal(entries, [
             join(project.cwd, "packages/bar/index.d.ts"),
+            join(project.cwd, "packages/bay/index.ts"),
             join(project.cwd, "packages/baz/index.ts"),
             join(project.cwd, "packages/foo/index.ts"),
         ]);


### PR DESCRIPTION
This PR provides some improvements for users of `--entryPointStrategy Packages`. These includes:

- [x] Improved support for `--entryPointStrategy Packages`. TypeDoc will now load package-specific configurations from `package.json` `typedoc` field. This configuration allows configuring a custom display name (`typedoc.displayName`) field, entry point (`typedoc.entryPoint` - this is equivalent and will override `typedocMain`), and path to a readme file to be rendered at the top of the package page (`typedoc.readmeFile`), fixes #1658 
-  [x] The `--includeVersion` option will now be respected by `--entryPointStrategy Packages`. Also, for this combination, missing `version` field in the root `package.json` will not issue a warning - _this fix would be useful for folks who want to turn on `--includeVersion` and yet don't really want to put a version in the main `package.json` because it's not always meaningful to do so in a monorepo_

This is the shape of the `typedoc` config (in the child-packages' `package.json`):

```ts
export interface TypedocPackageManifestConfig {
    entryPoint?: string | undefined;
    displayName?: string | undefined;
    readmeFile?: string | undefined;
}
```

I feel that having per-package config allows more flexibility.

This is a screenshot of my change (the README per module and the version per child package)


https://user-images.githubusercontent.com/13574879/177013017-8ddb2f9c-736a-4bb8-8bc3-a6cefee64d55.mov


Let me know what you think about these features!


---
**UPDATED**

I notice that when I develop locally, converter tests will likely fail due to the hardcoded `url` in the `specs.json` file. I suppose you don't mind since you run locally and push directly to the repo, for us who work on the fork, these tests will likely fail.

^ Thanks @Gerrit0 ! Works like charms now 🙏 