### PR TITLE
Add support for "none" category

### DIFF
--- a/src/lib/output/themes/default/DefaultTheme.tsx
+++ b/src/lib/output/themes/default/DefaultTheme.tsx
@@ -383,21 +383,11 @@ export class DefaultTheme extends Theme {
             }
 
             if (parent.categories && shouldShowCategories(parent, opts)) {
-                const noneCategory = parent.categories.find((x) => x.title === "none");
-                const otherCategories = parent.categories.filter((x) => x.title !== "none");
-
-                const mappedOthers = filterMap(otherCategories, toNavigation);
-
-                if (noneCategory) {
-                    const noneMappedChildren = filterMap(noneCategory.children, toNavigation);
-                    return [...noneMappedChildren, ...mappedOthers];
-                }
-
-                return mappedOthers;
+                return filterMapWithNoneCollection(parent.categories);
             }
 
             if (parent.groups && shouldShowGroups(parent, opts)) {
-                return filterMap(parent.groups, toNavigation);
+                return filterMapWithNoneCollection(parent.groups);
             }
 
             if (opts.includeFolders && parent.childrenIncludingDocuments?.some((child) => child.name.includes("/"))) {
@@ -405,6 +395,20 @@ export class DefaultTheme extends Theme {
             }
 
             return filterMap(parent.childrenIncludingDocuments, toNavigation);
+        }
+
+        function filterMapWithNoneCollection(reflection: ReflectionGroup[] | ReflectionCategory[]) {
+            const none = reflection.find((x) => x.title.toLocaleLowerCase() === "none");
+            const others = reflection.filter((x) => x.title.toLocaleLowerCase() !== "none");
+
+            const mappedOthers = filterMap(others, toNavigation);
+
+            if (none) {
+                const noneMappedChildren = filterMap(none.children, toNavigation);
+                return [...noneMappedChildren, ...mappedOthers];
+            }
+
+            return mappedOthers;
         }
 
         function deriveModuleFolders(children: Array<DeclarationReflection | DocumentReflection>) {

--- a/src/lib/output/themes/default/DefaultTheme.tsx
+++ b/src/lib/output/themes/default/DefaultTheme.tsx
@@ -383,7 +383,17 @@ export class DefaultTheme extends Theme {
             }
 
             if (parent.categories && shouldShowCategories(parent, opts)) {
-                return filterMap(parent.categories, toNavigation);
+                const noneCategory = parent.categories.find((x) => x.title === "none");
+                const otherCategories = parent.categories.filter((x) => x.title !== "none");
+
+                const mappedOthers = filterMap(otherCategories, toNavigation);
+
+                if (noneCategory) {
+                    const noneMappedChildren = filterMap(noneCategory.children, toNavigation);
+                    return [...noneMappedChildren, ...mappedOthers];
+                }
+
+                return mappedOthers;
             }
 
             if (parent.groups && shouldShowGroups(parent, opts)) {


### PR DESCRIPTION
Resolves #2656

```md
---
title: Syntax Highlighting
category: none
---
```
With `navigation.includeCategories` being set to true, this will place the markdown file at the top level of navigation:

![image](https://github.com/user-attachments/assets/369d59c2-8d57-4f7c-8103-6a03ad153732)
