### PR TITLE
Fix #2101 support externalSymbolLinkMappings wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+### Features
+
+-   Allow to define wildcard mapping in `externalSymbolLinkMappings`.
+
 ## v0.23.20 (2022-11-03)
 
 ### Bug Fixes

--- a/internal-docs/third-party-symbols.md
+++ b/internal-docs/third-party-symbols.md
@@ -32,6 +32,20 @@ detected as belonging to the `typescript` package rather than the `global` packa
 }
 ```
 
+A wildcard can be used to provide a fallback link to any unmapped type.
+
+```jsonc
+// typedoc.json
+{
+    "externalSymbolLinkMappings": {
+        "external-lib": {
+            "SomeObject": "https://external-lib.site/docs/SomeObject",
+            "*": "https://external-lib.site/docs"
+        }
+    }
+}
+```
+
 Plugins can add support for linking to third party sites by calling `app.converter.addUnknownSymbolResolver`.
 
 If the given symbol is unknown, or does not appear in the documentation site, the resolver may return `undefined`

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -190,6 +190,9 @@ export class Converter extends ChildableComponent<
             if (typeof modLinks[name] === "string") {
                 return modLinks[name];
             }
+            if (typeof modLinks["*"] === "string") {
+                return modLinks["*"];
+            }
         });
     }
 

--- a/src/test/behaviorTests.ts
+++ b/src/test/behaviorTests.ts
@@ -225,6 +225,10 @@ export const behaviorTests: {
             typescript: {
                 Promise: "/promise2",
             },
+            "@types/marked": {
+                Lexer: "https://marked.js.org/using_pro#lexer",
+                "*": "https://marked.js.org",
+            },
         });
     },
     externalSymbols(project) {
@@ -238,6 +242,14 @@ export const behaviorTests: {
 
         equal(p.type?.type, "reference" as const);
         equal(p.type.externalUrl, "/promise2");
+
+        const m = query(project, "L");
+        equal(m.type?.type, "reference" as const);
+        equal(m.type.externalUrl, "https://marked.js.org/using_pro#lexer");
+
+        const s = query(project, "S");
+        equal(s.type?.type, "reference" as const);
+        equal(s.type.externalUrl, "https://marked.js.org");
     },
 
     groupTag(project) {

--- a/src/test/converter2/behavior/externalSymbols.ts
+++ b/src/test/converter2/behavior/externalSymbols.ts
@@ -1,5 +1,10 @@
+import { Lexer, Slugger } from "marked";
+
 /**
  * Testing custom external link resolution
  * {@link !Promise}
  */
 export type P = Promise<string>;
+
+export const L = new Lexer();
+export const S = new Slugger();


### PR DESCRIPTION
This solves #2101 with the syntax suggested in said issue.

```json
{
    "externalSymbolLinkMappings": {
        "external-lib": {
            "SomeObject": "https://external-lib.site/docs/SomeObject",
            "*": "https://external-lib.site/docs"
        }
    }
}
```