### PR TITLE
Added support for TypeScript 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   Added `--disableGit` option to prevent TypeDoc from using Git to try to determine if sources can be linked, #2326.
 -   Added support for tags `@showGroups`, `@hideGroups`, `@showCategories`, `@hideCategories` to configure the navigation pane on a
     per-reflection basis, #2329.
+-   Added support for TypeScript 5.2, #2296.
 
 ### Bug Fixes
 

--- a/example/package.json
+++ b/example/package.json
@@ -19,6 +19,6 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "typescript": "^5.1.3"
+    "typescript": "^5.2.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "shiki": "^0.14.1"
   },
   "peerDependencies": {
-    "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+    "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x"
   },
   "devDependencies": {
     "@types/lunr": "^2.3.4",


### PR DESCRIPTION
This PR adds support for TypeScript 5.2

Closes https://github.com/TypeStrong/typedoc/issues/2373