### PR TITLE
Remove default template headers of Hierarchy and Type Parameters from DefaultThemeRenderContext when overridden.

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "build:prod": "npm run build:prod:tsc && npm run build:themes",
     "build:prod:tsc": "tsc --project . --sourceMap false",
     "lint": "eslint . && npm run prettier -- --check .",
-    "prettier": "prettier --config .config/.prettierrc.json --ignore-path .config/.prettierignore",
+    "prettier": "prettier -w --config .config/.prettierrc.json --ignore-path .config/.prettierignore",
     "prepublishOnly": "node scripts/set_strict.js false && npm run build:prod && npm test",
     "postpublish": "node scripts/set_strict.js true"
   },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "build:prod": "npm run build:prod:tsc && npm run build:themes",
     "build:prod:tsc": "tsc --project . --sourceMap false",
     "lint": "eslint . && npm run prettier -- --check .",
-    "prettier": "prettier -w --config .config/.prettierrc.json --ignore-path .config/.prettierignore",
+    "prettier": "prettier --config .config/.prettierrc.json --ignore-path .config/.prettierignore",
     "prepublishOnly": "node scripts/set_strict.js false && npm run build:prod && npm test",
     "postpublish": "node scripts/set_strict.js true"
   },

--- a/src/lib/output/themes/default/partials/hierarchy.tsx
+++ b/src/lib/output/themes/default/partials/hierarchy.tsx
@@ -2,16 +2,20 @@ import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext";
 import { JSX } from "../../../../utils";
 import type { DeclarationHierarchy } from "../../../../models";
 
