### PR TITLE
Pretty print types in Default theme

### DIFF
--- a/src/lib/output/themes/default/DefaultThemeRenderContext.ts
+++ b/src/lib/output/themes/default/DefaultThemeRenderContext.ts
@@ -46,12 +46,25 @@ function bind<F, L extends any[], R>(fn: (f: F, ...a: L) => R, first: F) {
 
 export class DefaultThemeRenderContext {
     options: Options;
+    private currentDepth: number = 0;
 
     constructor(private theme: DefaultTheme, options: Options) {
         this.options = options;
     }
 
     icons = icons;
+
+    getCurrentDepth(): number {
+        return this.currentDepth;
+    }
+
+    incrementCurrentDepth(): void {
+        this.currentDepth ++;
+    }
+
+    decrementCurrentDepth(): void {
+        this.currentDepth --;
+    }
 
     hook = (name: keyof RendererHooks) =>
         this.theme.owner.hooks.emit(name, this);

--- a/src/lib/output/themes/default/DefaultThemeRenderContext.ts
+++ b/src/lib/output/themes/default/DefaultThemeRenderContext.ts
@@ -59,11 +59,11 @@ export class DefaultThemeRenderContext {
     }
 
     incrementCurrentDepth(): void {
-        this.currentDepth ++;
+        this.currentDepth++;
     }
 
     decrementCurrentDepth(): void {
-        this.currentDepth --;
+        this.currentDepth--;
     }
 
     hook = (name: keyof RendererHooks) =>

--- a/src/lib/output/themes/default/DefaultThemeRenderContext.ts
+++ b/src/lib/output/themes/default/DefaultThemeRenderContext.ts
@@ -46,7 +46,7 @@ function bind<F, L extends any[], R>(fn: (f: F, ...a: L) => R, first: F) {
 
 export class DefaultThemeRenderContext {
     options: Options;
-    private currentDepth: number = 0;
+    private currentDepth = 0;
 
     constructor(private theme: DefaultTheme, options: Options) {
         this.options = options;

--- a/src/lib/output/themes/default/partials/type.tsx
+++ b/src/lib/output/themes/default/partials/type.tsx
@@ -68,9 +68,11 @@ function renderUniquePath(context: DefaultThemeRenderContext, reflection: Reflec
     ));
 }
 function includeIndentation(context: DefaultThemeRenderContext): JSX.Element {
-    return context.getCurrentDepth() > 0 
-        ? <span>{new Array(context.getCurrentDepth() * 4).fill('\u00A0').join('')}</span> 
-        : <></>; 
+    return context.getCurrentDepth() > 0 ? (
+        <span>{new Array(context.getCurrentDepth() * 4).fill("\u00A0").join("")}</span>
+    ) : (
+        <></>
+    );
 }
 
 // The type helper accepts an optional needsParens parameter that is checked
@@ -372,7 +374,7 @@ const typeRenderers: {
                 includeIndentation(context),
                 m,
                 <span class="tsd-signature-symbol">; </span>,
-                <br></br>
+                <br></br>,
             ]);
             membersWithSeparators.pop();
 

--- a/src/lib/output/themes/default/partials/type.tsx
+++ b/src/lib/output/themes/default/partials/type.tsx
@@ -1,5 +1,6 @@
 import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext";
 import {
+    DeclarationReflection,
     LiteralType,
     ProjectReflection,
     ReferenceType,
@@ -65,6 +66,11 @@ function renderUniquePath(context: DefaultThemeRenderContext, reflection: Reflec
             {item.name}
         </a>
     ));
+}
+function includeIndentation(context: DefaultThemeRenderContext): JSX.Element {
+    return context.getCurrentDepth() > 0 
+        ? <span>{new Array(context.getCurrentDepth() * 4).fill('\u00A0').join('')}</span> 
+        : <></>; 
 }
 
 // The type helper accepts an optional needsParens parameter that is checked
@@ -277,8 +283,11 @@ const typeRenderers: {
     },
     reflection(context, type) {
         const members: JSX.Element[] = [];
+        const children: DeclarationReflection[] = type.declaration.children || [];
 
-        for (const item of type.declaration.children || []) {
+        if (children.length) context.incrementCurrentDepth();
+
+        for (const item of children) {
             if (item.getSignature && item.setSignature) {
                 members.push(
                     <>
@@ -359,14 +368,24 @@ const typeRenderers: {
         }
 
         if (members.length) {
-            const membersWithSeparators = members.flatMap((m) => [m, <span class="tsd-signature-symbol">; </span>]);
+            const membersWithSeparators = members.flatMap((m) => [
+                includeIndentation(context),
+                m,
+                <span class="tsd-signature-symbol">; </span>,
+                <br></br>
+            ]);
             membersWithSeparators.pop();
+
+            context.decrementCurrentDepth();
 
             return (
                 <>
                     <span class="tsd-signature-symbol">{"{"} </span>
+                    <br></br>
                     {membersWithSeparators}
-                    <span class="tsd-signature-symbol"> {"}"}</span>
+                    <br></br>
+                    {includeIndentation(context)}
+                    <span class="tsd-signature-symbol">{"}"}</span>
                 </>
             );
         }


### PR DESCRIPTION
I faced same issue as mentioned [here](https://github.com/TypeStrong/typedoc/issues/1793) - large types looks ugly because of no line wraps or indentation.

I offer an improvement for DefaultTheme that allows to render types as formatted tree using `DefaultThemeRenderContext` as storage when recursively rendering nesting types.

Example of working:

![before](https://user-images.githubusercontent.com/18083995/193501522-fcb35c3a-bdbc-4faa-8b2f-17bbfa9b1b9f.png)

![after](https://user-images.githubusercontent.com/18083995/193501595-32b25af0-d8a1-4c00-9729-7bbdfb49a8c2.png)

I think this feature should be controlled with some additional configuration options (at least, use this feature or no and indent spaces quantity), but I'm not sure about your policy of adding theme-related options.
