### PR TITLE
the --includeVersion flag now checks if the prefix "v" already exists…

### DIFF
--- a/scripts/compare_screenshots.sh
+++ b/scripts/compare_screenshots.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 test -d ./tmp/output && rm -rf ./tmp/output
 mkdir -p ./tmp/{output,screenshots,baseline}

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -136,7 +136,9 @@ export class PackagePlugin extends ConverterComponent {
             }
             if (this.includeVersion) {
                 if (packageInfo.version) {
-                    project.name = `${project.name} - v${packageInfo.version}`;
+                    project.name = `${project.name} - ${
+                        packageInfo.version.slice(0, 1) !== "v" ? "v" : ""
+                    }${packageInfo.version}`;
                 } else {
                     // since not all monorepo specifies a meaningful version to the main package.json
                     // this warning should be optional


### PR DESCRIPTION
… in the version field of the package to prevent duplicate v's in the project name.