### PR TITLE
Fix declared flags option

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -227,7 +227,7 @@ export class Application extends ChildableComponent<
             } catch (error) {
                 ok(error instanceof Error);
                 if (reportErrors) {
-                    this.logger.error(error.message);
+                    this.logger.error(`Failed to set option ${key}: ${error.message}`);
                 }
             }
         }

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -227,7 +227,9 @@ export class Application extends ChildableComponent<
             } catch (error) {
                 ok(error instanceof Error);
                 if (reportErrors) {
-                    this.logger.error(`Failed to set option ${key}: ${error.message}`);
+                    this.logger.error(
+                        `Failed to set option ${key}: ${error.message}`,
+                    );
                 }
             }
         }

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -328,7 +328,7 @@ export class Options {
         );
 
         if (declaration.type === ParameterType.Flags) {
-            Object.assign(this._values[declaration.name] as any, converted);
+            Object.assign(this._values[declaration.name] || {}, converted);
         } else {
             this._values[declaration.name] = converted;
         }

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -128,7 +128,7 @@ export class TSConfigReader implements OptionsReader {
                 );
             } catch (error) {
                 ok(error instanceof Error);
-                logger.error(error.message);
+                logger.error(`Failed to set option ${key}: ${error.message}`);
             }
         }
     }

--- a/src/lib/utils/options/readers/typedoc.ts
+++ b/src/lib/utils/options/readers/typedoc.ts
@@ -150,7 +150,7 @@ export class TypeDocReader implements OptionsReader {
                 );
             } catch (error) {
                 ok(error instanceof Error);
-                logger.error(error.message);
+                logger.error(`Failed to set option ${key}: ${error.message}`);
             }
         }
     }

--- a/src/test/utils/options/readers/typedoc.test.ts
+++ b/src/test/utils/options/readers/typedoc.test.ts
@@ -119,7 +119,7 @@ describe("Options - TypeDocReader", () => {
         {
             someOptionThatDoesNotExist: true,
         },
-        "error: Tried to set an option (someOptionThatDoesNotExist) that was not declared. You may have meant:*",
+        "error: Failed to set option someOptionThatDoesNotExist: Tried to set an option (someOptionThatDoesNotExist) that was not declared. You may have meant:*",
     );
     testError(
         "Errors if extends results in a loop",


### PR DESCRIPTION
When setting an option with the type of `ParameterType.Flags`, if `this._values[declaration.name]` doesn't exist yet, TypeDoc will throw `[error] Cannot convert undefined or null to object`. This PR fixes it by assigning an empty object when it is undefined.


This PR also improves the logging by adding some extra information about the current key when `setValue` method throws an error.