### PR TITLE
feat: add extra entry-point related paths on reflections

### DIFF
--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -4,6 +4,7 @@ import type { Application } from "../application";
 import {
     Comment,
     CommentDisplayPart,
+    EntrypointInfos,
     ProjectReflection,
     Reflection,
     ReflectionKind,
@@ -368,6 +369,7 @@ export class Converter extends ChildableComponent<
             // Special case for when we're giving a single entry point, we don't need to
             // create modules for each entry. Register the project as this module.
             context.project.registerReflection(context.project, symbol);
+            context.project.entrypointInfos = EntrypointInfos.fromDocumentationEntrypoint(entryPoint);
             context.project.comment = symbol
                 ? context.getComment(symbol, context.project.kind)
                 : context.getFileComment(node);
@@ -410,6 +412,7 @@ export class Converter extends ChildableComponent<
             }
 
             reflection.packageVersion = entryPoint.version;
+            reflection.entrypointInfos = EntrypointInfos.fromDocumentationEntrypoint(entryPoint);
 
             context.finalizeDeclarationReflection(reflection);
             moduleContext = context.withScope(reflection);

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -369,7 +369,8 @@ export class Converter extends ChildableComponent<
             // Special case for when we're giving a single entry point, we don't need to
             // create modules for each entry. Register the project as this module.
             context.project.registerReflection(context.project, symbol);
-            context.project.entrypointInfos = EntrypointInfos.fromDocumentationEntrypoint(entryPoint);
+            context.project.entrypointInfos =
+                EntrypointInfos.fromDocumentationEntrypoint(entryPoint);
             context.project.comment = symbol
                 ? context.getComment(symbol, context.project.kind)
                 : context.getFileComment(node);
@@ -412,7 +413,8 @@ export class Converter extends ChildableComponent<
             }
 
             reflection.packageVersion = entryPoint.version;
-            reflection.entrypointInfos = EntrypointInfos.fromDocumentationEntrypoint(entryPoint);
+            reflection.entrypointInfos =
+                EntrypointInfos.fromDocumentationEntrypoint(entryPoint);
 
             context.finalizeDeclarationReflection(reflection);
             moduleContext = context.withScope(reflection);

