### PR TITLE
fix: await async plugin load

### DIFF
--- a/bin/typedoc
+++ b/bin/typedoc
@@ -16,57 +16,97 @@ const ExitCodes = {
 const td = require("..");
 const { getOptionsHelp } = require("../dist/lib/utils/options/help");
 
-const app = new td.Application();
+async function main () {
+    const app = new td.Application();
 
-app.options.addReader(new td.ArgumentsReader(0));
-app.options.addReader(new td.TypeDocReader());
-app.options.addReader(new td.TSConfigReader());
-app.options.addReader(new td.ArgumentsReader(300));
+    app.options.addReader(new td.ArgumentsReader(0));
+    app.options.addReader(new td.TypeDocReader());
+    app.options.addReader(new td.TSConfigReader());
+    app.options.addReader(new td.ArgumentsReader(300));
 
-app.bootstrap();
+    await app.bootstrap();
 
-run(app)
-    .catch((error) => {
-        console.error("TypeDoc exiting with unexpected error:");
-        console.error(error);
-        return ExitCodes.ExceptionThrown;
-    })
-    .then((exitCode) => (process.exitCode = exitCode));
+    run(app)
+        .catch((error) => {
+            console.error("TypeDoc exiting with unexpected error:");
+            console.error(error);
+            return ExitCodes.ExceptionThrown;
+        })
+        .then((exitCode) => (process.exitCode = exitCode));
 
-/** @param {td.Application} app */
-async function run(app) {
-    if (app.options.getValue("version")) {
-        console.log(app.toString());
-        return ExitCodes.Ok;
-    }
+    /** @param {td.Application} app */
+    async function run(app) {
+        if (app.options.getValue("version")) {
+            console.log(app.toString());
+            return ExitCodes.Ok;
+        }
 
-    if (app.options.getValue("help")) {
-        console.log(getOptionsHelp(app.options));
-        return ExitCodes.Ok;
-    }
+        if (app.options.getValue("help")) {
+            console.log(getOptionsHelp(app.options));
+            return ExitCodes.Ok;
+        }
 
-    if (app.options.getValue("showConfig")) {
-        console.log(app.options.getRawValues());
-        return ExitCodes.Ok;
-    }
+        if (app.options.getValue("showConfig")) {
+            console.log(app.options.getRawValues());
+            return ExitCodes.Ok;
+        }
 
-    if (app.logger.hasErrors()) {
-        return ExitCodes.OptionError;
-    }
-    if (
-        app.options.getValue("treatWarningsAsErrors") &&
-        app.logger.hasWarnings()
-    ) {
-        return ExitCodes.OptionError;
-    }
+        if (app.logger.hasErrors()) {
+            return ExitCodes.OptionError;
+        }
+        if (
+            app.options.getValue("treatWarningsAsErrors") &&
+            app.logger.hasWarnings()
+        ) {
+            return ExitCodes.OptionError;
+        }
 
-    if (app.options.getValue("entryPoints").length === 0) {
-        app.logger.error("No entry points provided");
-        return ExitCodes.NoEntryPoints;
-    }
+        if (app.options.getValue("entryPoints").length === 0) {
+            app.logger.error("No entry points provided");
+            return ExitCodes.NoEntryPoints;
+        }
 
-    if (app.options.getValue("watch")) {
-        app.convertAndWatch(async (project) => {
+        if (app.options.getValue("watch")) {
+            app.convertAndWatch(async (project) => {
+                const out = app.options.getValue("out");
+                if (out) {
+                    await app.generateDocs(project, out);
+                }
+                const json = app.options.getValue("json");
+                if (json) {
+                    await app.generateJson(project, json);
+                }
+
+                if (!out && !json) {
+                    await app.generateDocs(project, "./docs");
+                }
+            });
+            return ExitCodes.Ok;
+        }
+
+        const project = app.convert();
+        if (!project) {
+            return ExitCodes.CompileError;
+        }
+        if (
+            app.options.getValue("treatWarningsAsErrors") &&
+            app.logger.hasWarnings()
+        ) {
+            return ExitCodes.CompileError;
+        }
+
+        app.validate(project);
+        if (app.logger.hasErrors()) {
+            return ExitCodes.ValidationError;
+        }
+        if (
+            app.options.getValue("treatWarningsAsErrors") &&
+            app.logger.hasWarnings()
+        ) {
+            return ExitCodes.ValidationError;
+        }
+
+        if (app.options.getValue("emit") !== "none") {
             const out = app.options.getValue("out");
             if (out) {
                 await app.generateDocs(project, out);
@@ -79,56 +119,23 @@ async function run(app) {
             if (!out && !json) {
                 await app.generateDocs(project, "./docs");
             }
-        });
+
+            if (app.logger.hasErrors()) {
+                return ExitCodes.OutputError;
+            }
+            if (
+                app.options.getValue("treatWarningsAsErrors") &&
+                app.logger.hasWarnings()
+            ) {
+                return ExitCodes.OutputError;
+            }
+        }
+
         return ExitCodes.Ok;
     }
-
-    const project = app.convert();
-    if (!project) {
-        return ExitCodes.CompileError;
-    }
-    if (
-        app.options.getValue("treatWarningsAsErrors") &&
-        app.logger.hasWarnings()
-    ) {
-        return ExitCodes.CompileError;
-    }
-
-    app.validate(project);
-    if (app.logger.hasErrors()) {
-        return ExitCodes.ValidationError;
-    }
-    if (
-        app.options.getValue("treatWarningsAsErrors") &&
-        app.logger.hasWarnings()
-    ) {
-        return ExitCodes.ValidationError;
-    }
-
-    if (app.options.getValue("emit") !== "none") {
-        const out = app.options.getValue("out");
-        if (out) {
-            await app.generateDocs(project, out);
-        }
-        const json = app.options.getValue("json");
-        if (json) {
-            await app.generateJson(project, json);
-        }
-
-        if (!out && !json) {
-            await app.generateDocs(project, "./docs");
-        }
-
-        if (app.logger.hasErrors()) {
-            return ExitCodes.OutputError;
-        }
-        if (
-            app.options.getValue("treatWarningsAsErrors") &&
-            app.logger.hasWarnings()
-        ) {
-            return ExitCodes.OutputError;
-        }
-    }
-
-    return ExitCodes.Ok;
 }
+
+main().catch(err => {
+    console.error(err)
+    process.exit(1)
+})

--- a/scripts/rebuild_specs.js
+++ b/scripts/rebuild_specs.js
@@ -11,101 +11,101 @@ const { SourceReference } = require("..");
 
 const base = path.join(__dirname, "../src/test/converter");
 
-const app = new TypeDoc.Application();
-app.options.addReader(new TypeDoc.TSConfigReader());
-app.bootstrap({
-    name: "typedoc",
-    excludeExternals: true,
-    disableSources: false,
-    tsconfig: path.join(base, "tsconfig.json"),
-    externalPattern: ["**/node_modules/**"],
-    entryPointStrategy: TypeDoc.EntryPointStrategy.Expand,
-    logLevel: TypeDoc.LogLevel.Warn,
-    gitRevision: "fake",
-});
-app.serializer.addSerializer({
-    priority: -1,
-    supports(obj) {
-        return obj instanceof SourceReference;
-    },
-    /**
-     * @param {SourceReference} ref
-     */
-    toObject(ref, obj, _serializer) {
-        if (obj.url) {
-            obj.url = `typedoc://${obj.url.substring(
-                obj.url.indexOf(ref.fileName)
-            )}`;
-        }
-        return obj;
-    },
-});
-
-/** @type {[string, () => void, () => void][]} */
-const conversions = [
-    [
-        "specs",
-        () => {
-            // nop
+async function main(filter = "") {
+    const app = new TypeDoc.Application();
+    app.options.addReader(new TypeDoc.TSConfigReader());
+    await app.bootstrap({
+        name: "typedoc",
+        excludeExternals: true,
+        disableSources: false,
+        tsconfig: path.join(base, "tsconfig.json"),
+        externalPattern: ["**/node_modules/**"],
+        entryPointStrategy: TypeDoc.EntryPointStrategy.Expand,
+        logLevel: TypeDoc.LogLevel.Warn,
+        gitRevision: "fake",
+    });
+    app.serializer.addSerializer({
+        priority: -1,
+        supports(obj) {
+            return obj instanceof SourceReference;
         },
-        () => {
-            // nop
+        /**
+         * @param {SourceReference} ref
+         */
+        toObject(ref, obj, _serializer) {
+            if (obj.url) {
+                obj.url = `typedoc://${obj.url.substring(
+                    obj.url.indexOf(ref.fileName)
+                )}`;
+            }
+            return obj;
         },
-    ],
-    [
-        "specs-with-lump-categories",
-        () => app.options.setValue("categorizeByGroup", false),
-        () => app.options.setValue("categorizeByGroup", true),
-    ],
-    [
-        "specs.nodoc",
-        () => app.options.setValue("excludeNotDocumented", true),
-        () => app.options.setValue("excludeNotDocumented", false),
-    ],
-];
-
-/**
- * Rebuilds the converter specs for the provided dirs.
- * @param {string[]} dirs
- */
-function rebuildConverterTests(dirs) {
-    const program = ts.createProgram(app.options.getFileNames(), {
-        ...app.options.getCompilerOptions(),
-        noEmit: true,
     });
 
-    const errors = ts.getPreEmitDiagnostics(program);
-    if (errors.length) {
-        app.logger.diagnostics(errors);
-        return;
-    }
+    /** @type {[string, () => void, () => void][]} */
+    const conversions = [
+        [
+            "specs",
+            () => {
+                // nop
+            },
+            () => {
+                // nop
+            },
+        ],
+        [
+            "specs-with-lump-categories",
+            () => app.options.setValue("categorizeByGroup", false),
+            () => app.options.setValue("categorizeByGroup", true),
+        ],
+        [
+            "specs.nodoc",
+            () => app.options.setValue("excludeNotDocumented", true),
+            () => app.options.setValue("excludeNotDocumented", false),
+        ],
+    ];
 
-    for (const fullPath of dirs) {
-        console.log(fullPath);
-        for (const [file, before, after] of conversions) {
-            const out = path.join(fullPath, `${file}.json`);
-            if (fs.existsSync(out)) {
-                TypeDoc.resetReflectionID();
-                before();
-                const entry = getExpandedEntryPointsForPaths(
-                    app.logger,
-                    [fullPath],
-                    app.options,
-                    [program]
-                );
-                ok(entry, "Missing entry point");
-                const result = app.converter.convert(entry);
-                const serialized = app.serializer.toObject(result);
+    /**
+     * Rebuilds the converter specs for the provided dirs.
+     * @param {string[]} dirs
+     */
+    function rebuildConverterTests(dirs) {
+        const program = ts.createProgram(app.options.getFileNames(), {
+            ...app.options.getCompilerOptions(),
+            noEmit: true,
+        });
 
-                const data = JSON.stringify(serialized, null, "  ") + "\n";
-                after();
-                fs.writeFileSync(out, data);
+        const errors = ts.getPreEmitDiagnostics(program);
+        if (errors.length) {
+            app.logger.diagnostics(errors);
+            return;
+        }
+
+        for (const fullPath of dirs) {
+            console.log(fullPath);
+            for (const [file, before, after] of conversions) {
+                const out = path.join(fullPath, `${file}.json`);
+                if (fs.existsSync(out)) {
+                    TypeDoc.resetReflectionID();
+                    before();
+                    const entry = getExpandedEntryPointsForPaths(
+                        app.logger,
+                        [fullPath],
+                        app.options,
+                        [program]
+                    );
+                    ok(entry, "Missing entry point");
+                    const result = app.converter.convert(entry);
+                    const serialized = app.serializer.toObject(result);
+
+                    const data = JSON.stringify(serialized, null, "  ") + "\n";
+                    after();
+                    fs.writeFileSync(out, data);
+                }
             }
         }
     }
-}
 
-async function main(filter = "") {
     console.log("Base directory is", base);
     const dirs = await fs.promises.readdir(base, { withFileTypes: true });
 

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -128,7 +128,7 @@ export class Application extends ChildableComponent<
      *
      * @param options  The desired options to set.
      */
-    bootstrap(options: Partial<TypeDocOptions> = {}): void {
+    async bootstrap(options: Partial<TypeDocOptions> = {}): Promise<void> {
         for (const [key, val] of Object.entries(options)) {
             try {
                 this.options.setValue(key as keyof TypeDocOptions, val);
@@ -149,7 +149,7 @@ export class Application extends ChildableComponent<
         this.logger.level = this.options.getValue("logLevel");
 
         const plugins = discoverPlugins(this);
-        loadPlugins(this, plugins);
+        await loadPlugins(this, plugins);
 
         this.options.reset();
         for (const [key, val] of Object.entries(options)) {

--- a/src/lib/utils/plugins.ts
+++ b/src/lib/utils/plugins.ts
@@ -6,7 +6,10 @@ import type { Logger } from "./loggers";
 import { nicePath } from "./paths";
 import { validate } from "./validation";
 
-export function loadPlugins(app: Application, plugins: readonly string[]) {
+export async function loadPlugins(
+    app: Application,
+    plugins: readonly string[]
+) {
     if (plugins.includes("none")) {
         return;
     }
@@ -20,7 +23,7 @@ export function loadPlugins(app: Application, plugins: readonly string[]) {
             const initFunction = instance.load;
 
             if (typeof initFunction === "function") {
-                initFunction(app);
+                await initFunction(app);
                 app.logger.info(`Loaded plugin ${pluginDisplay}`);
             } else {
                 app.logger.error(

--- a/src/test/capture-screenshots.ts
+++ b/src/test/capture-screenshots.ts
@@ -58,7 +58,7 @@ class PQueue {
 export async function captureRegressionScreenshots() {
     const app = new Application();
     app.options.addReader(new TSConfigReader());
-    app.bootstrap({
+    await app.bootstrap({
         logger: "console",
         readme: join(src, "..", "README.md"),
         name: "typedoc",

--- a/src/test/converter.test.ts
+++ b/src/test/converter.test.ts
@@ -8,13 +8,18 @@ import {
     getConverterBase,
     getConverterProgram,
 } from "./programs";
+import type { Application } from "..";
 
 describe("Converter", function () {
     const base = getConverterBase();
-    const app = getConverterApp();
+    let app: Application;
 
-    it("Compiles", () => {
-        getConverterProgram();
+    before(async () => {
+        app = await getConverterApp();
+    });
+
+    it("Compiles", async () => {
+        await getConverterProgram();
     });
 
     const checks: [string, () => void, () => void][] = [
@@ -54,14 +59,14 @@ describe("Converter", function () {
 
                 let result: ProjectReflection | undefined;
 
-                it(`[${file}] converts fixtures`, function () {
+                it(`[${file}] converts fixtures`, async function () {
                     before();
                     resetReflectionID();
                     const entryPoints = getExpandedEntryPointsForPaths(
                         app.logger,
                         [path],
                         app.options,
-                        [getConverterProgram()]
+                        [await getConverterProgram()]
                     );
                     ok(entryPoints, "Failed to get entry points");
                     result = app.converter.convert(entryPoints);

--- a/src/test/converter2.test.ts
+++ b/src/test/converter2.test.ts
@@ -13,7 +13,7 @@ import {
 import { TestLogger } from "./TestLogger";
 
 const base = getConverter2Base();
-const app = getConverter2App();
+const appPromise = getConverter2App();
 
 function runTest(
     title: string,
@@ -21,8 +21,10 @@ function runTest(
     entry: string,
     check: (project: ProjectReflection, logger: TestLogger) => void
 ) {
-    it(title, () => {
-        const program = getConverter2Program();
+    it(title, async () => {
+        const app = await appPromise;
+
+        const program = await getConverter2Program();
 
         const entryPoint = [
             join(base, `${entry}.ts`),
@@ -57,8 +59,8 @@ function runTest(
 }
 
 describe("Converter2", () => {
-    it("Compiles", () => {
-        getConverter2Program();
+    it("Compiles", async () => {
+        await getConverter2Program();
     });
 
     for (const [entry, check] of Object.entries(issueTests)) {

--- a/src/test/issueTests.ts
+++ b/src/test/issueTests.ts
@@ -498,8 +498,8 @@ export const issueTests: {
         );
     },
 
-    gh1898(project, logger) {
-        const app = getConverter2App();
+    async gh1898(project, logger) {
+        const app = await getConverter2App();
         app.validate(project);
         logger.discardDebugMessages();
         logger.expectMessage(

--- a/src/test/programs.ts
+++ b/src/test/programs.ts
@@ -18,11 +18,11 @@ export function getConverterBase() {
     return join(process.cwd(), "src/test/converter");
 }
 
-export function getConverterApp() {
+export async function getConverterApp() {
     if (!converterApp) {
         converterApp = new Application();
         converterApp.options.addReader(new TSConfigReader());
-        converterApp.bootstrap({
+        await converterApp.bootstrap({
             logger: "none",
             name: "typedoc",
             excludeExternals: true,
@@ -57,9 +57,9 @@ export function getConverterApp() {
     return converterApp;
 }
 
-export function getConverterProgram() {
+export async function getConverterProgram() {
     if (!converterProgram) {
-        const app = getConverterApp();
+        const app = await getConverterApp();
         converterProgram = ts.createProgram(
             app.options.getFileNames(),
             app.options.getCompilerOptions()
@@ -75,11 +75,11 @@ export function getConverter2Base() {
     return join(process.cwd(), "src/test/converter2");
 }
 
-export function getConverter2App() {
+export async function getConverter2App() {
     if (!converter2App) {
         converter2App = new Application();
         converter2App.options.addReader(new TSConfigReader());
-        converter2App.bootstrap({
+        await converter2App.bootstrap({
             excludeExternals: true,
             tsconfig: join(getConverter2Base(), "tsconfig.json"),
             plugin: [],
@@ -89,9 +89,9 @@ export function getConverter2App() {
     return converter2App;
 }
 
-export function getConverter2Program() {
+export async function getConverter2Program() {
     if (!converter2Program) {
-        const app = getConverter2App();
+        const app = await getConverter2App();
         converter2Program = ts.createProgram(
             app.options.getFileNames(),
             app.options.getCompilerOptions()

--- a/src/test/slow/entry-point.test.ts
+++ b/src/test/slow/entry-point.test.ts
@@ -27,8 +27,8 @@ describe("Entry Points", () => {
     const tsconfig = join(fixture.cwd, "tsconfig.json");
     app.options.addReader(new TSConfigReader());
 
-    it("Supports expanding existing paths", () => {
-        app.bootstrap({
+    it("Supports expanding existing paths", async () => {
+        await app.bootstrap({
             tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.Expand,
@@ -43,8 +43,8 @@ describe("Entry Points", () => {
         );
     });
 
-    it("Supports expanding globs in paths", () => {
-        app.bootstrap({
+    it("Supports expanding globs in paths", async () => {
+        await app.bootstrap({
             tsconfig,
             entryPoints: [`${fixture.cwd}/*.ts`],
             entryPointStrategy: EntryPointStrategy.Expand,
@@ -59,8 +59,8 @@ describe("Entry Points", () => {
         );
     });
 
-    it("Supports resolving directories", () => {
-        app.bootstrap({
+    it("Supports resolving directories", async () => {
+        await app.bootstrap({
             tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.Resolve,
@@ -75,8 +75,8 @@ describe("Entry Points", () => {
         );
     });
 
-    it("Supports resolving packages", () => {
-        app.bootstrap({
+    it("Supports resolving packages", async () => {
+        await app.bootstrap({
             tsconfig: tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.Packages,
@@ -89,7 +89,7 @@ describe("Entry Points", () => {
         equal(entryPoints[0].readmeFile, void 0);
     });
 
-    it("Supports resolving packages outside of cwd", () => {
+    it("Supports resolving packages outside of cwd", async () => {
         const fixture = tempdirProject({ rootDir: tmpdir() });
         fixture.addJsonFile("tsconfig.json", {
             include: ["."],
@@ -100,7 +100,7 @@ describe("Entry Points", () => {
         fixture.addFile("index.ts", "export function fromIndex() {}");
         fixture.write();
 
-        app.bootstrap({
+        await app.bootstrap({
             tsconfig: tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.Packages,
@@ -113,7 +113,7 @@ describe("Entry Points", () => {
         equal(entryPoints[0].version, void 0);
     });
 
-    it("Supports custom tsconfig files #2061", () => {
+    it("Supports custom tsconfig files #2061", async () => {
         const fixture = tempdirProject({ rootDir: tmpdir() });
         fixture.addJsonFile("tsconfig.lib.json", {
             include: ["."],
@@ -127,7 +127,7 @@ describe("Entry Points", () => {
         fixture.addFile("index.ts", "export function fromIndex() {}");
         fixture.write();
 
-        app.bootstrap({
+        await app.bootstrap({
             tsconfig: tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.Packages,
@@ -139,7 +139,7 @@ describe("Entry Points", () => {
         equal(entryPoints.length, 1);
     });
 
-    it("Supports automatically discovering the readme files", () => {
+    it("Supports automatically discovering the readme files", async () => {
         const fixture = tempdirProject();
         fixture.addJsonFile("tsconfig.json", {
             include: ["."],
@@ -151,7 +151,7 @@ describe("Entry Points", () => {
         fixture.addFile("index.ts", "export function fromIndex() {}");
         fixture.write();
 
-        app.bootstrap({
+        await app.bootstrap({
             tsconfig: tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.Packages,

--- a/src/test/utils/fixtures/async-plugin.js
+++ b/src/test/utils/fixtures/async-plugin.js
@@ -1,0 +1,5 @@
+module.exports = {
+    async load(app) {
+        app.convert();
+    },
+};

--- a/src/test/utils/fixtures/slow-async-plugin.js
+++ b/src/test/utils/fixtures/slow-async-plugin.js
@@ -1,0 +1,9 @@
+module.exports = {
+    async load(app) {
+        await new Promise((resolve) => {
+            setTimeout(() => resolve(), 500);
+        });
+
+        app.convert();
+    },
+};

--- a/src/test/utils/fixtures/sync-plugin.js
+++ b/src/test/utils/fixtures/sync-plugin.js
@@ -1,0 +1,5 @@
+module.exports = {
+    load(app) {
+        app.convert();
+    },
+};

--- a/src/test/utils/plugins.test.ts
+++ b/src/test/utils/plugins.test.ts
@@ -1,0 +1,38 @@
+import { deepStrictEqual as equal } from "assert";
+import type { Application } from "../../lib/application";
+import { loadPlugins } from "../../lib/utils";
+import * as Path from "path";
+
+describe("Plugins", () => {
+    async function testPlugin(plugin: string) {
+        let loaded = false;
+        const app: Application = {
+            // @ts-expect-error incomplete implementation
+            logger: { info: () => {}, error: () => {} },
+            // this method will be invoked by the test plugin to prove it's been loaded
+            convert: () => {
+                loaded = true;
+
+                return undefined;
+            },
+        };
+        const pluginName = Path.join(__dirname, "fixtures", plugin);
+        const plugins = [pluginName];
+
+        await loadPlugins(app, plugins);
+
+        equal(loaded, true);
+    }
+
+    it("Should load plugins", async () => {
+        await testPlugin("sync-plugin.js");
+    });
+
+    it("Should load async plugins", async () => {
+        await testPlugin("async-plugin.js");
+    });
+
+    it("Should load slow async plugins", async () => {
+        await testPlugin("slow-async-plugin.js");
+    });
+});

--- a/src/test/validation.test.ts
+++ b/src/test/validation.test.ts
@@ -6,9 +6,9 @@ import { validateExports } from "../lib/validation/exports";
 import { getConverter2App, getConverter2Program } from "./programs";
 import { TestLogger } from "./TestLogger";
 
-function convertValidationFile(file: string) {
-    const app = getConverter2App();
-    const program = getConverter2Program();
+async function convertValidationFile(file: string) {
+    const app = await getConverter2App();
+    const program = await getConverter2Program();
     const sourceFile = program.getSourceFile(
         join(__dirname, "converter2/validation", file)
     );
@@ -26,13 +26,13 @@ function convertValidationFile(file: string) {
     return project;
 }
 
-function expectWarning(
+async function expectWarning(
     typeName: string,
     file: string,
     referencingName: string,
     intentionallyNotExported: readonly string[] = []
 ) {
-    const project = convertValidationFile(file);
+    const project = await convertValidationFile(file);
 
     const logger = new TestLogger();
     validateExports(project, logger, intentionallyNotExported);
@@ -42,12 +42,12 @@ function expectWarning(
     );
 }
 
-function expectNoWarning(
+async function expectNoWarning(
     file: string,
     intentionallyNotExported: readonly string[] = []
 ) {
-    const app = getConverter2App();
-    const program = getConverter2Program();
+    const app = await getConverter2App();
+    const program = await getConverter2Program();
     const sourceFile = program.getSourceFile(
         join(__dirname, "converter2/validation", file)
     );
@@ -70,63 +70,65 @@ function expectNoWarning(
 }
 
 describe("validateExports", () => {
-    it("Should warn if a variable type is missing", () => {
-        expectWarning("Foo", "variable.ts", "foo");
+    it("Should warn if a variable type is missing", async () => {
+        await expectWarning("Foo", "variable.ts", "foo");
     });
 
-    it("Should warn if a type parameter clause is missing", () => {
-        expectWarning("Foo", "typeParameter.ts", "Bar.T");
+    it("Should warn if a type parameter clause is missing", async () => {
+        await expectWarning("Foo", "typeParameter.ts", "Bar.T");
     });
 
-    it("Should warn if an index signature type is missing", () => {
-        expectWarning("Bar", "indexSignature.ts", "Foo.__index");
+    it("Should warn if an index signature type is missing", async () => {
+        await expectWarning("Bar", "indexSignature.ts", "Foo.__index");
     });
 
-    it("Should warn within object types", () => {
-        expectWarning("Foo", "object.ts", "x.__type.foo");
+    it("Should warn within object types", async () => {
+        await expectWarning("Foo", "object.ts", "x.__type.foo");
     });
 
-    it("Should warn if a get signature type is missing", () => {
-        expectWarning("Bar", "getSignature.ts", "Foo.foo.foo");
+    it("Should warn if a get signature type is missing", async () => {
+        await expectWarning("Bar", "getSignature.ts", "Foo.foo.foo");
     });
 
-    it("Should warn if a set signature type is missing", () => {
-        expectWarning("Bar", "setSignature.ts", "Foo.foo.foo._value");
+    it("Should warn if a set signature type is missing", async () => {
+        await expectWarning("Bar", "setSignature.ts", "Foo.foo.foo._value");
     });
 
-    it("Should warn if an implemented type is missing", () => {
-        expectWarning("Bar", "implemented.ts", "Foo");
+    it("Should warn if an implemented type is missing", async () => {
+        await expectWarning("Bar", "implemented.ts", "Foo");
     });
 
-    it("Should warn if a parameter type is missing", () => {
-        expectWarning("Bar", "parameter.ts", "Foo.Foo.x");
+    it("Should warn if a parameter type is missing", async () => {
+        await expectWarning("Bar", "parameter.ts", "Foo.Foo.x");
     });
 
-    it("Should warn if a return type is missing", () => {
-        expectWarning("Bar", "return.ts", "foo.foo");
+    it("Should warn if a return type is missing", async () => {
+        await expectWarning("Bar", "return.ts", "foo.foo");
     });
 
-    it("Should allow filtering warnings by file name", () => {
-        expectNoWarning("variable.ts", ["variable.ts:Foo"]);
-        expectNoWarning("variable.ts", ["validation/variable.ts:Foo"]);
-        expectNoWarning("variable.ts", ["Foo"]);
+    it("Should allow filtering warnings by file name", async () => {
+        await expectNoWarning("variable.ts", ["variable.ts:Foo"]);
+        await expectNoWarning("variable.ts", ["validation/variable.ts:Foo"]);
+        await expectNoWarning("variable.ts", ["Foo"]);
     });
 
-    it("Should not apply warnings filtered by file name to other files", () => {
-        expectWarning("Foo", "variable.ts", "foo", ["notVariable.ts:Foo"]);
+    it("Should not apply warnings filtered by file name to other files", async () => {
+        await expectWarning("Foo", "variable.ts", "foo", [
+            "notVariable.ts:Foo",
+        ]);
     });
 
-    it("Should not produce warnings for types originating in node_modules", () => {
-        expectNoWarning("externalType.ts");
+    it("Should not produce warnings for types originating in node_modules", async () => {
+        await expectNoWarning("externalType.ts");
     });
 
-    it("Should not warn if namespaced name is given to intentionallyNotExported", () => {
-        expectNoWarning("namespace.ts", ["Bar.Baz"]);
+    it("Should not warn if namespaced name is given to intentionallyNotExported", async () => {
+        await expectNoWarning("namespace.ts", ["Bar.Baz"]);
     });
 
-    it("Should warn if intentionallyNotExported contains unused values", () => {
-        const app = getConverter2App();
-        const program = getConverter2Program();
+    it("Should warn if intentionallyNotExported contains unused values", async () => {
+        const app = await getConverter2App();
+        const program = await getConverter2Program();
         const sourceFile = program.getSourceFile(
             join(__dirname, "converter2/validation/variable.ts")
         );
@@ -167,8 +169,8 @@ describe("validateExports", () => {
 });
 
 describe("validateDocumentation", () => {
-    it("Should correctly handle functions", () => {
-        const project = convertValidationFile("function.ts");
+    it("Should correctly handle functions", async () => {
+        const project = await convertValidationFile("function.ts");
         const logger = new TestLogger();
         validateDocumentation(project, logger, ["Function"]);
 
@@ -176,8 +178,8 @@ describe("validateDocumentation", () => {
         logger.expectNoOtherMessages();
     });
 
-    it("Should correctly handle accessors", () => {
-        const project = convertValidationFile("getSignature.ts");
+    it("Should correctly handle accessors", async () => {
+        const project = await convertValidationFile("getSignature.ts");
         const logger = new TestLogger();
         validateDocumentation(project, logger, ["Accessor"]);
 
@@ -185,8 +187,8 @@ describe("validateDocumentation", () => {
         logger.expectNoOtherMessages();
     });
 
-    it("Should correctly handle constructors", () => {
-        const project = convertValidationFile("class.ts");
+    it("Should correctly handle constructors", async () => {
+        const project = await convertValidationFile("class.ts");
         const logger = new TestLogger();
         validateDocumentation(project, logger, ["Constructor"]);
 
@@ -196,8 +198,8 @@ describe("validateDocumentation", () => {
         logger.expectNoOtherMessages();
     });
 
-    it("Should correctly handle interfaces", () => {
-        const project = convertValidationFile("interface.ts");
+    it("Should correctly handle interfaces", async () => {
+        const project = await convertValidationFile("interface.ts");
         const logger = new TestLogger();
         validateDocumentation(project, logger, ["Method"]);
 


### PR DESCRIPTION
[5ddbbf6](https://github.com/TypeStrong/typedoc/commit/5ddbbf69e376936bd9ef2d9ce6fa2cd0ecdca2e3) added a documentation note that says plugins can return a promise from their `load` function, but that promise needs to be awaited otherwise it'll resolve outside of the normal execution flow (e.g. it could resolve after doc generation has finished) and can also cause `unhandledPromiseRejection`s.

The change here is to await the result of `initFunction`, which means making the `loadPlugins` function async and cascading that asynchronicity upwards which is why it's so noisy.

Also adds tests for loading sync/async and very slow plugins as I couldn't see where these were tested.

Refs: #185