### PR TITLE
Fix getReflectionsFromSymbolId to filter undefined reflections.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc",
   "description": "Create api documentation for TypeScript projects.",
-  "version": "0.25.9",
+  "version": "0.25.10",
   "homepage": "https://typedoc.org",
   "exports": {
     ".": "./dist/index.js",

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -284,7 +284,8 @@ export class ProjectReflection extends ContainerReflection {
         if (typeof id === "number") {
             return [this.getReflectionById(id)!];
         } else if (typeof id === "object") {
-            return id.map((id) => this.getReflectionById(id)!);
+            return id.map((id) => this.getReflectionById(id))
+              .filter(reflection => reflection !== undefined);
         }
 
         return [];


### PR DESCRIPTION
getReflectionsFromSymbolId can return [undefined] in certain situations, causing downstream null pointer exceptions.

Prevents the runtime error:
```
TypeError: Cannot read properties of undefined (reading 'kindOf')
    at ./node_modules/typedoc/dist/lib/models/types.js:688:25
    at Array.find (<anonymous>)
    at get reflection [as reflection] 
```