### PR TITLE
Support ESM and functions/async functions in config files

### DIFF
--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -79,7 +79,7 @@ async function run(app: td.Application) {
         return ExitCodes.Ok;
     }
 
-    const project = app.convert();
+    const project = await app.convert();
     if (!project) {
         return ExitCodes.CompileError;
     }

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -54,7 +54,7 @@ export interface OptionsReader {
      * @param logger logger to be used to report errors
      * @param cwd the directory which should be treated as the current working directory for option file discovery
      */
-    read(container: Options, logger: Logger, cwd: string): void;
+    read(container: Options, logger: Logger, cwd: string): Promise<void>;
 }
 
 const optionSnapshots = new WeakMap<
@@ -197,9 +197,9 @@ export class Options {
         insertOrderSorted(this._readers, reader);
     }
 
-    read(logger: Logger, cwd = process.cwd()) {
+    async read(logger: Logger, cwd = process.cwd()) {
         for (const reader of this._readers) {
-            reader.read(this, logger, cwd);
+            await reader.read(this, logger, cwd);
         }
     }
 

--- a/src/lib/utils/options/readers/arguments.ts
+++ b/src/lib/utils/options/readers/arguments.ts
@@ -24,7 +24,7 @@ export class ArgumentsReader implements OptionsReader {
         this.args = args;
     }
 
-    read(container: Options, logger: Logger): void {
+    read(container: Options, logger: Logger): Promise<void> {
         // Make container's type more lax, we do the appropriate checks manually.
         const options = container as Options & {
             setValue(name: string, value: unknown): void;
@@ -118,5 +118,6 @@ export class ArgumentsReader implements OptionsReader {
             );
             index++;
         }
+        return Promise.resolve();
     }
 }

--- a/src/lib/utils/options/readers/package-json.ts
+++ b/src/lib/utils/options/readers/package-json.ts
@@ -15,11 +15,11 @@ export class PackageJsonReader implements OptionsReader {
 
     name = "package-json";
 
-    read(container: Options, logger: Logger, cwd: string): void {
+    read(container: Options, logger: Logger, cwd: string): Promise<void> {
         const result = discoverPackageJson(cwd);
 
         if (!result) {
-            return;
+            return Promise.resolve();
         }
 
         const { file, content } = result;
@@ -34,7 +34,7 @@ export class PackageJsonReader implements OptionsReader {
 
         const optsKey = "typedocOptions";
         if (!(optsKey in content)) {
-            return;
+            return Promise.resolve();
         }
 
         const opts = content[optsKey];
@@ -44,7 +44,7 @@ export class PackageJsonReader implements OptionsReader {
                     file
                 )}, ensure it exists and contains an object.`
             );
-            return;
+            return Promise.resolve();
         }
 
         for (const [opt, val] of Object.entries(opts)) {
@@ -55,5 +55,6 @@ export class PackageJsonReader implements OptionsReader {
                 logger.error(err.message);
             }
         }
+        return Promise.resolve();
     }
 }

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -71,7 +71,7 @@ export class TSConfigReader implements OptionsReader {
 
     private seenTsdocPaths = new Set<string>();
 
-    read(container: Options, logger: Logger, cwd: string): void {
+    read(container: Options, logger: Logger, cwd: string): Promise<void> {
         const file = container.getValue("tsconfig") || cwd;
 
         let fileToRead = findTsConfigFile(file);
@@ -90,7 +90,7 @@ export class TSConfigReader implements OptionsReader {
                     "No tsconfig file found, this will prevent TypeDoc from finding your entry points."
                 );
             }
-            return;
+            return Promise.resolve();
         }
 
         fileToRead = normalizePath(resolve(fileToRead));
@@ -99,7 +99,7 @@ export class TSConfigReader implements OptionsReader {
 
         const parsed = readTsConfig(fileToRead, logger);
         if (!parsed) {
-            return;
+            return Promise.resolve();
         }
 
         logger.diagnostics(parsed.errors);
@@ -139,6 +139,8 @@ export class TSConfigReader implements OptionsReader {
                 logger.error(error.message);
             }
         }
+
+        return Promise.resolve();
     }
 
     private addTagsFromTsdocJson(

--- a/src/test/capture-screenshots.ts
+++ b/src/test/capture-screenshots.ts
@@ -58,7 +58,7 @@ class PQueue {
 export async function captureRegressionScreenshots() {
     const app = new Application();
     app.options.addReader(new TSConfigReader());
-    app.bootstrap({
+    await app.bootstrap({
         readme: join(src, "..", "README.md"),
         name: "typedoc",
         cleanOutputDir: true,
@@ -67,7 +67,7 @@ export async function captureRegressionScreenshots() {
         entryPoints: [src],
         entryPointStrategy: EntryPointStrategy.Expand,
     });
-    const project = app.convert();
+    const project = await app.convert();
     if (!project) throw new Error("Failed to convert.");
     await fs.promises.rm(outputDirectory, { recursive: true, force: true });
     await app.generateDocs(project, baseDirectory);

--- a/src/test/converter.test.ts
+++ b/src/test/converter.test.ts
@@ -137,12 +137,12 @@ comparisonSerializer.addSerializer({
     },
 });
 
-describe("Converter", function () {
+describe("Converter", async function () {
     const base = getConverterBase();
-    const app = getConverterApp();
+    const app = await getConverterApp();
 
-    it("Compiles", () => {
-        getConverterProgram();
+    it("Compiles", async () => {
+        await getConverterProgram();
     });
 
     const checks: [string, () => void, () => void][] = [
@@ -184,14 +184,14 @@ describe("Converter", function () {
 
                 let result: ProjectReflection | undefined;
 
-                it(`[${file}] converts fixtures`, function () {
+                it(`[${file}] converts fixtures`, async function () {
                     before();
                     resetReflectionID();
                     const entryPoints = getExpandedEntryPointsForPaths(
                         app.logger,
                         [path],
                         app.options,
-                        [getConverterProgram()]
+                        [await getConverterProgram()]
                     );
                     ok(entryPoints, "Failed to get entry points");
                     result = app.converter.convert(entryPoints);

--- a/src/test/issues.c2.test.ts
+++ b/src/test/issues.c2.test.ts
@@ -27,12 +27,15 @@ import { TestLogger } from "./TestLogger";
 import { clearCommentCache } from "../lib/converter/comments";
 import { join } from "path";
 import { existsSync } from "fs";
+import type { Application } from "..";
+import type { Program } from "typescript";
 
-const base = getConverter2Base();
-const app = getConverter2App();
-const program = getConverter2Program();
-
-function doConvert(entry: string) {
+function doConvert(
+    base: string,
+    app: Application,
+    program: Program,
+    entry: string
+) {
     const entryPoint = [
         join(base, `issues/${entry}.ts`),
         join(base, `issues/${entry}.d.ts`),
@@ -67,13 +70,23 @@ describe("Issue Tests", () => {
     let logger: TestLogger;
     let convert: (name?: string) => ProjectReflection;
     let optionsSnap: { __optionSnapshot: never };
+    let app: Application;
+    let base: string;
+    let program: Program;
+
+    before(async () => {
+        base = getConverter2Base();
+        app = await getConverter2App();
+        program = await getConverter2Program();
+    });
 
     beforeEach(function () {
         app.logger = logger = new TestLogger();
         optionsSnap = app.options.snapshot();
         const issueNumber = this.currentTest?.title.match(/#(\d+)/)?.[1];
         ok(issueNumber, "Test name must contain an issue number.");
-        convert = (name = `gh${issueNumber}`) => doConvert(name);
+        convert = (name = `gh${issueNumber}`) =>
+            doConvert(base, app, program, name);
     });
 
     afterEach(() => {

--- a/src/test/merge.test.ts
+++ b/src/test/merge.test.ts
@@ -12,9 +12,9 @@ import { TestLogger } from "./TestLogger";
 const base = getConverterBase();
 
 describe("Merging projects", () => {
-    it("Handles multiple projects", () => {
+    it("Handles multiple projects", async () => {
         const app = new Application();
-        app.bootstrap({
+        await app.bootstrap({
             entryPointStrategy: EntryPointStrategy.Merge,
             entryPoints: [
                 join(base, "alias/specs.json"),
@@ -24,7 +24,7 @@ describe("Merging projects", () => {
         const logger = new TestLogger();
         app.logger = logger;
 
-        const project = app.convert();
+        const project = await app.convert();
         logger.expectNoOtherMessages();
 
         equal(project?.name, "typedoc");

--- a/src/test/programs.ts
+++ b/src/test/programs.ts
@@ -20,11 +20,11 @@ export function getConverterBase() {
     return join(process.cwd(), "src/test/converter");
 }
 
-export function getConverterApp() {
+export async function getConverterApp() {
     if (!converterApp) {
         converterApp = new Application();
         converterApp.options.addReader(new TSConfigReader());
-        converterApp.bootstrap({
+        await converterApp.bootstrap({
             name: "typedoc",
             excludeExternals: true,
             disableSources: false,
@@ -72,9 +72,9 @@ export function getConverterApp() {
     return converterApp;
 }
 
-export function getConverterProgram() {
+export async function getConverterProgram() {
     if (!converterProgram) {
-        const app = getConverterApp();
+        const app = await getConverterApp();
         converterProgram = ts.createProgram(
             app.options.getFileNames(),
             app.options.getCompilerOptions()
@@ -90,11 +90,11 @@ export function getConverter2Base() {
     return join(process.cwd(), "src/test/converter2");
 }
 
-export function getConverter2App() {
+export async function getConverter2App() {
     if (!converter2App) {
         converter2App = new Application();
         converter2App.options.addReader(new TSConfigReader());
-        converter2App.bootstrap({
+        await converter2App.bootstrap({
             excludeExternals: true,
             tsconfig: join(getConverter2Base(), "tsconfig.json"),
             validation: true,
@@ -103,9 +103,9 @@ export function getConverter2App() {
     return converter2App;
 }
 
-export function getConverter2Program() {
+export async function getConverter2Program() {
     if (!converter2Program) {
-        const app = getConverter2App();
+        const app = await getConverter2App();
         converter2Program = ts.createProgram(
             app.options.getFileNames(),
             app.options.getCompilerOptions()

--- a/src/test/slow/entry-point.test.ts
+++ b/src/test/slow/entry-point.test.ts
@@ -27,8 +27,8 @@ describe("Entry Points", () => {
     const tsconfig = join(fixture.cwd, "tsconfig.json");
     app.options.addReader(new TSConfigReader());
 
-    it("Supports expanding existing paths", () => {
-        app.bootstrap({
+    it("Supports expanding existing paths", async () => {
+        await app.bootstrap({
             tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.Expand,
@@ -43,8 +43,8 @@ describe("Entry Points", () => {
         );
     });
 
-    it("Supports expanding globs in paths", () => {
-        app.bootstrap({
+    it("Supports expanding globs in paths", async () => {
+        await app.bootstrap({
             tsconfig,
             entryPoints: [`${fixture.cwd}/*.ts`],
             entryPointStrategy: EntryPointStrategy.Expand,
@@ -59,8 +59,8 @@ describe("Entry Points", () => {
         );
     });
 
-    it("Supports resolving directories", () => {
-        app.bootstrap({
+    it("Supports resolving directories", async () => {
+        await app.bootstrap({
             tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.Resolve,
@@ -75,8 +75,8 @@ describe("Entry Points", () => {
         );
     });
 
-    it("Supports resolving packages", () => {
-        app.bootstrap({
+    it("Supports resolving packages", async () => {
+        await app.bootstrap({
             tsconfig: tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.LegacyPackages,
@@ -89,7 +89,7 @@ describe("Entry Points", () => {
         equal(entryPoints[0].readmeFile, void 0);
     });
 
-    it("Supports resolving packages outside of cwd", () => {
+    it("Supports resolving packages outside of cwd", async () => {
         const fixture = tempdirProject({ rootDir: tmpdir() });
         fixture.addJsonFile("tsconfig.json", {
             include: ["."],
@@ -100,7 +100,7 @@ describe("Entry Points", () => {
         fixture.addFile("index.ts", "export function fromIndex() {}");
         fixture.write();
 
-        app.bootstrap({
+        await app.bootstrap({
             tsconfig: tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.LegacyPackages,
@@ -113,7 +113,7 @@ describe("Entry Points", () => {
         equal(entryPoints[0].version, void 0);
     });
 
-    it("Supports custom tsconfig files #2061", () => {
+    it("Supports custom tsconfig files #2061", async () => {
         const fixture = tempdirProject({ rootDir: tmpdir() });
         fixture.addJsonFile("tsconfig.lib.json", {
             include: ["."],
@@ -127,7 +127,7 @@ describe("Entry Points", () => {
         fixture.addFile("index.ts", "export function fromIndex() {}");
         fixture.write();
 
-        app.bootstrap({
+        await app.bootstrap({
             tsconfig: tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.LegacyPackages,
@@ -139,7 +139,7 @@ describe("Entry Points", () => {
         equal(entryPoints.length, 1);
     });
 
-    it("Supports automatically discovering the readme files", () => {
+    it("Supports automatically discovering the readme files", async () => {
         const fixture = tempdirProject();
         fixture.addJsonFile("tsconfig.json", {
             include: ["."],
@@ -151,7 +151,7 @@ describe("Entry Points", () => {
         fixture.addFile("index.ts", "export function fromIndex() {}");
         fixture.write();
 
-        app.bootstrap({
+        await app.bootstrap({
             tsconfig: tsconfig,
             entryPoints: [fixture.cwd],
             entryPointStrategy: EntryPointStrategy.LegacyPackages,

--- a/src/test/utils/options/readers/arguments.test.ts
+++ b/src/test/utils/options/readers/arguments.test.ts
@@ -48,11 +48,11 @@ describe("Options - ArgumentsReader", () => {
     });
 
     function test(name: string, args: string[], cb: () => void) {
-        it(name, () => {
+        it(name, async () => {
             const reader = new ArgumentsReader(1, args);
             options.reset();
             options.addReader(reader);
-            options.read(logger);
+            await options.read(logger);
             cb();
         });
     }
@@ -121,12 +121,12 @@ describe("Options - ArgumentsReader", () => {
         }
     );
 
-    it("Errors if given an unknown option", () => {
+    it("Errors if given an unknown option", async () => {
         const similarOptions = options.getSimilarOptions("badOption");
         const reader = new ArgumentsReader(1, ["--badOption"]);
         options.reset();
         options.addReader(reader);
-        options.read(logger);
+        await options.read(logger);
         logger.expectMessage(
             `error: Unknown option: --badOption, you may have meant:\n\t${similarOptions.join(
                 "\n\t"
@@ -134,7 +134,7 @@ describe("Options - ArgumentsReader", () => {
         );
     });
 
-    it("Warns if option is expecting a value but no value is provided", () => {
+    it("Warns if option is expecting a value but no value is provided", async () => {
         let check = false;
         class TestLogger extends Logger {
             override warn(msg: string) {
@@ -146,7 +146,7 @@ describe("Options - ArgumentsReader", () => {
         const reader = new ArgumentsReader(1, ["--out"]);
         options.reset();
         options.addReader(reader);
-        options.read(new TestLogger());
+        await options.read(new TestLogger());
         equal(check, true, "Reader did not report an error.");
     });
 

--- a/src/test/utils/options/readers/package-json.test.ts
+++ b/src/test/utils/options/readers/package-json.test.ts
@@ -15,8 +15,8 @@ describe("Options - PackageJsonReader", () => {
         optsContainer.addReader(new PackageJsonReader());
     });
 
-    it("Does not error if no package.json file is found", () => {
-        optsContainer.read(testLogger, "/does-not-exist");
+    it("Does not error if no package.json file is found", async () => {
+        await optsContainer.read(testLogger, "/does-not-exist");
         testLogger.expectNoOtherMessages();
     });
 
@@ -25,12 +25,12 @@ describe("Options - PackageJsonReader", () => {
         pkgJsonContent: string,
         test: (logger: TestLogger) => void
     ): void {
-        it(testTitle, () => {
+        it(testTitle, async () => {
             const proj = project(testTitle.replace(/[ "]/g, "_"));
             proj.addFile("package.json", pkgJsonContent);
             proj.write();
 
-            optsContainer.read(testLogger, proj.cwd);
+            await optsContainer.read(testLogger, proj.cwd);
 
             proj.rm();
 

--- a/src/test/utils/options/readers/tsconfig.test.ts
+++ b/src/test/utils/options/readers/tsconfig.test.ts
@@ -12,18 +12,18 @@ describe("Options - TSConfigReader", () => {
     options.addReader(new TSConfigReader());
     const logger = new TestLogger();
 
-    function readWithProject(project: Project, reset = true) {
+    async function readWithProject(project: Project, reset = true) {
         if (reset) {
             options.reset();
         }
         logger.reset();
         options.setValue("tsconfig", project.cwd);
         project.write();
-        options.read(logger);
+        await options.read(logger);
         project.rm();
     }
 
-    it("Errors if the file cannot be found", () => {
+    it("Errors if the file cannot be found", async () => {
         options.reset();
         logger.reset();
 
@@ -31,15 +31,15 @@ describe("Options - TSConfigReader", () => {
             "tsconfig",
             join(tmpdir(), "typedoc/does-not-exist.json")
         );
-        options.read(logger);
+        await options.read(logger);
         logger.expectMessage("error: *");
     });
 
     function testError(name: string, file: object) {
-        it(name, () => {
+        it(name, async () => {
             const project = tempdirProject();
             project.addJsonFile("tsconfig.json", file);
-            readWithProject(project);
+            await readWithProject(project);
             equal(logger.hasErrors(), true, "No error was logged");
         });
     }
@@ -66,14 +66,14 @@ describe("Options - TSConfigReader", () => {
         },
     });
 
-    it("Errors if a tsconfig file cannot be parsed", () => {
+    it("Errors if a tsconfig file cannot be parsed", async () => {
         const project = tempdirProject();
         project.addFile("tsconfig.json", '{"test}');
-        readWithProject(project);
+        await readWithProject(project);
         logger.expectMessage("error: *");
     });
 
-    it("Does not error if the option file cannot be found but was not set.", () => {
+    it("Does not error if the option file cannot be found but was not set.", async () => {
         const logger = new Logger();
 
         const options = new (class LyingOptions extends Options {
@@ -87,21 +87,21 @@ describe("Options - TSConfigReader", () => {
             join(__dirname, "data/does_not_exist.json")
         );
         options.addReader(new TSConfigReader());
-        options.read(logger);
+        await options.read(logger);
         equal(logger.hasErrors(), false);
     });
 
-    function readTsconfig(tsconfig: object) {
+    async function readTsconfig(tsconfig: object) {
         const project = tempdirProject();
         project.addFile("file.ts", "export const abc = 123");
         project.addJsonFile("tsconfig.json", tsconfig);
 
-        readWithProject(project);
+        await readWithProject(project);
         logger.expectNoOtherMessages();
     }
 
-    it("Sets files for the program", () => {
-        readTsconfig({
+    it("Sets files for the program", async () => {
+        await readTsconfig({
             files: ["./file.ts"],
         });
         equal(
@@ -110,8 +110,8 @@ describe("Options - TSConfigReader", () => {
         );
     });
 
-    it("Allows stripInternal to set excludeInternal", () => {
-        readTsconfig({
+    it("Allows stripInternal to set excludeInternal", async () => {
+        await readTsconfig({
             compilerOptions: {
                 stripInternal: true,
             },
@@ -119,7 +119,7 @@ describe("Options - TSConfigReader", () => {
         equal(options.getValue("excludeInternal"), true);
     });
 
-    it("Does not set excludeInternal by stripInternal if already set", () => {
+    it("Does not set excludeInternal by stripInternal if already set", async () => {
         const project = tempdirProject();
         project.addJsonFile("tsconfig.json", {
             compilerOptions: { stripInternal: true },
@@ -127,40 +127,40 @@ describe("Options - TSConfigReader", () => {
 
         options.reset();
         options.setValue("excludeInternal", false);
-        readWithProject(project, false);
+        await readWithProject(project, false);
         equal(options.getValue("excludeInternal"), false);
     });
 
-    it("Correctly handles folder names ending with .json (#1712)", () => {
+    it("Correctly handles folder names ending with .json (#1712)", async () => {
         const project = tempdirProject();
         project.addJsonFile("tsconfig.json", {
             compilerOptions: { strict: true },
         });
-        readWithProject(project);
+        await readWithProject(project);
         equal(options.getCompilerOptions().strict, true);
     });
 
-    function testTsdoc(tsdoc: object, cb?: () => void, reset = true) {
+    async function testTsdoc(tsdoc: object, cb?: () => void, reset = true) {
         const project = tempdirProject();
         project.addFile("file.ts", "export const abc = 123");
         project.addJsonFile("tsconfig.json", {});
         project.addJsonFile("tsdoc.json", tsdoc);
 
-        readWithProject(project, reset);
+        await readWithProject(project, reset);
         cb?.();
         logger.expectNoOtherMessages();
     }
 
-    it("Handles failed tsdoc reads", () => {
-        testTsdoc([], () => {
+    it("Handles failed tsdoc reads", async () => {
+        await testTsdoc([], () => {
             logger.expectMessage(
                 "error: Failed to read tsdoc.json file at */tsdoc.json."
             );
         });
     });
 
