### PR TITLE
Fix getReflectionsFromSymbolId from returning undefined elements

### DIFF
--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -282,9 +282,13 @@ export class ProjectReflection extends ContainerReflection {
     getReflectionsFromSymbolId(symbolId: ReflectionSymbolId) {
         const id = this.symbolToReflectionIdMap.get(symbolId);
         if (typeof id === "number") {
-            return [this.getReflectionById(id)!];
+            const refl = this.getReflectionById(id);
+            if (refl === undefined) return [];
+            return [refl];
         } else if (typeof id === "object") {
-            return id.map((id) => this.getReflectionById(id)!);
+            return id
+                .map((id) => this.getReflectionById(id))
+                .filter((refl): refl is Reflection => refl !== undefined);
         }
 
         return [];


### PR DESCRIPTION
Returning [undefined] causes downstream TypeErrors.

Example:
```
TypeError: Cannot read properties of undefined (reading 'kindOf')
    at ./node_modules/typedoc/dist/lib/models/types.js:688:25
    at Array.find (<anonymous>)
    at get reflection [as reflection]
```