### PR TITLE
fix: Resolve the name of parameters referring to default exports

### DIFF
--- a/src/lib/converter/types.ts
+++ b/src/lib/converter/types.ts
@@ -743,9 +743,17 @@ const referenceConverter: TypeConverter<
             return ref;
         }
 
+        let name;
+        if (ts.isIdentifier(node.typeName)) {
+            name = node.typeName.text;
+        } else {
+            name = node.typeName.right.text;
+        }
+
         const ref = ReferenceType.createSymbolReference(
             context.resolveAliasedSymbol(symbol),
             context,
+            name,
         );
         if (type.flags & ts.TypeFlags.Substitution) {
             // NoInfer<T>

--- a/src/lib/models/types.ts
+++ b/src/lib/models/types.ts
@@ -907,11 +907,39 @@ export class ReferenceType extends Type {
         return new ReferenceType(name, target, project, name);
     }
 
+    /**
+     * In certain cases, TypeScript returns the name `default` for the name of a type that is defined with
+     * the format `export default class` or `export default function`. This method checks for that case and returns the
+     * declaration of the export instead of the name `default`.
+     */
+    private static getNameForDefaultExport(
+        symbol: ts.Symbol,
+    ): string | undefined {
+        if (
+            symbol.name !== "default" ||
+            symbol.valueDeclaration === undefined
+        ) {
+            return;
+        }
+
+        const name = ts.getNameOfDeclaration(symbol.valueDeclaration);
+
+        if (!name) {
+            return;
+        }
+
+        if (ts.isIdentifier(name)) {
+            return name.text;
+        }
+    }
+
     static createSymbolReference(
         symbol: ts.Symbol,
         context: Context,
         name?: string,
     ) {
+        name ??= this.getNameForDefaultExport(symbol);
+
         const ref = new ReferenceType(
             name ?? symbol.name,
             new ReflectionSymbolId(symbol),

--- a/src/lib/models/types.ts
+++ b/src/lib/models/types.ts
@@ -907,39 +907,11 @@ export class ReferenceType extends Type {
         return new ReferenceType(name, target, project, name);
     }
 
-    /**
-     * In certain cases, TypeScript returns the name `default` for the name of a type that is defined with
-     * the format `export default class` or `export default function`. This method checks for that case and returns the
-     * declaration of the export instead of the name `default`.
-     */
-    private static getNameForDefaultExport(
-        symbol: ts.Symbol,
-    ): string | undefined {
-        if (
-            symbol.name !== "default" ||
-            symbol.valueDeclaration === undefined
-        ) {
-            return;
-        }
-
-        const name = ts.getNameOfDeclaration(symbol.valueDeclaration);
-
-        if (!name) {
-            return;
-        }
-
-        if (ts.isIdentifier(name)) {
-            return name.text;
-        }
-    }
-
     static createSymbolReference(
         symbol: ts.Symbol,
         context: Context,
         name?: string,
     ) {
-        name ??= this.getNameForDefaultExport(symbol);
-
         const ref = new ReferenceType(
             name ?? symbol.name,
             new ReflectionSymbolId(symbol),

--- a/src/test/converter2/issues/gh2574/default.ts
+++ b/src/test/converter2/issues/gh2574/default.ts
@@ -1,0 +1,6 @@
+/**
+ * Default export and class implementation
+ */
+export default class DefaultExport {
+    constructor() {}
+}

--- a/src/test/converter2/issues/gh2574/index.ts
+++ b/src/test/converter2/issues/gh2574/index.ts
@@ -1,0 +1,3 @@
+import { Default } from "./reexported";
+
+export function usesDefaultExport(param: Default) {}

--- a/src/test/converter2/issues/gh2574/index.ts
+++ b/src/test/converter2/issues/gh2574/index.ts
@@ -1,3 +1,5 @@
-import { Default } from "./reexported";
+import { Default, NotDefault } from "./reexported";
 
 export function usesDefaultExport(param: Default) {}
+
+export function usesNonDefaultExport(param: NotDefault) {}

--- a/src/test/converter2/issues/gh2574/notDefault.ts
+++ b/src/test/converter2/issues/gh2574/notDefault.ts
@@ -1,0 +1,3 @@
+export class NotDefaultExport {
+    constructor() {}
+}

--- a/src/test/converter2/issues/gh2574/reexported.ts
+++ b/src/test/converter2/issues/gh2574/reexported.ts
@@ -1,0 +1,1 @@
+export { default as Default } from "./default";

--- a/src/test/converter2/issues/gh2574/reexported.ts
+++ b/src/test/converter2/issues/gh2574/reexported.ts
@@ -1,1 +1,2 @@
 export { default as Default } from "./default";
+export { NotDefaultExport as NotDefault } from "./notDefault";

--- a/src/test/issues.c2.test.ts
+++ b/src/test/issues.c2.test.ts
@@ -15,6 +15,7 @@ import {
     ProjectReflection,
     QueryType,
     ReferenceReflection,
+    ReferenceType,
     ReflectionKind,
     ReflectionType,
     SignatureReflection,
@@ -89,6 +90,21 @@ describe("Issue Tests", () => {
             Comment.combineDisplayParts(param.comment?.summary),
             "JSDoc style param name",
         );
+    });
+
+    it("#2574", () => {
+        const project = convert();
+        const usesDefaultExport = query(project, "usesDefaultExport");
+        const sig = usesDefaultExport.signatures?.[0];
+        ok(sig, "Missing signature for usesDefaultExport");
+        const param = sig.parameters?.[0];
+        ok(param, "Missing parameter");
+        equal(param.name, "param", "Incorrect parameter name");
+        const paramType = param.type as ReferenceType | undefined;
+        ok(paramType, "Parameter type is not a reference type or undefined");
+        equal(paramType.type, "reference", "Parameter is not a reference type");
+        equal(paramType.name, "DefaultExport", "Incorrect reference name");
+        equal(paramType.qualifiedName, "default", "Incorrect qualified name");
     });
 
     it("#671", () => {

--- a/src/test/issues.c2.test.ts
+++ b/src/test/issues.c2.test.ts
@@ -15,7 +15,6 @@ import {
     ProjectReflection,
     QueryType,
     ReferenceReflection,
-    ReferenceType,
     ReflectionKind,
     ReflectionType,
     SignatureReflection,
@@ -90,21 +89,6 @@ describe("Issue Tests", () => {
             Comment.combineDisplayParts(param.comment?.summary),
             "JSDoc style param name",
         );
-    });
-
-    it("#2574", () => {
-        const project = convert();
-        const usesDefaultExport = query(project, "usesDefaultExport");
-        const sig = usesDefaultExport.signatures?.[0];
-        ok(sig, "Missing signature for usesDefaultExport");
-        const param = sig.parameters?.[0];
-        ok(param, "Missing parameter");
-        equal(param.name, "param", "Incorrect parameter name");
-        const paramType = param.type as ReferenceType | undefined;
-        ok(paramType, "Parameter type is not a reference type or undefined");
-        equal(paramType.type, "reference", "Parameter is not a reference type");
-        equal(paramType.name, "DefaultExport", "Incorrect reference name");
-        equal(paramType.qualifiedName, "default", "Incorrect qualified name");
     });
 
     it("#671", () => {
@@ -1459,5 +1443,41 @@ describe("Issue Tests", () => {
         const project = convert();
         app.validate(project);
         logger.expectNoOtherMessages();
+    });
+
+    it("#2574 default export", () => {
+        const project = convert();
+        const sig = querySig(project, "usesDefaultExport");
+        const param = sig.parameters?.[0];
+        ok(param, "Missing parameter");
+        equal(param.name, "param", "Incorrect parameter name");
+        ok(param.type, "Parameter type is not a reference type or undefined");
+        equal(
+            param.type!.type,
+            "reference",
+            "Parameter is not a reference type",
+        );
+        equal(param.type!.name, "DefaultExport", "Incorrect reference name");
+        equal(param.type!.qualifiedName, "default", "Incorrect qualified name");
+    });
+
+    it("#2574 not default export", () => {
+        const project = convert();
+        const sig = querySig(project, "usesNonDefaultExport");
+        const param = sig.parameters?.[0];
+        ok(param, "Missing parameter");
+        equal(param.name, "param", "Incorrect parameter name");
+        ok(param.type, "Parameter type is not a reference type or undefined");
+        equal(
+            param.type!.type,
+            "reference",
+            "Parameter is not a reference type",
+        );
+        equal(param.type!.name, "NotDefaultExport", "Incorrect reference name");
+        equal(
+            param.type!.qualifiedName,
+            "NotDefaultExport",
+            "Incorrect qualified name",
+        );
     });
 });


### PR DESCRIPTION
Hello! My team recently discovered some strange behavior with TypeDoc resolving the type name of a class as `default` instead of the name of the class. I discovered that this happens when the following constraints are met:

1. A file that's not included in the documentation exports a default function/class.
3. Another file exports that default export as a non-default member.
4. A file that is included in documentation references that type in the parameter of a function, a property of a class, etc.

Note: This can only happen if the function/class is declared using `export default class` or `export default function`, since TypeScript will resolve the type back to any normal `export class` or `export function` with the correct name.

I noticed that TypeScript itself resolves the parameter's symbol type as the name `default` instead of the name of the type. I'm unsure if this is correct, so I applied conditional logic to help handle this particular case.

Here's a visual example from our generated docs:
![image](https://github.com/TypeStrong/typedoc/assets/91133241/fcb981ec-63ae-44bd-97bc-cce830796fff)
...where the correct type should be `DataTable`.

Please let me know if a better solution is more desirable 🙏 