-export const hierarchy = (context: DefaultThemeRenderContext, props: DeclarationHierarchy) => (
+export const hierarchy = (context: DefaultThemeRenderContext, props: DeclarationHierarchy | undefined) => (
     <>
-        <h4>Hierarchy</h4>
-        <ul class="tsd-hierarchy">
-            {props.types.map((item, i, l) => (
-                <li>
-                    {props.isTarget ? <span class="target">{item.toString()}</span> : context.type(item)}
-                    {i === l.length - 1 && !!props.next && context.hierarchy(props.next)}
-                </li>
-            ))}
-        </ul>
+        {!!props && (
+            <section class="tsd-panel tsd-hierarchy">
+                <h4>Hierarchy</h4>
+                <ul class="tsd-hierarchy">
+                    {props.types.map((item, i, l) => (
+                        <li>
+                            {props.isTarget ? <span class="target">{item.toString()}</span> : context.type(item)}
+                            {i === l.length - 1 && !!props.next && context.hierarchy(props.next)}
+                        </li>
+                    ))}
+                </ul>
+            </section>
+        )}
     </>
 );

--- a/src/lib/output/themes/default/partials/hierarchy.tsx
+++ b/src/lib/output/themes/default/partials/hierarchy.tsx
@@ -3,12 +3,15 @@ import { JSX } from "../../../../utils";
 import type { DeclarationHierarchy } from "../../../../models";
 
 export const hierarchy = (context: DefaultThemeRenderContext, props: DeclarationHierarchy) => (
-    <ul class="tsd-hierarchy">
-        {props.types.map((item, i, l) => (
-            <li>
-                {props.isTarget ? <span class="target">{item.toString()}</span> : context.type(item)}
-                {i === l.length - 1 && !!props.next && context.hierarchy(props.next)}
-            </li>
-        ))}
-    </ul>
+    <>
+        <h4>Hierarchy</h4>
+        <ul class="tsd-hierarchy">
+            {props.types.map((item, i, l) => (
+                <li>
+                    {props.isTarget ? <span class="target">{item.toString()}</span> : context.type(item)}
+                    {i === l.length - 1 && !!props.next && context.hierarchy(props.next)}
+                </li>
+            ))}
+        </ul>
+    </>
 );

--- a/src/lib/output/themes/default/partials/typeParameters.tsx
+++ b/src/lib/output/themes/default/partials/typeParameters.tsx
@@ -4,28 +4,31 @@ import { JSX } from "../../../../utils";
 
 export function typeParameters(context: DefaultThemeRenderContext, typeParameters: TypeParameterReflection[]) {
     return (
-        <ul class="tsd-type-parameters">
-            {typeParameters?.map((item) => (
-                <li>
-                    <h4>
-                        {item.varianceModifier ? `${item.varianceModifier} ` : ""}
-                        {item.name}
-                        {!!item.type && (
-                            <>
-                                <span class="tsd-signature-symbol"> extends </span>
-                                {context.type(item.type)}
-                            </>
-                        )}
-                        {!!item.default && (
-                            <>
-                                {" = "}
-                                {context.type(item.default)}
-                            </>
-                        )}
-                    </h4>
-                    {context.comment(item)}
-                </li>
-            ))}
-        </ul>
+        <>
+            <h4>Type Parameters</h4>
+            <ul class="tsd-type-parameters">
+                {typeParameters?.map((item) => (
+                    <li>
+                        <h4>
+                            {item.varianceModifier ? `${item.varianceModifier} ` : ""}
+                            {item.name}
+                            {!!item.type && (
+                                <>
+                                    <span class="tsd-signature-symbol"> extends </span>
+                                    {context.type(item.type)}
+                                </>
+                            )}
+                            {!!item.default && (
+                                <>
+                                    {" = "}
+                                    {context.type(item.default)}
+                                </>
+                            )}
+                        </h4>
+                        {context.comment(item)}
+                    </li>
+                ))}
+            </ul>
+        </>
     );
 }

--- a/src/lib/output/themes/default/partials/typeParameters.tsx
+++ b/src/lib/output/themes/default/partials/typeParameters.tsx
@@ -5,30 +5,32 @@ import { JSX } from "../../../../utils";
 export function typeParameters(context: DefaultThemeRenderContext, typeParameters: TypeParameterReflection[]) {
     return (
         <>
-            <h4>Type Parameters</h4>
-            <ul class="tsd-type-parameters">
-                {typeParameters?.map((item) => (
-                    <li>
-                        <h4>
-                            {item.varianceModifier ? `${item.varianceModifier} ` : ""}
-                            {item.name}
-                            {!!item.type && (
-                                <>
-                                    <span class="tsd-signature-symbol"> extends </span>
-                                    {context.type(item.type)}
-                                </>
-                            )}
-                            {!!item.default && (
-                                <>
-                                    {" = "}
-                                    {context.type(item.default)}
-                                </>
-                            )}
-                        </h4>
-                        {context.comment(item)}
-                    </li>
-                ))}
-            </ul>
+            <section class="tsd-panel tsd-type-parameters">
+                <h4>Type Parameters</h4>
+                <ul class="tsd-type-parameters">
+                    {typeParameters?.map((item) => (
+                        <li>
+                            <h4>
+                                {item.varianceModifier ? `${item.varianceModifier} ` : ""}
+                                {item.name}
+                                {!!item.type && (
+                                    <>
+                                        <span class="tsd-signature-symbol"> extends </span>
+                                        {context.type(item.type)}
+                                    </>
+                                )}
+                                {!!item.default && (
+                                    <>
+                                        {" = "}
+                                        {context.type(item.default)}
+                                    </>
+                                )}
+                            </h4>
+                            {context.comment(item)}
+                        </li>
+                    ))}
+                </ul>
+            </section>
         </>
     );
 }

--- a/src/lib/output/themes/default/templates/reflection.tsx
+++ b/src/lib/output/themes/default/templates/reflection.tsx
@@ -18,7 +18,6 @@ export function reflectionTemplate(context: DefaultThemeRenderContext, props: Pa
 
             {hasTypeParameters(props.model) && (
                 <section class="tsd-panel tsd-type-parameters">
-                    <h4>Type Parameters</h4>
                     {context.typeParameters(props.model.typeParameters)}
                 </section>
             )}
@@ -26,7 +25,6 @@ export function reflectionTemplate(context: DefaultThemeRenderContext, props: Pa
                 <>
                     {!!props.model.typeHierarchy && (
                         <section class="tsd-panel tsd-hierarchy">
-                            <h4>Hierarchy</h4>
                             {context.hierarchy(props.model.typeHierarchy)}
                         </section>
                     )}

--- a/src/lib/output/themes/default/templates/reflection.tsx
+++ b/src/lib/output/themes/default/templates/reflection.tsx
@@ -16,18 +16,11 @@ export function reflectionTemplate(context: DefaultThemeRenderContext, props: Pa
                 <section class="tsd-panel tsd-comment">{context.comment(props.model)}</section>
             )}
 
-            {hasTypeParameters(props.model) && (
-                <section class="tsd-panel tsd-type-parameters">
-                    {context.typeParameters(props.model.typeParameters)}
-                </section>
-            )}
+            {hasTypeParameters(props.model) && <> {context.typeParameters(props.model.typeParameters)} </>}
             {props.model instanceof DeclarationReflection && (
                 <>
-                    {!!props.model.typeHierarchy && (
-                        <section class="tsd-panel tsd-hierarchy">
-                            {context.hierarchy(props.model.typeHierarchy)}
-                        </section>
-                    )}
+                    {context.hierarchy(props.model.typeHierarchy)}
+
                     {!!props.model.implementedTypes && (
                         <section class="tsd-panel">
                             <h4>Implements</h4>


### PR DESCRIPTION
If you create your own theme by extending `DefaultThemeRenderContext` and attempt to override `this.hierarchy` or `this.typeParameters` with empty content (disable them), their HTML headers get generated to the output document regardless. This PR removes the HTML headers if the default template is overridden.

```typescript
export class FooterOverrideThemeContext extends DefaultThemeRenderContext {
  constructor(theme: DefaultTheme, options: Options) {
    super(theme, options);
    // disable:
    this.hierarchy = () => { return (<></>)}
    this.typeParameters = () => { return(<></>)}
  }
}

```