### PR TITLE
Change default font to be compatible with Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+### Bug Fixes
+
+-   Updated page font to work around issues with Mac rendering, #2518
+
+### Thanks!
+
+-   @docmattman
+
 ## v0.25.11 (2024-03-06)
 
 ### Bug Fixes

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap');
+
 :root {
     /* Light */
     --light-color-background: #f2f4f8;
@@ -405,7 +407,7 @@ dd {
 }
 body {
     background: var(--color-background);
-    font-family: "Segoe UI", sans-serif;
+    font-family: "Open Sans", sans-serif;
     font-size: 16px;
     color: var(--color-text);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -405,7 +405,8 @@ dd {
 }
 body {
     background: var(--color-background);
-    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+        Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
     font-size: 16px;
     color: var(--color-text);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap');
-
 :root {
     /* Light */
     --light-color-background: #f2f4f8;
@@ -407,7 +405,7 @@ dd {
 }
 body {
     background: var(--color-background);
-    font-family: "Open Sans", sans-serif;
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"
     font-size: 16px;
     color: var(--color-text);
 }


### PR DESCRIPTION
Segoe UI causes some text rendering issues on Mac.  Use Open Sans as a close replacement.

Closes: #2518 