### PR TITLE
Add module readmes to json output

### DIFF
--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -311,6 +311,7 @@ export class DeclarationReflection extends ContainerReflection {
                 this.implementedTypes,
             ),
             implementedBy: serializer.toObjectsOptional(this.implementedBy),
+            readme: Comment.serializeDisplayParts(serializer, this.readme),
         };
     }
 

--- a/src/lib/models/reflections/declaration.ts
+++ b/src/lib/models/reflections/declaration.ts
@@ -321,14 +321,15 @@ export class DeclarationReflection extends ContainerReflection {
     ): void {
         super.fromObject(de, obj);
 
+        if (obj.readme) {
+            this.readme = Comment.deserializeDisplayParts(de, obj.readme);
+        }
+
         // This happens when merging multiple projects together.
         // If updating this, also check ProjectReflection.fromObject.
         if (obj.variant === "project") {
             this.kind = ReflectionKind.Module;
             this.packageVersion = obj.packageVersion;
-            if (obj.readme) {
-                this.readme = Comment.deserializeDisplayParts(de, obj.readme);
-            }
 
             de.defer(() => {
                 for (const [id, sid] of Object.entries(obj.symbolIdMap || {})) {

--- a/src/lib/serialization/schema.ts
+++ b/src/lib/serialization/schema.ts
@@ -177,6 +177,7 @@ export interface DeclarationReflection
             | "getSignature"
             | "setSignature"
             | "typeParameters"
+            | "readme"
         > {}
 
 /** @category Reflections */


### PR DESCRIPTION
Resolves #2499

--

This change attempts to fix the above by mimicking the behavior of the ProjectReflection json serialization, which properly outputs the json readme property.

I skimmed through the test suites, but could not find a good place to integrate a test for this at a glance. Let me know which existing tests should be updated (if needed) and where new test logic should be implemented and I'll dig into it, assuming this change in behavior is acceptable.