### PR TITLE
Add new event MarkdownEvent.INCLUDE

### DIFF
--- a/src/lib/output/events.ts
+++ b/src/lib/output/events.ts
@@ -139,6 +139,7 @@ export class PageEvent<out Model = unknown> extends Event {
  * An event emitted when markdown is being parsed. Allows other plugins to manipulate the result.
  *
  * @see {@link MarkdownEvent.PARSE}
+ * @see {@link MarkdownEvent.INCLUDE}
  */
 export class MarkdownEvent extends Event {
     /**
@@ -161,6 +162,12 @@ export class MarkdownEvent extends Event {
      * @event
      */
     static readonly PARSE = "parseMarkdown";
+
+    /**
+     * Triggered on the renderer when this plugin includes a markdown file through a markdown include tag.
+     * @event
+     */
+    static readonly INCLUDE = "includeMarkdown";
 
     constructor(
         name: string,

--- a/src/lib/output/themes/MarkedPlugin.ts
+++ b/src/lib/output/themes/MarkedPlugin.ts
@@ -95,7 +95,14 @@ output file :
                 path = Path.join(this.includes!, path.trim());
                 if (isFile(path)) {
                     const contents = readFile(path);
-                    return contents;
+                    const event = new MarkdownEvent(
+                        MarkdownEvent.INCLUDE,
+                        page,
+                        contents,
+                        contents
+                    );
+                    this.owner.trigger(event);
+                    return event.parsedText;
                 } else {
                     this.application.logger.warn(
                         "Could not find file to include: " + path


### PR DESCRIPTION
Adds a new event that enables plugins to treat included markdown files separately.

I would need this for [this plugin](https://github.com/krisztianb/typedoc-plugin-replace-text) and the option `inIncludedFiles` which enables users to replace text only in included files. I found out that currently this option is broken because the plugin uses the `MarkdownEvent.PARSE` event which is also emitted for comment texts and tag texts.