### PR TITLE
chore: bump typescript from 5.0.4 to 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "shiki": "^0.14.1"
   },
   "peerDependencies": {
-    "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+    "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
   },
   "devDependencies": {
     "@types/lunr": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "2.8.7",
     "puppeteer": "^13.5.2",
     "ts-node": "^10.9.1",
-    "typescript": "5.0.4"
+    "typescript": "5.1.3"
   },
   "files": [
     "/bin",


### PR DESCRIPTION
chore: bump typescript from 5.0.4 to 5.1.3