### PR TITLE
feat: Make `mappings` and `getMapping` public

### DIFF
--- a/src/lib/output/themes/default/DefaultTheme.tsx
+++ b/src/lib/output/themes/default/DefaultTheme.tsx
@@ -77,7 +77,7 @@ export class DefaultTheme extends Theme {
     /**
      * Mappings of reflections kinds to templates used by this theme.
      */
-    private mappings: TemplateMapping[] = [
+    mappings: TemplateMapping[] = [
         {
             kind: [ReflectionKind.Class],
             directory: "classes",
@@ -185,7 +185,7 @@ export class DefaultTheme extends Theme {
      * @param reflection  The reflection whose mapping should be resolved.
      * @returns           The found mapping or undefined if no mapping could be found.
      */
-    private getMapping(reflection: DeclarationReflection): TemplateMapping | undefined {
+    getMapping(reflection: DeclarationReflection): TemplateMapping | undefined {
         return this.mappings.find((mapping) => reflection.kindOf(mapping.kind));
     }
 


### PR DESCRIPTION
Allows for the overriding of `mappings`, so that they can be overriden by child themes that extend `DefaultTheme`.

This will resolve current issues such as https://github.com/TypeStrong/typedoc/issues/2111 with the creation of a simple theme like in https://github.com/NikolaRHristov/TypeScriptESBuild/blob/main/Source/Class/Theme.ts