### PR TITLE
Prepend markdown anchor links with '#md:'

### DIFF
--- a/src/lib/output/themes/MarkedPlugin.ts
+++ b/src/lib/output/themes/MarkedPlugin.ts
@@ -195,6 +195,19 @@ output file :
         if (!markedOptions.renderer) {
             markedOptions.renderer = new Marked.Renderer();
 
+            markedOptions.renderer.link = (href, title, text) => {
+                // Prefix the #anchor links `#md:`.
+                href =
+                    href
+                        ?.replace(/^#(?:md:)?(.+)/, "#md:$1")
+                        .replace(/"/g, "&quot;") || "";
+                let html = `<a href="${href}"`;
+                if (title != null)
+                    html += ` title="${title.replace(/"/g, "&quot;")}"`;
+                html += `>${text}</a>`;
+                return html;
+            };
+
             markedOptions.renderer.heading = (text, level, _, slugger) => {
                 const slug = slugger.slug(text);
                 // Prefix the slug with an extra `md:` to prevent conflicts with TypeDoc's anchors.


### PR DESCRIPTION
Typedoc prepends `md:` to heading anchor ids generated by marked (added to fix https://github.com/TypeStrong/typedoc/issues/1135), but currently doesn't update any existing anchor links that points to them. This PR should address that.