### PR TITLE
fix: gitRevision fix in sourceLinkTemplate

### DIFF
--- a/src/lib/converter/utils/repository.ts
+++ b/src/lib/converter/utils/repository.ts
@@ -37,7 +37,7 @@ export class AssumedRepository implements Repository {
         };
 
         return this.sourceLinkTemplate.replace(
-            /\{(path|line)\}/g,
+            /\{(gitRevision|path|line)\}/g,
             (_, key) => replacements[key as never],
         );
     }


### PR DESCRIPTION
`gitRevision` is not being replaced with gitRevision value provided in config.
