### PR TITLE
feat(search) Show a no results placeholder when no results are available

### DIFF
--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -174,6 +174,17 @@ function updateResults(
         item.score *= boost;
     }
 
+    if (res.length === 0) {
+        let item = document.createElement("li");
+        item.classList.add("no-results");
+
+        let anchor = document.createElement("span");
+        anchor.textContent = "No results found";
+
+        item.appendChild(anchor);
+        results.appendChild(item);
+    }
+
     res.sort((a, b) => b.score - a.score);
 
     for (let i = 0, c = Math.min(10, res.length); i < c; i++) {

--- a/static/style.css
+++ b/static/style.css
@@ -909,8 +909,8 @@ a.tsd-index-link {
 #tsd-search .results li.state {
     display: none;
 }
-#tsd-search .results li.current,
-#tsd-search .results li:hover {
+#tsd-search .results li.current:not(.no-results),
+#tsd-search .results li:hover:not(.no-results) {
     background-color: var(--color-accent);
 }
 #tsd-search .results a {


### PR DESCRIPTION
 - Adds placeholder text (_"No Results Found"_) when no search results are available.

Note: this result does **not** have a hover state as there are no actions that can be taken with it


Before:

<img width="873" alt="Screenshot 2023-07-25 at 09 50 49" src="https://github.com/TypeStrong/typedoc/assets/18101008/e0e44489-cc00-43fa-94d7-af1862b7cdbb">

After:

<img width="873" alt="Screenshot 2023-07-25 at 09 49 48" src="https://github.com/TypeStrong/typedoc/assets/18101008/bf137ced-ddc8-4884-aa1c-fabd6f804aa7">
