### PR TITLE
Feature: allow plugins to return async values from getUrls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Features
+-   Plugins can now optionally return a promise from `getUrls` to allow async determination of url mappings
+
 ### Bug Fixes
 
 -   Private parameter properties will no longer be ignored, #2064.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ### Features
+
 -   Plugins can now optionally return a promise from `getUrls` to allow async determination of url mappings
 
 ### Bug Fixes

--- a/src/lib/models/reflections/index.ts
+++ b/src/lib/models/reflections/index.ts
@@ -15,3 +15,4 @@ export { ReferenceReflection } from "./reference";
 export { SignatureReflection } from "./signature";
 export { TypeParameterReflection, VarianceModifier } from "./type-parameter";
 export { splitUnquotedString } from "./utils";
+export type { MaybePromise } from "./utils";

--- a/src/lib/models/reflections/utils.ts
+++ b/src/lib/models/reflections/utils.ts
@@ -1,3 +1,5 @@
+export type MaybePromise<T> = T | Promise<T>;
+
 export function splitUnquotedString(
     input: string,
     delimiter: string

--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -233,7 +233,7 @@ export class Renderer extends ChildableComponent<
             outputDirectory,
             project
         );
-        output.urls = this.theme!.getUrls(project);
+        output.urls = await this.theme!.getUrls(project);
 
         this.trigger(output);
 

--- a/src/lib/output/theme.ts
+++ b/src/lib/output/theme.ts
@@ -4,8 +4,7 @@ import type { UrlMapping } from "./models/UrlMapping";
 import { RendererComponent } from "./components";
 import { Component } from "../utils/component";
 import type { PageEvent } from "./events";
-import type { Reflection } from "../models";
-
+import type { Reflection, MaybePromise } from "../models";
 /**
  * Base class of all themes.
  *
@@ -41,7 +40,7 @@ export abstract class Theme extends RendererComponent {
      * @returns A list of {@link UrlMapping} instances defining which models
      * should be rendered to which files.
      */
-    abstract getUrls(project: ProjectReflection): UrlMapping[];
+    abstract getUrls(project: ProjectReflection): MaybePromise<UrlMapping[]>;
 
     /**
      * Renders the provided page to a string, which will be written to disk by the {@link Renderer}


### PR DESCRIPTION
We found this necessary to support alternative templating systems which require async time to read templates from disk or otherwise do thinking to determine the URL mappings based on something async.

Because `await` on scalars is a no-op this change seems to be inert to old code.

Many thanks!