### PR TITLE
fix: unsafe usage of declaration (Close #2175)

### DIFF
--- a/src/lib/converter/comments/index.ts
+++ b/src/lib/converter/comments/index.ts
@@ -176,6 +176,9 @@ export function getJsDocComment(
     config: CommentParserConfig,
     logger: Logger
 ): Comment | undefined {
+    if (!declaration) {
+        return undefined;
+    }
     const file = declaration.getSourceFile();
 
     // First, get the whole comment. We know we'll need all of it.


### PR DESCRIPTION
Although the declaration is not supposed to be empty this block:

```
export function getComment(
    symbol: ts.Symbol,
    kind: ReflectionKind,
    config: CommentParserConfig,
    logger: Logger,
    commentStyle: CommentStyle
): Comment | undefined {
    if (
        symbol
            .getDeclarations()
            ?.every((d) => jsDocCommentKinds.includes(d.kind))
    ) {
        return getJsDocComment(
            symbol.declarations![0] as ts.JSDocPropertyLikeTag,
            config,
            logger
        );
    }
```

will generate an empty declaration if symbol.declarations is undefined.