-    it("Handles invalid tsdoc files", () => {
-        testTsdoc(
+    it("Handles invalid tsdoc files", async () => {
+        await testTsdoc(
             {
                 doesNotMatchSchema: true,
             },
@@ -172,11 +172,11 @@ describe("Options - TSConfigReader", () => {
         );
     });
 
-    it("Warns if an option will be overwritten", () => {
+    it("Warns if an option will be overwritten", async () => {
         options.reset();
         options.setValue("blockTags", []);
         options.setValue("modifierTags", []);
-        testTsdoc(
+        await testTsdoc(
             {},
             () => {
                 logger.expectMessage(
@@ -188,8 +188,8 @@ describe("Options - TSConfigReader", () => {
         );
     });
 
-    it("Reads tsdoc.json", () => {
-        testTsdoc({
+    it("Reads tsdoc.json", async () => {
+        await testTsdoc({
             noStandardTags: true,
             tagDefinitions: [
                 {
@@ -212,7 +212,7 @@ describe("Options - TSConfigReader", () => {
         equal(options.getValue("modifierTags"), ["@tag3"]);
     });
 
-    it("Handles extends in tsdoc.json", () => {
+    it("Handles extends in tsdoc.json", async () => {
         const project = tempdirProject();
         project.addFile("file.ts", "export const abc = 123");
         project.addJsonFile("tsconfig.json", {});
@@ -227,13 +227,13 @@ describe("Options - TSConfigReader", () => {
             ],
         });
 
-        readWithProject(project);
+        await readWithProject(project);
         equal(options.getValue("blockTags"), ["@tag"]);
         logger.expectNoOtherMessages();
     });
 
-    it("Handles supportForTags in tsdoc.json", () => {
-        testTsdoc({
+    it("Handles supportForTags in tsdoc.json", async () => {
+        await testTsdoc({
             noStandardTags: true,
             tagDefinitions: [
                 {
@@ -259,8 +259,8 @@ describe("Options - TSConfigReader", () => {
         equal(options.getValue("modifierTags"), []);
     });
 
-    it("Handles circular extends", () => {
-        testTsdoc(
+    it("Handles circular extends", async () => {
+        await testTsdoc(
             {
                 extends: ["./tsdoc.json"],
             },
@@ -272,8 +272,8 @@ describe("Options - TSConfigReader", () => {
         );
     });
 
-    it("Handles extends which reference invalid files", () => {
-        testTsdoc(
+    it("Handles extends which reference invalid files", async () => {
+        await testTsdoc(
             {
                 extends: ["typedoc/nope"],
             },


### PR DESCRIPTION
Support ESM in config files.  Also support the default export of config files being any of the following:

1. The config itself (current behavior)
2. A function that returns the config
3. A function that returns a promise that resolves to the config (or an async function that returns the config)