### PR TITLE
fix sidebar highlighting when links share path but not hash

### DIFF
--- a/src/lib/output/themes/default/assets/typedoc/Navigation.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Navigation.ts
@@ -98,13 +98,13 @@ function addNavText(
         if (location.pathname + location.hash === a.pathname + a.hash) {
             a.classList.add("current");
         }
-        a.addEventListener("click", function(e) {
+        a.addEventListener("click", function (e) {
             if (window.location.hash !== this.hash) {
                 e.preventDefault();
                 window.location.href = this.href;
                 window.location.reload();
             }
-        })
+        });
         if (el.kind) {
             a.innerHTML = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" class="tsd-kind-icon"><use href="#icon-${el.kind}"></use></svg>`;
         }

--- a/src/lib/output/themes/default/assets/typedoc/Navigation.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Navigation.ts
@@ -98,7 +98,7 @@ function addNavText(
         if (location.pathname + location.hash === a.pathname + a.hash) {
             a.classList.add("current");
         }
-        a.addEventListener('click', function(e) {
+        a.addEventListener("click", function(e) {
             if (window.location.hash !== this.hash) {
                 e.preventDefault();
                 window.location.href = this.href;

--- a/src/lib/output/themes/default/assets/typedoc/Navigation.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Navigation.ts
@@ -95,9 +95,16 @@ function addNavText(
         if (classes) {
             a.className = classes;
         }
-        if (location.pathname === a.pathname) {
+        if (location.pathname + location.hash === a.pathname + a.hash) {
             a.classList.add("current");
         }
+        a.addEventListener('click', function(e) {
+            if (window.location.hash !== this.hash) {
+                e.preventDefault();
+                window.location.href = this.href;
+                window.location.reload();
+            }
+        })
         if (el.kind) {
             a.innerHTML = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" class="tsd-kind-icon"><use href="#icon-${el.kind}"></use></svg>`;
         }


### PR DESCRIPTION
Fixes an issue where many items in the sidebar are highlighted at the same time. (Shared pathname, different hashes)

Less than ideal because it uses a page refresh to rebuild the sidebar
Perhaps it could instead add `current` to the active link and also somehow find the old link to remove `current` from?
Feel free to modify as you see fit.