### PR TITLE
Add internal-first sort strategy

### DIFF
--- a/src/lib/utils/sort.ts
+++ b/src/lib/utils/sort.ts
@@ -19,6 +19,7 @@ export const SORT_STRATEGIES = [
     "visibility",
     "required-first",
     "kind",
+    "internal-first",
 ] as const;
 
 export type SortStrategy = (typeof SORT_STRATEGIES)[number];
@@ -150,6 +151,9 @@ const sorts: Record<
     },
     kind(a, b, { kindSortOrder }) {
         return kindSortOrder.indexOf(a.kind) < kindSortOrder.indexOf(b.kind);
+    },
+    "internal-first"(a, b) {
+        return !a.flags.isExternal && b.flags.isExternal;
     },
 };
 

--- a/src/lib/utils/sort.ts
+++ b/src/lib/utils/sort.ts
@@ -19,7 +19,7 @@ export const SORT_STRATEGIES = [
     "visibility",
     "required-first",
     "kind",
-    "internal-first",
+    "external-last",
 ] as const;
 
 export type SortStrategy = (typeof SORT_STRATEGIES)[number];
@@ -152,7 +152,7 @@ const sorts: Record<
     kind(a, b, { kindSortOrder }) {
         return kindSortOrder.indexOf(a.kind) < kindSortOrder.indexOf(b.kind);
     },
-    "internal-first"(a, b) {
+    "external-last"(a, b) {
         return !a.flags.isExternal && b.flags.isExternal;
     },
 };

--- a/src/test/utils/sort.test.ts
+++ b/src/test/utils/sort.test.ts
@@ -209,7 +209,7 @@ describe("Sort", () => {
         );
     });
 
-    it("Should sort by internal first", () => {
+    it("Should sort by external last", () => {
         const arr = [
             new DeclarationReflection("a", ReflectionKind.Function),
             new DeclarationReflection("b", ReflectionKind.Function),
@@ -219,7 +219,7 @@ describe("Sort", () => {
         arr[1].setFlag(ReflectionFlag.External, false);
         arr[2].setFlag(ReflectionFlag.External, true);
 
-        sortReflections(arr, ["internal-first"]);
+        sortReflections(arr, ["external-last"]);
         equal(
             arr.map((r) => r.name),
             ["b", "a", "c"],

--- a/src/test/utils/sort.test.ts
+++ b/src/test/utils/sort.test.ts
@@ -209,6 +209,23 @@ describe("Sort", () => {
         );
     });
 
+    it("Should sort by internal first", () => {
+        const arr = [
+            new DeclarationReflection("a", ReflectionKind.Function),
+            new DeclarationReflection("b", ReflectionKind.Function),
+            new DeclarationReflection("c", ReflectionKind.Function),
+        ];
+        arr[0].setFlag(ReflectionFlag.External, true);
+        arr[1].setFlag(ReflectionFlag.External, false);
+        arr[2].setFlag(ReflectionFlag.External, true);
+
+        sortReflections(arr, ["internal-first"]);
+        equal(
+            arr.map((r) => r.name),
+            ["b", "a", "c"],
+        );
+    });
+
     it("Should sort with multiple strategies", () => {
         resetReflectionID();
         const arr = [


### PR DESCRIPTION
I have a use case for displaying internal properties before external/inherited properties. This PR adds `internal-first` as a sort strategy.

Companion documentation PR: https://github.com/TypeStrong/typedoc-site/pull/68