### PR TITLE
Handle descriptions for named parameters

### DIFF
--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -386,10 +386,12 @@ export class CommentPlugin extends ConverterComponent {
                 );
 
                 if (tag) {
-                    if(!parameter.comment){
+                    if (!parameter.comment) {
                         parameter.comment = new Comment();
                     }
-                    parameter.comment.summary = Comment.cloneDisplayParts(tag.content);
+                    parameter.comment.summary = Comment.cloneDisplayParts(
+                        tag.content
+                    );
                 }
             });
 
@@ -543,17 +545,19 @@ function moveNestedParamTags(comment: Comment, parameter: ParameterReflection) {
                 }
             }
         },
-        reference(){
-            comment.blockTags.filter(
-                (t) =>
-                    t.tag === "@param" &&
-                    t.name?.startsWith(`${parameter.name}.`)
-            ).forEach(tag => {
-                if(!parameter.comment){
-                    parameter.comment = new Comment();
-                }
-                parameter.comment.blockTags.push(tag);
-            })
+        reference() {
+            comment.blockTags
+                .filter(
+                    (t) =>
+                        t.tag === "@param" &&
+                        t.name?.startsWith(`${parameter.name}.`)
+                )
+                .forEach((tag) => {
+                    if (!parameter.comment) {
+                        parameter.comment = new Comment();
+                    }
+                    parameter.comment.blockTags.push(tag);
+                });
         },
         // #1876, also do this for unions/intersections.
         union(u) {

--- a/src/lib/converter/plugins/CommentPlugin.ts
+++ b/src/lib/converter/plugins/CommentPlugin.ts
@@ -386,9 +386,10 @@ export class CommentPlugin extends ConverterComponent {
                 );
 
                 if (tag) {
-                    parameter.comment = new Comment(
-                        Comment.cloneDisplayParts(tag.content)
-                    );
+                    if(!parameter.comment){
+                        parameter.comment = new Comment();
+                    }
+                    parameter.comment.summary = Comment.cloneDisplayParts(tag.content);
                 }
             });
 
@@ -541,6 +542,18 @@ function moveNestedParamTags(comment: Comment, parameter: ParameterReflection) {
                     );
                 }
             }
+        },
+        reference(){
+            comment.blockTags.filter(
+                (t) =>
+                    t.tag === "@param" &&
+                    t.name?.startsWith(`${parameter.name}.`)
+            ).forEach(tag => {
+                if(!parameter.comment){
+                    parameter.comment = new Comment();
+                }
+                parameter.comment.blockTags.push(tag);
+            })
         },
         // #1876, also do this for unions/intersections.
         union(u) {


### PR DESCRIPTION
This PR aims to fix #2147. Not sur you want to merge it in the present state, has I did not update the templates. 
I looked at it though, and it seems like you dont make much process over the input JSON, while this PR would require a bit of aggregation of the result. Here is what I get now: 
### Comments for named params 
![Screenshot from 2023-01-20 14-07-03](https://user-images.githubusercontent.com/7451806/213702030-b0f894fc-5317-442d-96dc-94f4324a356e.png)
### Comments for unnamed params
![Screenshot from 2023-01-20 14-06-52](https://user-images.githubusercontent.com/7451806/213702040-39c801f6-cbcf-4762-be62-b570725cbea9.png)

I would do something in the template to get the same result in both cases.
 What do you think ?