### PR TITLE
fixes for schema.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,22 @@
 {
+    "files.associations": {
+        "tsdoc.json": "jsonc", // TSDoc allows comments.
+        "typedoc.json": "jsonc" // TypeDoc uses the JSONC parser for its configuration files.
+    },
+
     "typescript.tsdk": "./node_modules/typescript/lib",
+
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "[typescriptreact]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+
     "prettier.enable": true,
     "prettier.configPath": ".config/.prettierrc.json",
     "prettier.ignorePath": ".config/.prettierignore",
+
     "eslint.workingDirectories": [".", "./example"],
     "mochaExplorer.configFile": ".config/mocha.test-explorer.json",
     "cSpell.words": ["cname", "tsbuildinfo", "tsdoc"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,11 +6,31 @@
 
     "typescript.tsdk": "./node_modules/typescript/lib",
 
+    // Automatically run the formatter when certain files are saved.
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.tabSize": 4
+    },
     "[typescript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.tabSize": 4
     },
     "[typescriptreact]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.tabSize": 4
+    },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.tabSize": 4
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.tabSize": 4
     },
 
     "prettier.enable": true,

--- a/scripts/generate_options_schema.js
+++ b/scripts/generate_options_schema.js
@@ -78,7 +78,9 @@ addTypeDocOptions({
                 data.enum =
                     map instanceof Map
                         ? [...map.keys()].map(lowerCaseFirstLetter)
-                        : Object.keys(map).filter((key) => isNaN(+key)).map(lowerCaseFirstLetter);
+                        : Object.keys(map)
+                              .filter((key) => isNaN(+key))
+                              .map(lowerCaseFirstLetter);
                 data.default =
                     /** @type {import("../dist").MapDeclarationOption} */ (
                         option

--- a/scripts/generate_options_schema.js
+++ b/scripts/generate_options_schema.js
@@ -77,10 +77,12 @@ addTypeDocOptions({
                     ).map;
                 data.enum =
                     map instanceof Map
-                        ? [...map.keys()].map(lowerCaseFirstLetter)
+                        ? [...map.values()]
                         : Object.keys(map)
                               .filter((key) => isNaN(+key))
-                              .map(lowerCaseFirstLetter);
+                              .map((key) =>
+                                  typeof map[key] === "number" ? key : map[key]
+                              );
                 data.default =
                     /** @type {import("../dist").MapDeclarationOption} */ (
                         option

--- a/scripts/generate_options_schema.js
+++ b/scripts/generate_options_schema.js
@@ -16,10 +16,6 @@ const schema = {
     allowTrailingCommas: true,
 };
 
-function lowerCaseFirstLetter(string) {
-    return string.charAt(0).toLowerCase() + string.slice(1);
-}
-
 addTypeDocOptions({
     /** @param {import("../dist").DeclarationOption} option */
     addDeclaration(option) {

--- a/scripts/generate_options_schema.js
+++ b/scripts/generate_options_schema.js
@@ -13,7 +13,12 @@ const schema = {
     title: "JSON Schema for typedoc.json",
     type: "object",
     properties: {},
+    allowTrailingCommas: true,
 };
+
+function lowerCaseFirstLetter(string) {
+    return string.charAt(0).toLowerCase() + string.slice(1);
+}
 
 addTypeDocOptions({
     /** @param {import("../dist").DeclarationOption} option */
@@ -72,8 +77,8 @@ addTypeDocOptions({
                     ).map;
                 data.enum =
                     map instanceof Map
-                        ? [...map.keys()]
-                        : Object.keys(map).filter((key) => isNaN(+key));
+                        ? [...map.keys()].map(lowerCaseFirstLetter)
+                        : Object.keys(map).filter((key) => isNaN(+key)).map(lowerCaseFirstLetter);
                 data.default =
                     /** @type {import("../dist").MapDeclarationOption} */ (
                         option


### PR DESCRIPTION
there are 3 fixes in this PR:

1) properly define json files in settings.json so that they don't throw errors in vscode when you open them
2) add `"allowTrailingCommas": true` as documented here: https://github.com/microsoft/vscode/issues/102061#issuecomment-656541600
3) lowercase first letter of enum members so that they match the stylization in the docs