### PR TITLE
tweak vscode and mocha tooling somewhat

### DIFF
--- a/.config/mocha.fast.json
+++ b/.config/mocha.fast.json
@@ -1,8 +1,9 @@
 {
     "$schema": "https://json.schemastore.org/mocharc.json",
-    "timeout": 5000,
-    "spec": ["src/test/**/*.test.ts"],
     "exclude": ["src/test/packages/**", "src/test/slow/**"],
-    "watch-files": ["src/**/*.ts"],
-    "extension": ["ts", "tsx"]
+    "extension": ["ts", "tsx"],
+    "require": ["ts-node/register"],
+    "spec": ["src/test/**/*.test.ts"],
+    "timeout": 5000,
+    "watch-files": ["src/**/*.ts"]
 }

--- a/.config/mocha.full.json
+++ b/.config/mocha.full.json
@@ -1,5 +1,7 @@
 {
+    "$schema": "https://json.schemastore.org/mocharc.json",
     "timeout": 0,
     "spec": "src/test/**/*.test.ts",
-    "exclude": ["src/test/packages/**"]
+    "exclude": ["src/test/packages/**"],
+    "require": ["ts-node/register"]
 }

--- a/.config/mocha.test-explorer.json
+++ b/.config/mocha.test-explorer.json
@@ -1,10 +1,11 @@
 {
+    "$schema": "https://json.schemastore.org/mocharc.json",
     "extension": ["ts"],
+    "ignore": ["src/test/slow/**", "src/test/packages/**"],
     "package": "./package.json",
     "require": "ts-node/register",
     "slow": 500,
     "spec": ["src/**/*.test.ts"],
-    "ignore": ["src/test/slow/**", "src/test/packages/**"],
     "timeout": 0,
     "watch-files": ["src/**/*.ts"]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,16 +4,81 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build",
-            "type": "shell",
-            "command": "npm run build",
-            "problemMatcher": ["$tsc"]
+            "label": "build-tsc",
+            "type": "npm",
+            "script": "build:tsc",
+            "problemMatcher": ["$tsc"],
+            "detail": "Build TypeDoc w/ tsc",
+            "presentation": {
+                "group": "build",
+                "panel": "dedicated"
+            },
+            "group": {
+                "kind": "build"
+            }
         },
         {
-            "label": "build_and_test",
+            "label": "build-themes",
+            "type": "npm",
+            "script": "build:themes",
+            "problemMatcher": ["$esbuild"],
+            "detail": "Build TypeDoc themes",
+            "presentation": {
+                "group": "build",
+                "panel": "dedicated"
+            },
+            "group": {
+                "kind": "build"
+            }
+        },
+        {
+            "label": "dev-build-tsc",
             "type": "shell",
-            "command": "npm run build_and_test",
-            "problemMatcher": ["$tsc"]
+            "command": "npm run build:tsc -- --watch",
+            "problemMatcher": ["$tsc-watch"],
+            "detail": "Build TypeDoc w/ tsc in watch mode",
+            "isBackground": true,
+            "presentation": {
+                "group": "dev",
+                "panel": "dedicated"
+            },
+            "group": {
+                "kind": "build"
+            }
+        },
+        {
+            "label": "dev-build-themes",
+            "type": "shell",
+            "command": "npm run build:themes -- --watch",
+            "problemMatcher": ["$esbuild-watch"],
+            "detail": "Build TypeDoc themes in watch mode",
+            "isBackground": true,
+            "presentation": {
+                "group": "dev",
+                "panel": "dedicated"
+            },
+            "group": {
+                "kind": "build"
+            }
+        },
+        {
+            "label": "dev",
+            "dependsOn": ["dev-build-tsc", "dev-build-themes"],
+            "detail": "Build TypeDoc in watch mode",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build"
+            }
+        },
+        {
+            "label": "build",
+            "dependsOn": ["build-tsc", "build-themes"],
+            "detail": "Build TypeDoc",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
     "/tsdoc.json"
   ],
   "scripts": {
-    "test": "mocha -r ts-node/register --config .config/mocha.fast.json",
-    "test:cov": "c8 mocha -r ts-node/register --config .config/mocha.fast.json",
+    "test": "mocha --config .config/mocha.fast.json",
+    "test:cov": "c8 mocha --config .config/mocha.fast.json",
     "doc:c": "node bin/typedoc --tsconfig src/test/converter/tsconfig.json",
     "doc:c2": "node bin/typedoc --tsconfig src/test/converter2/tsconfig.json",
-    "test:full": "c8 mocha -r ts-node/register --config .config/mocha.full.json",
+    "test:full": "c8 mocha --config .config/mocha.full.json",
     "test:visual": "ts-node ./src/test/capture-screenshots.ts && ./scripts/compare_screenshots.sh",
     "test:visual:accept": "node scripts/accept_visual_regression.js",
     "rebuild_specs": "node scripts/rebuild_specs.js",

--- a/scripts/build_themes.js
+++ b/scripts/build_themes.js
@@ -1,12 +1,18 @@
 const esbuild = require("esbuild");
 
-esbuild.buildSync({
-    entryPoints: ["src/lib/output/themes/default/assets/bootstrap.ts"],
-    bundle: true,
-    minify: true,
-    outfile: "static/main.js",
-    banner: {
-        js: '"use strict";',
-    },
-    logLevel: "info",
-});
+esbuild
+    .build({
+        entryPoints: ["src/lib/output/themes/default/assets/bootstrap.ts"],
+        bundle: true,
+        minify: true,
+        outfile: "static/main.js",
+        banner: {
+            js: '"use strict";',
+        },
+        logLevel: "info",
+        watch: process.argv.slice(2).includes("--watch"),
+    })
+    .catch((err) => {
+        console.error(err);
+        process.exitCode = 1;
+    });


### PR DESCRIPTION
The Mocha changes are just refactors/housekeeping, but the VS Code changes improve the workflow for a vscode development environment.

#### Mocha

- Sorted the JSON
- Added a `$schema` ref
- Use `require: ts-node/register` here
- Remove `require: ts-node/register` from scripts in `package.json`

#### VS Code
- Creates some build and watch tasks
- Removed invalid task
- Update `build_themes.js` to run async and support watch mode (watch mode cannot run using `esbuild.buildSync()`)
