### PR TITLE
An attempt to fix issue with navigation links on mobile

### DIFF
--- a/src/lib/output/themes/default/partials/navigation.tsx
+++ b/src/lib/output/themes/default/partials/navigation.tsx
@@ -36,7 +36,9 @@ export function sidebarLinks(context: DefaultThemeRenderContext) {
                 <a href={url}>{label}</a>
             ))}
             {navLinks.map(([label, url]) => (
-                <a href={url} class="tsd-nav-link">{label}</a>
+                <a href={url} class="tsd-nav-link">
+                    {label}
+                </a>
             ))}
         </nav>
     );

--- a/src/lib/output/themes/default/partials/navigation.tsx
+++ b/src/lib/output/themes/default/partials/navigation.tsx
@@ -27,11 +27,16 @@ function buildFilterItem(context: DefaultThemeRenderContext, name: string, displ
 
 export function sidebarLinks(context: DefaultThemeRenderContext) {
     const links = Object.entries(context.options.getValue("sidebarLinks"));
-    if (!links.length) return null;
+    const navLinks = Object.entries(context.options.getValue("navigationLinks"));
+
+    if (!links.length && !navLinks.length) return null;
     return (
         <nav id="tsd-sidebar-links" class="tsd-navigation">
             {links.map(([label, url]) => (
                 <a href={url}>{label}</a>
+            ))}
+            {navLinks.map(([label, url]) => (
+                <a href={url} class="tsd-nav-link">{label}</a>
             ))}
         </nav>
     );

--- a/static/style.css
+++ b/static/style.css
@@ -1343,11 +1343,11 @@ img {
     .has-menu .tsd-navigation {
         max-height: 100%;
     }
-    .tsd-toolbar-contents .tsd-toolbar-links {
+    #tsd-toolbar-links {
         display: none;
     }
     .tsd-navigation .tsd-nav-link {
-        display: unset;
+        display: flex;
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -762,6 +762,9 @@ input[type="checkbox"]:checked ~ svg .tsd-checkbox-checkmark {
     padding: 0;
     max-width: 100%;
 }
+.tsd-navigation .tsd-nav-link {
+    display: none;
+}
 .tsd-nested-navigation {
     margin-left: 3rem;
 }
@@ -1339,6 +1342,12 @@ img {
     }
     .has-menu .tsd-navigation {
         max-height: 100%;
+    }
+    .tsd-toolbar-contents .tsd-toolbar-links {
+        display: none;
+    }
+    .tsd-navigation .tsd-nav-link {
+        display: unset;
     }
 }
 


### PR DESCRIPTION
Fixes #2547

I'm opening this PR for initial review of the solution.
The idea was to move the navigation links to the same place as the sidebar links on mobile devices.
I have added the navigation links to the sidebar links.
I have removed the toolbar links on mobile using css.
I have changed the css so that navigation links are not displayed in the sidebar when not on mobile device.

I have tested by coping the resulting build to my project's node_modules.

Before:
![image](https://github.com/TypeStrong/typedoc/assets/3269297/c3f6307b-fb46-4b1b-a2fa-6cc4e3b10510)
![image](https://github.com/TypeStrong/typedoc/assets/3269297/3dfc2110-7f3b-452d-8f5c-275a61713aaf)

After:
![image](https://github.com/TypeStrong/typedoc/assets/3269297/78517c27-bd88-4454-911b-99557310d483)
![image](https://github.com/TypeStrong/typedoc/assets/3269297/ea2c1a83-89c5-4dfc-9241-f3c96bcbaeac)
![image](https://github.com/TypeStrong/typedoc/assets/3269297/bcdb75d2-9b49-47dd-907d-6ddcf22e368d)

