### PR TITLE
Add more Github Enterprise URLs

### DIFF
--- a/src/lib/converter/utils/repository.ts
+++ b/src/lib/converter/utils/repository.ts
@@ -71,7 +71,7 @@ export class Repository {
 
         for (let i = 0, c = repoLinks.length; i < c; i++) {
             let match =
-                /(github(?:\.[a-z]+)*\.[a-z]{2,})[:/]([^/]+)\/(.*)/.exec(
+                /(github(?!.us)(?:\.[a-z]+)*\.[a-z]{2,})[:/]([^/]+)\/(.*)/.exec(
                     repoLinks[i]
                 );
 
@@ -80,6 +80,16 @@ export class Repository {
                 match = /(\w+\.githubprivate.com)[:/]([^/]+)\/(.*)/.exec(
                     repoLinks[i]
                 );
+            }
+
+            // Github Enterprise
+            if (!match) {
+                match = /(\w+\.ghe.com)[:/]([^/]+)\/(.*)/.exec(repoLinks[i]);
+            }
+
+            // Github Enterprise
+            if (!match) {
+                match = /(\w+\.github.us)[:/]([^/]+)\/(.*)/.exec(repoLinks[i]);
             }
 
             if (!match) {

--- a/src/test/Repository.test.ts
+++ b/src/test/Repository.test.ts
@@ -46,6 +46,32 @@ describe("Repository", function () {
             equal(repository.type, RepositoryType.GitHub);
         });
 
+        it("handles a ghe.com URL", function () {
+            const mockRemotes = [
+                "ssh://org@bigcompany.ghe.com/joebloggs/foobar.git",
+            ];
+
+            const repository = new Repository("", "", mockRemotes);
+
+            equal(repository.hostname, "bigcompany.ghe.com");
+            equal(repository.user, "joebloggs");
+            equal(repository.project, "foobar");
+            equal(repository.type, RepositoryType.GitHub);
+        });
+
+        it("handles a github.us URL", function () {
+            const mockRemotes = [
+                "ssh://org@bigcompany.github.us/joebloggs/foobar.git",
+            ];
+
+            const repository = new Repository("", "", mockRemotes);
+
+            equal(repository.hostname, "bigcompany.github.us");
+            equal(repository.user, "joebloggs");
+            equal(repository.project, "foobar");
+            equal(repository.type, RepositoryType.GitHub);
+        });
+
         it("handles a Bitbucket HTTPS URL", function () {
             const mockRemotes = [
                 "https://joebloggs@bitbucket.org/joebloggs/foobar.git",


### PR DESCRIPTION
This PR adds support for more github enterprise URLs. They offer:

```
*.ghe.com
*.github.us
```

https://github.com/github/docs/blob/5f4ef9a6217181efc12e67463894783496fb0c79/content/admin/identity-and-access-management/using-saml-for-enterprise-iam/saml-configuration-reference.md#saml-response-requirements