### PR TITLE
Fix sidebar margins on mobile devices

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -483,10 +483,9 @@ blockquote {
     .has-menu .col-menu {
         visibility: visible;
         transform: translate(0, 0);
-        display: grid;
-        align-items: center;
-        grid-template-rows: auto 1fr;
-        grid-gap: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
         max-height: 100vh;
         padding: 1rem 2rem;
     }

--- a/static/style.css
+++ b/static/style.css
@@ -911,7 +911,7 @@ a.tsd-index-link {
     margin-right: 0.8rem;
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1025px) {
     .col-content {
         margin: 2rem auto;
     }


### PR DESCRIPTION
Fixes #2191.

The margin at the top of the sidebar is caused when the display is precisely 1024px wide, because of overlapping min-width and max-width media queries. Also switched to flex for the mobile sidebar to prevent unnecessary gaps.