### PR TITLE
Require the bash shell to run `compare_screenshots.sh` script

### DIFF
--- a/scripts/compare_screenshots.sh
+++ b/scripts/compare_screenshots.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 test -d ./tmp/output && rm -rf ./tmp/output
 mkdir -p ./tmp/{output,screenshots,baseline}


### PR DESCRIPTION
This ensures the bracket expansion for creating the directories is properly interpreted.

Resolves #2204