### PR TITLE
add ref noopener to link to typedoc.org

### DIFF
--- a/src/lib/output/themes/default/partials/footer.tsx
+++ b/src/lib/output/themes/default/partials/footer.tsx
@@ -17,7 +17,7 @@ export function footer(context: DefaultThemeRenderContext) {
             generatorDisplay = (
                 <p class="tsd-generator">
                     {pre}
-                    <a href="https://typedoc.org/" target="_blank">
+                    <a href="https://typedoc.org/" target="_blank" rel="noopener noreferrer">
                         TypeDoc
                     </a>
                     {post}


### PR DESCRIPTION
The link to typedoc.org in the footer of generated pages could be considered an unsafe 3rd party link vulnerable to tabnabbing and might be flagged in security audits. Adding `ref="noopener noreferrer"` will prevent that.