--- a/src/lib/models/EntrypointInfos.ts
+++ b/src/lib/models/EntrypointInfos.ts
@@ -6,9 +6,9 @@ export class EntrypointInfos {
     readmeFile?: string;
     rootDir: string;
     packageJsonFile?: string;
-    entrySourceFilePath: string;
+    entrySourceFilePath?: string;
 
-    constructor(rootDir: string, entrySourceFilePath: string) {
+    constructor(rootDir: string, entrySourceFilePath?: string) {
         this.rootDir = rootDir;
         this.entrySourceFilePath = entrySourceFilePath;
     }
@@ -58,8 +58,12 @@ export class EntrypointInfos {
     }
     
     fromObject(de: Deserializer, obj: JSONOutput.EntrypointInfos) {
-        this.readmeFile = obj.readmeFile;
-        this.packageJsonFile = obj.packageJsonFile;
+        if(obj.readmeFile){
+            this.readmeFile = obj.readmeFile;
+        }
+        if(obj.packageJsonFile){
+            this.packageJsonFile = obj.packageJsonFile;
+        }
     }
 }
 

--- a/src/lib/models/EntrypointInfos.ts
+++ b/src/lib/models/EntrypointInfos.ts
@@ -1,0 +1,71 @@
+import { DocumentationEntryPoint, normalizePath } from "../utils";
+import type { Deserializer, JSONOutput, Serializer } from "../serialization";
+import { isAbsolute, relative } from "path";
+
+export class EntrypointInfos {
+    readmeFile?: string;
+    rootDir: string;
+    packageJsonFile?: string;
+    entrySourceFilePath: string;
+
+    constructor(rootDir: string, entrySourceFilePath: string) {
+        this.rootDir = rootDir;
+        this.entrySourceFilePath = entrySourceFilePath;
+    }
+
+    static fromDocumentationEntrypoint(docEntryPoint: DocumentationEntryPoint): EntrypointInfos {
+        const entrypointInfos = new EntrypointInfos(toRelative(docEntryPoint.rootDir), toRelative(docEntryPoint.sourceFile.fileName));
+        if(docEntryPoint.readmeFile){
+            entrypointInfos.readmeFile = toRelative(docEntryPoint.readmeFile)
+        }
+        if(docEntryPoint.packageJsonFile){
+            entrypointInfos.packageJsonFile = toRelative(docEntryPoint.packageJsonFile)
+        }
+        return entrypointInfos;
+    }
+
+    clone(): EntrypointInfos {
+        const entrypointInfos = new EntrypointInfos(
+            this.rootDir,
+            this.entrySourceFilePath
+        );
+        if (this.readmeFile) {
+            entrypointInfos.readmeFile = this.readmeFile;
+        }
+        if (this.packageJsonFile) {
+            entrypointInfos.packageJsonFile = this.packageJsonFile;
+        }
+        return entrypointInfos;
+    }
+
+    toObject(serializer: Serializer): JSONOutput.EntrypointInfos {
+        return {
+            readmeFile: this.readmeFile,
+            rootDir: this.rootDir,
+            packageJsonFile: this.packageJsonFile,
+            entrySourceFilePath: this.entrySourceFilePath,
+        };
+    }
+
+
+    static fromObject(de: Deserializer, obj?: JSONOutput.EntrypointInfos) {
+        if(!obj){
+            return undefined;
+        }
+        const entrypointInfos = new EntrypointInfos(obj.rootDir, obj.entrySourceFilePath);
+        entrypointInfos.fromObject(de, obj);
+        return entrypointInfos;
+    }
+    
+    fromObject(de: Deserializer, obj: JSONOutput.EntrypointInfos) {
+        this.readmeFile = obj.readmeFile;
+        this.packageJsonFile = obj.packageJsonFile;
+    }
+}
+
+const toRelative = <T extends string | undefined>(path: T): T => {
+    if(path){
+        return normalizePath(isAbsolute(path) ? relative(process.cwd(), path) : path) as T;
+    }
+    return path;
+}

--- a/src/lib/models/EntrypointInfos.ts
+++ b/src/lib/models/EntrypointInfos.ts
@@ -1,5 +1,5 @@
 import { DocumentationEntryPoint, normalizePath } from "../utils";
-import type { Deserializer, JSONOutput, Serializer } from "../serialization";
+import type { JSONOutput } from "../serialization";
 import { isAbsolute, relative } from "path";
 
 export class EntrypointInfos {
@@ -13,13 +13,20 @@ export class EntrypointInfos {
         this.entrySourceFilePath = entrySourceFilePath;
     }
 
-    static fromDocumentationEntrypoint(docEntryPoint: DocumentationEntryPoint): EntrypointInfos {
-        const entrypointInfos = new EntrypointInfos(toRelative(docEntryPoint.rootDir), toRelative(docEntryPoint.sourceFile.fileName));
-        if(docEntryPoint.readmeFile){
-            entrypointInfos.readmeFile = toRelative(docEntryPoint.readmeFile)
+    static fromDocumentationEntrypoint(
+        docEntryPoint: DocumentationEntryPoint
+    ): EntrypointInfos {
+        const entrypointInfos = new EntrypointInfos(
+            toRelative(docEntryPoint.rootDir),
+            toRelative(docEntryPoint.sourceFile.fileName)
+        );
+        if (docEntryPoint.readmeFile) {
+            entrypointInfos.readmeFile = toRelative(docEntryPoint.readmeFile);
         }
-        if(docEntryPoint.packageJsonFile){
-            entrypointInfos.packageJsonFile = toRelative(docEntryPoint.packageJsonFile)
+        if (docEntryPoint.packageJsonFile) {
+            entrypointInfos.packageJsonFile = toRelative(
+                docEntryPoint.packageJsonFile
+            );
         }
         return entrypointInfos;
     }
@@ -38,7 +45,7 @@ export class EntrypointInfos {
         return entrypointInfos;
     }
 
-    toObject(serializer: Serializer): JSONOutput.EntrypointInfos {
+    toObject(): JSONOutput.EntrypointInfos {
         return {
             readmeFile: this.readmeFile,
             rootDir: this.rootDir,
@@ -47,29 +54,33 @@ export class EntrypointInfos {
         };
     }
 
-
-    static fromObject(de: Deserializer, obj?: JSONOutput.EntrypointInfos) {
-        if(!obj){
+    static fromObject(obj?: JSONOutput.EntrypointInfos) {
+        if (!obj) {
             return undefined;
         }
-        const entrypointInfos = new EntrypointInfos(obj.rootDir, obj.entrySourceFilePath);
-        entrypointInfos.fromObject(de, obj);
+        const entrypointInfos = new EntrypointInfos(
+            obj.rootDir,
+            obj.entrySourceFilePath
+        );
+        entrypointInfos.fromObject(obj);
         return entrypointInfos;
     }
-    
-    fromObject(de: Deserializer, obj: JSONOutput.EntrypointInfos) {
-        if(obj.readmeFile){
+
+    fromObject(obj: JSONOutput.EntrypointInfos) {
+        if (obj.readmeFile) {
             this.readmeFile = obj.readmeFile;
         }
-        if(obj.packageJsonFile){
+        if (obj.packageJsonFile) {
             this.packageJsonFile = obj.packageJsonFile;
         }
     }
 }
 
 const toRelative = <T extends string | undefined>(path: T): T => {
-    if(path){
-        return normalizePath(isAbsolute(path) ? relative(process.cwd(), path) : path) as T;
+    if (path) {
+        return normalizePath(
+            isAbsolute(path) ? relative(process.cwd(), path) : path
+        ) as T;
     }
     return path;
-}
+};

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -4,3 +4,4 @@ export * from "./comments/index";
 export * from "./sources/index";
 export * from "./ReflectionGroup";
 export * from "./ReflectionCategory";
+export * from "./EntrypointInfos";

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -328,7 +328,9 @@ export class DeclarationReflection extends ContainerReflection {
         if (obj.variant === "project") {
             this.kind = ReflectionKind.Module;
             this.packageVersion = obj.packageVersion;
-            this.entrypointInfos = EntrypointInfos.fromObject(de, obj.entrypointInfos);
+            this.entrypointInfos = EntrypointInfos.fromObject(
+                obj.entrypointInfos
+            );
             if (obj.readme) {
                 this.readme = Comment.deserializeDisplayParts(de, obj.readme);
             }
@@ -354,7 +356,7 @@ export class DeclarationReflection extends ContainerReflection {
         }
 
         this.packageVersion = obj.packageVersion;
-        this.entrypointInfos = EntrypointInfos.fromObject(de, obj.entrypointInfos);
+        this.entrypointInfos = EntrypointInfos.fromObject(obj.entrypointInfos);
         this.sources = de.reviveMany(
             obj.sources,
             (src) => new SourceReference(src.fileName, src.line, src.character)

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -9,6 +9,7 @@ import { Comment, CommentDisplayPart } from "../comments";
 import { SourceReference } from "../sources/file";
 import { ReflectionSymbolId } from "./ReflectionSymbolId";
 import { ReflectionKind } from "./kind";
+import { EntrypointInfos } from "../EntrypointInfos";
 
 /**
  * Stores hierarchical type data.
@@ -157,14 +158,16 @@ export class DeclarationReflection extends ContainerReflection {
     typeHierarchy?: DeclarationHierarchy;
 
     /**
+     * The version of the module when found.
+     */
+    packageVersion?: string;
+
+    /**
      * The contents of the readme file of the module when found.
      */
     readme?: CommentDisplayPart[];
 
-    /**
-     * The version of the module when found.
-     */
-    packageVersion?: string;
+    entrypointInfos?: EntrypointInfos;
 
     /**
      * Flags for information about a reflection which is needed solely during conversion.
@@ -291,6 +294,7 @@ export class DeclarationReflection extends ContainerReflection {
             ...super.toObject(serializer),
             variant: this.variant,
             packageVersion: this.packageVersion,
+            entrypointInfos: this.entrypointInfos,
             sources: serializer.toObjectsOptional(this.sources),
             relevanceBoost:
                 this.relevanceBoost === 1 ? undefined : this.relevanceBoost,
@@ -324,6 +328,7 @@ export class DeclarationReflection extends ContainerReflection {
         if (obj.variant === "project") {
             this.kind = ReflectionKind.Module;
             this.packageVersion = obj.packageVersion;
+            this.entrypointInfos = EntrypointInfos.fromObject(de, obj.entrypointInfos);
             if (obj.readme) {
                 this.readme = Comment.deserializeDisplayParts(de, obj.readme);
             }
@@ -349,6 +354,7 @@ export class DeclarationReflection extends ContainerReflection {
         }
 
         this.packageVersion = obj.packageVersion;
+        this.entrypointInfos = EntrypointInfos.fromObject(de, obj.entrypointInfos);
         this.sources = de.reviveMany(
             obj.sources,
             (src) => new SourceReference(src.fileName, src.line, src.character)

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -14,6 +14,7 @@ import { ReflectionSymbolId } from "./ReflectionSymbolId";
 import type { Serializer } from "../../serialization/serializer";
 import type { Deserializer, JSONOutput } from "../../serialization/index";
 import { DefaultMap, StableKeyMap } from "../../utils/map";
+import { EntrypointInfos } from "../EntrypointInfos";
 
 /**
  * A reflection that represents the root of the project.
@@ -60,6 +61,8 @@ export class ProjectReflection extends ContainerReflection {
      * The contents of the readme.md file of the project when found.
      */
     readme?: CommentDisplayPart[];
+
+    entrypointInfos?: EntrypointInfos;
 
     constructor(name: string) {
         super(name, ReflectionKind.Project);
@@ -281,6 +284,7 @@ export class ProjectReflection extends ContainerReflection {
             variant: this.variant,
             packageName: this.packageName,
             packageVersion: this.packageVersion,
+            entrypointInfos: this.entrypointInfos?.toObject(serializer),
             readme: Comment.serializeDisplayParts(serializer, this.readme),
             symbolIdMap,
         };
@@ -297,6 +301,7 @@ export class ProjectReflection extends ContainerReflection {
         if (obj.readme) {
             this.readme = Comment.deserializeDisplayParts(de, obj.readme);
         }
+        this.entrypointInfos = EntrypointInfos.fromObject(de, obj.entrypointInfos);
 
         de.defer(() => {
             for (const [id, sid] of Object.entries(obj.symbolIdMap || {})) {

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -284,7 +284,7 @@ export class ProjectReflection extends ContainerReflection {
             variant: this.variant,
             packageName: this.packageName,
             packageVersion: this.packageVersion,
-            entrypointInfos: this.entrypointInfos?.toObject(serializer),
+            entrypointInfos: this.entrypointInfos?.toObject(),
             readme: Comment.serializeDisplayParts(serializer, this.readme),
             symbolIdMap,
         };
@@ -301,7 +301,7 @@ export class ProjectReflection extends ContainerReflection {
         if (obj.readme) {
             this.readme = Comment.deserializeDisplayParts(de, obj.readme);
         }
-        this.entrypointInfos = EntrypointInfos.fromObject(de, obj.entrypointInfos);
+        this.entrypointInfos = EntrypointInfos.fromObject(obj.entrypointInfos);
 
         de.defer(() => {
             for (const [id, sid] of Object.entries(obj.symbolIdMap || {})) {

--- a/src/lib/serialization/deserializer.ts
+++ b/src/lib/serialization/deserializer.ts
@@ -4,6 +4,7 @@ import {
     ArrayType,
     ConditionalType,
     DeclarationReflection,
+    EntrypointInfos,
     IndexedAccessType,
     InferredType,
     IntersectionType,
@@ -257,6 +258,7 @@ export class Deserializer {
         }
 
         const project = new ProjectReflection(name);
+        project.entrypointInfos = new EntrypointInfos('.')
         project.children = [];
         this.project = project;
 

--- a/src/lib/serialization/deserializer.ts
+++ b/src/lib/serialization/deserializer.ts
@@ -258,7 +258,7 @@ export class Deserializer {
         }
 
         const project = new ProjectReflection(name);
-        project.entrypointInfos = new EntrypointInfos('.')
+        project.entrypointInfos = new EntrypointInfos(".");
         project.children = [];
         this.project = project;
 

--- a/src/lib/serialization/schema.ts
+++ b/src/lib/serialization/schema.ts
@@ -76,6 +76,8 @@ type _ModelToObject<T> =
         ? CommentDisplayPart
         : T extends M.SourceReference
         ? SourceReference
+        : T extends M.EntrypointInfos
+        ? EntrypointInfos
         : never;
 
 type Primitive = string | number | undefined | null | boolean;
@@ -155,6 +157,7 @@ export interface DeclarationReflection
             M.DeclarationReflection,
             | "variant"
             | "packageVersion"
+            | "entrypointInfos"
             | "sources"
             | "relevanceBoost"
             | "type"
@@ -184,7 +187,7 @@ export interface ProjectReflection
     extends Omit<ContainerReflection, "variant">,
         S<
             M.ProjectReflection,
-            "variant" | "packageName" | "packageVersion" | "readme"
+            "variant" | "packageName" | "packageVersion" | "readme" | "entrypointInfos"
         > {
     symbolIdMap: Record<number, ReflectionSymbolId>;
 }
@@ -355,3 +358,6 @@ export interface InlineTagDisplayPart {
 
 export interface SourceReference
     extends S<M.SourceReference, "fileName" | "line" | "character" | "url"> {}
+
+    export interface EntrypointInfos
+        extends S<M.EntrypointInfos, "readmeFile" | "rootDir" | "packageJsonFile" | "entrySourceFilePath"> {}

--- a/src/lib/serialization/schema.ts
+++ b/src/lib/serialization/schema.ts
@@ -187,7 +187,11 @@ export interface ProjectReflection
     extends Omit<ContainerReflection, "variant">,
         S<
             M.ProjectReflection,
-            "variant" | "packageName" | "packageVersion" | "readme" | "entrypointInfos"
+            | "variant"
+            | "packageName"
+            | "packageVersion"
+            | "readme"
+            | "entrypointInfos"
         > {
     symbolIdMap: Record<number, ReflectionSymbolId>;
 }
@@ -359,5 +363,8 @@ export interface InlineTagDisplayPart {
 export interface SourceReference
     extends S<M.SourceReference, "fileName" | "line" | "character" | "url"> {}
 
-    export interface EntrypointInfos
-        extends S<M.EntrypointInfos, "readmeFile" | "rootDir" | "packageJsonFile" | "entrySourceFilePath"> {}
+export interface EntrypointInfos
+    extends S<
+        M.EntrypointInfos,
+        "readmeFile" | "rootDir" | "packageJsonFile" | "entrySourceFilePath"
+    > {}

--- a/src/lib/utils/entry-point.ts
+++ b/src/lib/utils/entry-point.ts
@@ -51,6 +51,8 @@ export type EntryPointStrategy =
     (typeof EntryPointStrategy)[keyof typeof EntryPointStrategy];
 
 export interface DocumentationEntryPoint {
+    rootDir: string;
+    packageJsonFile?: string;
     displayName: string;
     readmeFile?: string;
     program: ts.Program;
@@ -195,7 +197,9 @@ function getEntryPointsForPaths(
 
     entryLoop: for (const fileOrDir of inputFiles.map(normalizePath)) {
         const toCheck = [fileOrDir];
+        let rootDir = normalizePath(Path.dirname(fileOrDir));
         if (!/\.([cm][tj]s|[tj]sx?)$/.test(fileOrDir)) {
+            rootDir = fileOrDir;
             toCheck.push(
                 `${fileOrDir}/index.ts`,
                 `${fileOrDir}/index.cts`,
@@ -216,6 +220,7 @@ function getEntryPointsForPaths(
                         displayName: getModuleName(resolve(check), baseDir),
                         sourceFile,
                         program,
+                        rootDir
                     });
                     continue entryLoop;
                 }
@@ -477,6 +482,8 @@ function getEntryPointsForLegacyPackages(
             ),
             program,
             sourceFile,
+            rootDir: packagePath,
+            packageJsonFile: packageJsonPath
         });
     }
 

--- a/src/lib/utils/entry-point.ts
+++ b/src/lib/utils/entry-point.ts
@@ -220,7 +220,7 @@ function getEntryPointsForPaths(
                         displayName: getModuleName(resolve(check), baseDir),
                         sourceFile,
                         program,
-                        rootDir
+                        rootDir,
                     });
                     continue entryLoop;
                 }
@@ -483,7 +483,7 @@ function getEntryPointsForLegacyPackages(
             program,
             sourceFile,
             rootDir: packagePath,
-            packageJsonFile: packageJsonPath
+            packageJsonFile: packageJsonPath,
         });
     }
 

--- a/src/test/behavior.c2.test.ts
+++ b/src/test/behavior.c2.test.ts
@@ -90,6 +90,7 @@ function convert(entry: string) {
             displayName: entry,
             program,
             sourceFile,
+            rootDir: base,
         },
     ]);
 }

--- a/src/test/converter/alias/specs.json
+++ b/src/test/converter/alias/specs.json
@@ -300,6 +300,10 @@
     }
   ],
   "packageName": "typedoc",
+  "entrypointInfos": {
+    "rootDir": "src/test/converter/alias",
+    "entrySourceFilePath": "src/test/converter/alias/alias.ts"
+  },
   "symbolIdMap": {
     "0": {
       "sourceFileName": "src/test/converter/alias/alias.ts",

--- a/src/test/converter/class/specs-with-lump-categories.json
+++ b/src/test/converter/class/specs-with-lump-categories.json
@@ -472,6 +472,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/access.ts"
+      },
       "sources": [
         {
           "fileName": "access.ts",
@@ -2351,6 +2355,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/class.ts"
+      },
       "sources": [
         {
           "fileName": "class.ts",
@@ -2916,6 +2924,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/constructor-properties.ts"
+      },
       "sources": [
         {
           "fileName": "constructor-properties.ts",
@@ -3349,6 +3361,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/decorators.ts"
+      },
       "sources": [
         {
           "fileName": "decorators.ts",
@@ -3457,6 +3473,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/events.ts"
+      },
       "sources": [
         {
           "fileName": "events.ts",
@@ -4021,6 +4041,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/events-overloads.ts"
+      },
       "sources": [
         {
           "fileName": "events-overloads.ts",
@@ -4598,6 +4622,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/generic-class.ts"
+      },
       "sources": [
         {
           "fileName": "generic-class.ts",
@@ -4985,6 +5013,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/getter-setter.ts"
+      },
       "sources": [
         {
           "fileName": "getter-setter.ts",
@@ -5119,6 +5151,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/this.ts"
+      },
       "sources": [
         {
           "fileName": "this.ts",
@@ -5382,6 +5418,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/type-operator.ts"
+      },
       "sources": [
         {
           "fileName": "type-operator.ts",

--- a/src/test/converter/class/specs.json
+++ b/src/test/converter/class/specs.json
@@ -472,6 +472,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/access.ts"
+      },
       "sources": [
         {
           "fileName": "access.ts",
@@ -2347,6 +2351,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/class.ts"
+      },
       "sources": [
         {
           "fileName": "class.ts",
@@ -2912,6 +2920,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/constructor-properties.ts"
+      },
       "sources": [
         {
           "fileName": "constructor-properties.ts",
@@ -3345,6 +3357,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/decorators.ts"
+      },
       "sources": [
         {
           "fileName": "decorators.ts",
@@ -3453,6 +3469,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/events.ts"
+      },
       "sources": [
         {
           "fileName": "events.ts",
@@ -4017,6 +4037,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/events-overloads.ts"
+      },
       "sources": [
         {
           "fileName": "events-overloads.ts",
@@ -4594,6 +4618,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/generic-class.ts"
+      },
       "sources": [
         {
           "fileName": "generic-class.ts",
@@ -4981,6 +5009,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/getter-setter.ts"
+      },
       "sources": [
         {
           "fileName": "getter-setter.ts",
@@ -5115,6 +5147,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/this.ts"
+      },
       "sources": [
         {
           "fileName": "this.ts",
@@ -5378,6 +5414,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/class",
+        "entrySourceFilePath": "src/test/converter/class/type-operator.ts"
+      },
       "sources": [
         {
           "fileName": "type-operator.ts",

--- a/src/test/converter/comment/specs.json
+++ b/src/test/converter/comment/specs.json
@@ -202,6 +202,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/comment",
+        "entrySourceFilePath": "src/test/converter/comment/comment.ts"
+      },
       "sources": [
         {
           "fileName": "comment.ts",
@@ -303,6 +307,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/comment",
+        "entrySourceFilePath": "src/test/converter/comment/comment2.ts"
+      },
       "sources": [
         {
           "fileName": "comment2.ts",
@@ -404,6 +412,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/comment",
+        "entrySourceFilePath": "src/test/converter/comment/comment3.ts"
+      },
       "sources": [
         {
           "fileName": "comment3.ts",
@@ -501,6 +513,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/comment",
+        "entrySourceFilePath": "src/test/converter/comment/comment4.ts"
+      },
       "sources": [
         {
           "fileName": "comment4.ts",

--- a/src/test/converter/declaration/specs.json
+++ b/src/test/converter/declaration/specs.json
@@ -120,6 +120,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/declaration",
+        "entrySourceFilePath": "src/test/converter/declaration/declaration.d.ts"
+      },
       "sources": [
         {
           "fileName": "declaration.d.ts",
@@ -240,6 +244,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/declaration",
+        "entrySourceFilePath": "src/test/converter/declaration/export-declaration.d.ts"
+      },
       "sources": [
         {
           "fileName": "export-declaration.d.ts",
@@ -291,6 +299,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/declaration",
+        "entrySourceFilePath": "src/test/converter/declaration/external.d.ts"
+      },
       "sources": [
         {
           "fileName": "external.d.ts",

--- a/src/test/converter/enum/specs.json
+++ b/src/test/converter/enum/specs.json
@@ -451,6 +451,10 @@
     }
   ],
   "packageName": "typedoc",
+  "entrypointInfos": {
+    "rootDir": "src/test/converter/enum",
+    "entrySourceFilePath": "src/test/converter/enum/enum.ts"
+  },
   "symbolIdMap": {
     "0": {
       "sourceFileName": "src/test/converter/enum/enum.ts",

--- a/src/test/converter/enum/specs.nodoc.json
+++ b/src/test/converter/enum/specs.nodoc.json
@@ -451,6 +451,10 @@
     }
   ],
   "packageName": "typedoc",
+  "entrypointInfos": {
+    "rootDir": "src/test/converter/enum",
+    "entrySourceFilePath": "src/test/converter/enum/enum.ts"
+  },
   "symbolIdMap": {
     "0": {
       "sourceFileName": "src/test/converter/enum/enum.ts",

--- a/src/test/converter/exports/specs.json
+++ b/src/test/converter/exports/specs.json
@@ -443,6 +443,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/exports",
+        "entrySourceFilePath": "src/test/converter/exports/export.ts"
+      },
       "sources": [
         {
           "fileName": "export.ts",
@@ -528,6 +532,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/exports",
+        "entrySourceFilePath": "src/test/converter/exports/export-assignment.ts"
+      },
       "sources": [
         {
           "fileName": "export-assignment.ts",
@@ -575,6 +583,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/exports",
+        "entrySourceFilePath": "src/test/converter/exports/export-default.ts"
+      },
       "sources": [
         {
           "fileName": "export-default.ts",
@@ -688,6 +700,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/exports",
+        "entrySourceFilePath": "src/test/converter/exports/export-with-local.ts"
+      },
       "sources": [
         {
           "fileName": "export-with-local.ts",
@@ -890,6 +906,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/exports",
+        "entrySourceFilePath": "src/test/converter/exports/mod.ts"
+      },
       "sources": [
         {
           "fileName": "mod.ts",
@@ -956,6 +976,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/exports",
+        "entrySourceFilePath": "src/test/converter/exports/no-doc-members.ts"
+      },
       "sources": [
         {
           "fileName": "no-doc-members.ts",

--- a/src/test/converter/exports/specs.nodoc.json
+++ b/src/test/converter/exports/specs.nodoc.json
@@ -70,6 +70,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/exports",
+        "entrySourceFilePath": "src/test/converter/exports/export.ts"
+      },
       "sources": [
         {
           "fileName": "export.ts",
@@ -230,6 +234,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/exports",
+        "entrySourceFilePath": "src/test/converter/exports/mod.ts"
+      },
       "sources": [
         {
           "fileName": "mod.ts",
@@ -263,6 +271,10 @@
             ]
           }
         ]
+      },
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/exports",
+        "entrySourceFilePath": "src/test/converter/exports/no-doc-members.ts"
       },
       "sources": [
         {

--- a/src/test/converter/function/specs.json
+++ b/src/test/converter/function/specs.json
@@ -2582,6 +2582,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/function",
+        "entrySourceFilePath": "src/test/converter/function/function.ts"
+      },
       "sources": [
         {
           "fileName": "function.ts",
@@ -2909,6 +2913,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/function",
+        "entrySourceFilePath": "src/test/converter/function/generic-function.ts"
+      },
       "sources": [
         {
           "fileName": "generic-function.ts",
@@ -3173,6 +3181,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/function",
+        "entrySourceFilePath": "src/test/converter/function/implicit-types.ts"
+      },
       "sources": [
         {
           "fileName": "implicit-types.ts",

--- a/src/test/converter/inherit-param-doc/specs.json
+++ b/src/test/converter/inherit-param-doc/specs.json
@@ -582,6 +582,10 @@
     }
   ],
   "packageName": "typedoc",
+  "entrypointInfos": {
+    "rootDir": "src/test/converter/inherit-param-doc",
+    "entrySourceFilePath": "src/test/converter/inherit-param-doc/inherit-param-doc.ts"
+  },
   "symbolIdMap": {
     "0": {
       "sourceFileName": "src/test/converter/inherit-param-doc/inherit-param-doc.ts",

--- a/src/test/converter/inheritance/specs.json
+++ b/src/test/converter/inheritance/specs.json
@@ -653,6 +653,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/inheritance",
+        "entrySourceFilePath": "src/test/converter/inheritance/inherit-doc.ts"
+      },
       "sources": [
         {
           "fileName": "inherit-doc.ts",
@@ -1001,6 +1005,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/inheritance",
+        "entrySourceFilePath": "src/test/converter/inheritance/mergable-class.ts"
+      },
       "sources": [
         {
           "fileName": "mergable-class.ts",

--- a/src/test/converter/interface/specs.json
+++ b/src/test/converter/interface/specs.json
@@ -212,6 +212,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/interface",
+        "entrySourceFilePath": "src/test/converter/interface/constructor-type.ts"
+      },
       "sources": [
         {
           "fileName": "constructor-type.ts",
@@ -451,6 +455,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/interface",
+        "entrySourceFilePath": "src/test/converter/interface/index-signature.ts"
+      },
       "sources": [
         {
           "fileName": "index-signature.ts",
@@ -646,6 +654,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/interface",
+        "entrySourceFilePath": "src/test/converter/interface/interface-empty.ts"
+      },
       "sources": [
         {
           "fileName": "interface-empty.ts",
@@ -2145,6 +2157,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/interface",
+        "entrySourceFilePath": "src/test/converter/interface/interface-implementation.ts"
+      },
       "sources": [
         {
           "fileName": "interface-implementation.ts",
@@ -2579,6 +2595,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/interface",
+        "entrySourceFilePath": "src/test/converter/interface/merging.ts"
+      },
       "sources": [
         {
           "fileName": "merging.ts",

--- a/src/test/converter/js/specs.json
+++ b/src/test/converter/js/specs.json
@@ -95,6 +95,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/js",
+        "entrySourceFilePath": "src/test/converter/js/export-eq-type.js"
+      },
       "sources": [
         {
           "fileName": "export-eq-type.js",
@@ -960,6 +964,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/js",
+        "entrySourceFilePath": "src/test/converter/js/index.js"
+      },
       "sources": [
         {
           "fileName": "index.js",

--- a/src/test/converter/mixin/specs.json
+++ b/src/test/converter/mixin/specs.json
@@ -2128,6 +2128,10 @@
     }
   ],
   "packageName": "typedoc",
+  "entrypointInfos": {
+    "rootDir": "src/test/converter/mixin",
+    "entrySourceFilePath": "src/test/converter/mixin/mixin.ts"
+  },
   "symbolIdMap": {
     "0": {
       "sourceFileName": "src/test/converter/mixin/mixin.ts",

--- a/src/test/converter/react/specs.json
+++ b/src/test/converter/react/specs.json
@@ -232,6 +232,10 @@
     }
   ],
   "packageName": "typedoc",
+  "entrypointInfos": {
+    "rootDir": "src/test/converter/react",
+    "entrySourceFilePath": "src/test/converter/react/react.tsx"
+  },
   "symbolIdMap": {
     "0": {
       "sourceFileName": "src/test/converter/react/react.tsx",

--- a/src/test/converter/types/specs.json
+++ b/src/test/converter/types/specs.json
@@ -309,6 +309,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/types",
+        "entrySourceFilePath": "src/test/converter/types/general.ts"
+      },
       "sources": [
         {
           "fileName": "general.ts",
@@ -495,6 +499,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/types",
+        "entrySourceFilePath": "src/test/converter/types/index-signature.ts"
+      },
       "sources": [
         {
           "fileName": "index-signature.ts",
@@ -853,6 +861,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/types",
+        "entrySourceFilePath": "src/test/converter/types/mapped.ts"
+      },
       "sources": [
         {
           "fileName": "mapped.ts",
@@ -949,6 +961,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/types",
+        "entrySourceFilePath": "src/test/converter/types/parens.ts"
+      },
       "sources": [
         {
           "fileName": "parens.ts",
@@ -1026,6 +1042,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/types",
+        "entrySourceFilePath": "src/test/converter/types/query.ts"
+      },
       "sources": [
         {
           "fileName": "query.ts",
@@ -1453,6 +1473,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/types",
+        "entrySourceFilePath": "src/test/converter/types/tuple.ts"
+      },
       "sources": [
         {
           "fileName": "tuple.ts",
@@ -1645,6 +1669,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/types",
+        "entrySourceFilePath": "src/test/converter/types/type-operator.ts"
+      },
       "sources": [
         {
           "fileName": "type-operator.ts",
@@ -1962,6 +1990,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/types",
+        "entrySourceFilePath": "src/test/converter/types/union-or-intersection.ts"
+      },
       "sources": [
         {
           "fileName": "union-or-intersection.ts",

--- a/src/test/converter/variables/specs.json
+++ b/src/test/converter/variables/specs.json
@@ -363,6 +363,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/variables",
+        "entrySourceFilePath": "src/test/converter/variables/array.ts"
+      },
       "sources": [
         {
           "fileName": "array.ts",
@@ -698,6 +702,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/variables",
+        "entrySourceFilePath": "src/test/converter/variables/destructuring.ts"
+      },
       "sources": [
         {
           "fileName": "destructuring.ts",
@@ -1926,6 +1934,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/variables",
+        "entrySourceFilePath": "src/test/converter/variables/literal.ts"
+      },
       "sources": [
         {
           "fileName": "literal.ts",
@@ -2185,6 +2197,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/variables",
+        "entrySourceFilePath": "src/test/converter/variables/variable.ts"
+      },
       "sources": [
         {
           "fileName": "variable.ts",

--- a/src/test/converter/variables/specs.nodoc.json
+++ b/src/test/converter/variables/specs.nodoc.json
@@ -240,6 +240,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/variables",
+        "entrySourceFilePath": "src/test/converter/variables/array.ts"
+      },
       "sources": [
         {
           "fileName": "array.ts",
@@ -322,6 +326,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/variables",
+        "entrySourceFilePath": "src/test/converter/variables/destructuring.ts"
+      },
       "sources": [
         {
           "fileName": "destructuring.ts",
@@ -1192,6 +1200,10 @@
           ]
         }
       ],
+      "entrypointInfos": {
+        "rootDir": "src/test/converter/variables",
+        "entrySourceFilePath": "src/test/converter/variables/literal.ts"
+      },
       "sources": [
         {
           "fileName": "literal.ts",

--- a/src/test/issues.c2.test.ts
+++ b/src/test/issues.c2.test.ts
@@ -54,6 +54,7 @@ function doConvert(entry: string) {
             displayName: entry,
             program,
             sourceFile,
+            rootDir: base,
         },
     ]);
 }

--- a/src/test/validation.test.ts
+++ b/src/test/validation.test.ts
@@ -20,6 +20,7 @@ function convertValidationFile(file: string) {
             displayName: "validation",
             program,
             sourceFile,
+            rootDir: __dirname,
         },
     ]);
 
@@ -59,6 +60,7 @@ function expectNoWarning(
             displayName: "validation",
             program,
             sourceFile,
+            rootDir: __dirname,
         },
     ]);
 
@@ -137,6 +139,7 @@ describe("validateExports", () => {
                 displayName: "validation",
                 program,
                 sourceFile,
+                rootDir: __dirname,
             },
         ]);
 


### PR DESCRIPTION
This PR adds extra informations about the entrypoint on declarations & projects.

As a plugin author, I would use those informations to read some files relative to each entrypoint. I found a hack to do this with 0.23.x, but it does not work for 0.24.x. So, the simplest solution I found was to add the required informations directly in TypeDoc.

Note that this inability to bring this hack from 0.23.x to 0.24.x prevents me from releasing versions of [@knodes/typedoc-plugin-pages](https://www.npmjs.com/package/@knodes/typedoc-plugin-pages) & [@knodes/typedoc-plugin-code-blocks](https://www.npmjs.com/package/@knodes/typedoc-plugin-code-blocks) compatible with 0.24.x onwards.

Feedbacks are welcome. This is a quick approximate draft, that I will continue by adding more precise tests if you'll be susceptible to accept such addition.

Thanks !