### PR TITLE
Make 'mixed' option defaults for plugins override at a sub-key level

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -154,27 +154,32 @@ export class Application extends ChildableComponent<
         }
         this.options.read(this.logger);
 
-        /* For plugin options as an object (ie. ParameterType.Mixed), this takes the default 
-         * options declared in 'load()' by the plugin developer, and merges them with any 
+        /* For plugin options as an object (ie. ParameterType.Mixed), this takes the default
+         * options declared in 'load()' by the plugin developer, and merges them with any
          * custom options declared by a user in 'typedoc.json'.
-         * 
+         *
          * see https://github.com/TypeStrong/typedoc/issues/2024
          */
         for (const [key, value] of Object.entries(defaultPluginOptions)) {
-            const loadedValue = this.options.getValue(key as keyof TypeDocOptions) as object;
+            const loadedValue = this.options.getValue(
+                key as keyof TypeDocOptions
+            ) as object;
             /* Only merge plugin keys from objects.
              * Arrays and string options, if set in typedoc.json, completely
              * overwrite the default plugin options.
-             */ 
-            if (typeof value === 'object' && !Array.isArray(value)) {
-                const newValue = {...value, ...loadedValue};
+             */
+            if (typeof value === "object" && !Array.isArray(value)) {
+                const newValue = { ...value, ...loadedValue };
                 try {
-                    this.options.setValue(key as keyof TypeDocOptions, newValue);
+                    this.options.setValue(
+                        key as keyof TypeDocOptions,
+                        newValue
+                    );
                 } catch (error) {
                     ok(error instanceof Error);
                     this.logger.error(error.message);
-                }    
-            } 
+                }
+            }
         }
 
         if (hasBeenLoadedMultipleTimes()) {
@@ -185,16 +190,20 @@ export class Application extends ChildableComponent<
     }
     /**
      * Isolates and returns options specific to plugins only.
-     * 
+     *
      * @param typedocOptionKeys an array of all typedoc specific options keys
      * @returns options specific to plugins
      */
-    private stashPluginOptions(typedocOptionKeys: string[]): {[key: string]: unknown} {
-        const allOptions: {[key: string]: unknown} = this.options.getRawValues();
-        const pluginOptions: {[key: string]: unknown} = {};
-        Object.keys(allOptions).forEach(key => {
-            (typedocOptionKeys.indexOf(key) < 0) && (pluginOptions[key] = allOptions[key])
-        })
+    private stashPluginOptions(typedocOptionKeys: string[]): {
+        [key: string]: unknown;
+    } {
+        const allOptions: { [key: string]: unknown } =
+            this.options.getRawValues();
+        const pluginOptions: { [key: string]: unknown } = {};
+        Object.keys(allOptions).forEach((key) => {
+            typedocOptionKeys.indexOf(key) < 0 &&
+                (pluginOptions[key] = allOptions[key]);
+        });
         return pluginOptions;
     }
 

--- a/src/test/plugins/testOptionsPlugin.js
+++ b/src/test/plugins/testOptionsPlugin.js
@@ -1,13 +1,13 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { ParameterType } = require('../../../');
+const { ParameterType } = require("../../../");
 exports.load = (app) => {
-	app.options.addDeclaration({
-		help: 'Test option parsing with default values from plugins',
-		name: 'testOptions',
-		type: ParameterType.Mixed,
-		defaultValue: {
-			foo: 'foo',
-			bar: ['foo', 'bar']
-		},
-	});
-}
+    app.options.addDeclaration({
+        help: "Test option parsing with default values from plugins",
+        name: "testOptions",
+        type: ParameterType.Mixed,
+        defaultValue: {
+            foo: "foo",
+            bar: ["foo", "bar"],
+        },
+    });
+};

--- a/src/test/plugins/testOptionsPlugin.js
+++ b/src/test/plugins/testOptionsPlugin.js
@@ -1,0 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ParameterType } = require('../../../');
+exports.load = (app) => {
+	app.options.addDeclaration({
+		help: 'Test option parsing with default values from plugins',
+		name: 'testOptions',
+		type: ParameterType.Mixed,
+		defaultValue: {
+			foo: 'foo',
+			bar: ['foo', 'bar']
+		},
+	});
+}

--- a/src/test/utils/options/default-options.test.ts
+++ b/src/test/utils/options/default-options.test.ts
@@ -113,18 +113,20 @@ describe("Default Options", () => {
     /* passing arrow functions to MOCHA is discouraged.
      * See: https://mochajs.org/#arrow-functions
      */
-    describe("plugin options", function() {
-        it("overrides 'mixed' type plugin options by individual keys", function (){
+    describe("plugin options", function () {
+        it("overrides 'mixed' type plugin options by individual keys", function () {
             const app = new Application();
             app.bootstrap({
                 plugin: ["./src/test/plugins/testOptionsPlugin.js"],
-                testOptions: {"foo": "foofoo"}
-            } as Partial<TypeDocOptions>)
-            const testOptions = app.options.getValue('testOptions' as keyof TypeDocOptions);
+                testOptions: { foo: "foofoo" },
+            } as Partial<TypeDocOptions>);
+            const testOptions = app.options.getValue(
+                "testOptions" as keyof TypeDocOptions
+            );
             deepEqual(testOptions, {
-                foo: 'foofoo',
-                bar: ['foo', 'bar']
-            })
+                foo: "foofoo",
+                bar: ["foo", "bar"],
+            });
         });
-    })
+    });
 });

--- a/src/test/utils/options/default-options.test.ts
+++ b/src/test/utils/options/default-options.test.ts
@@ -1,6 +1,7 @@
-import { ok, throws, strictEqual, doesNotThrow } from "assert";
+import { ok, throws, strictEqual, doesNotThrow, deepEqual } from "assert";
 import { BUNDLED_THEMES } from "shiki";
-import { Logger, Options } from "../../../lib/utils";
+import { Logger, Options, TypeDocOptions } from "../../../lib/utils";
+import { Application } from "../../../lib/application";
 
 describe("Default Options", () => {
     const opts = new Options(new Logger());
@@ -108,4 +109,22 @@ describe("Default Options", () => {
             doesNotThrow(() => opts.setValue("searchGroupBoosts", { Enum: 5 }));
         });
     });
+
+    /* passing arrow functions to MOCHA is discouraged.
+     * See: https://mochajs.org/#arrow-functions
+     */
+    describe("plugin options", function() {
+        it("overrides 'mixed' type plugin options by individual keys", function (){
+            const app = new Application();
+            app.bootstrap({
+                plugin: ["./src/test/plugins/testOptionsPlugin.js"],
+                testOptions: {"foo": "foofoo"}
+            } as Partial<TypeDocOptions>)
+            const testOptions = app.options.getValue('testOptions' as keyof TypeDocOptions);
+            deepEqual(testOptions, {
+                foo: 'foofoo',
+                bar: ['foo', 'bar']
+            })
+        });
+    })
 });


### PR DESCRIPTION
This resolves [issue 2024](https://github.com/TypeStrong/typedoc/issues/2024).

It:
- allows default plugin options declared as 'mixed' type to be overridden partially by sub-key in typedoc.json


