### PR TITLE
fix: update typescript dependency and peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,13 +32,13 @@
         "prettier": "3.0.3",
         "puppeteer": "^13.5.2",
         "ts-node": "^10.9.2",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x | 5.4.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3253,9 +3253,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "shiki": "^0.14.7"
   },
   "peerDependencies": {
-    "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x"
+    "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x | 5.4.x"
   },
   "devDependencies": {
     "@types/lunr": "^2.3.5",
@@ -47,7 +47,7 @@
     "prettier": "3.0.3",
     "puppeteer": "^13.5.2",
     "ts-node": "^10.9.2",
-    "typescript": "5.3.3"
+    "typescript": "5.4.2"
   },
   "files": [
     "/bin",


### PR DESCRIPTION
This updates typescript as well as the peer dependency definition of which typescript versions are allowed to use.