### PR TITLE
TypeDoc displays a superfluous type on number constants implementation

### DIFF
--- a/src/lib/converter/symbols.ts
+++ b/src/lib/converter/symbols.ts
@@ -968,24 +968,6 @@ function convertVariable(
     setModifiers(symbol, declaration, reflection);
 
     reflection.defaultValue = convertDefaultValue(declaration);
-
-    /** Fix for #2717. If type is the same as value the type is omited */
-    if(reflection.type.type === "literal") {
-        let reflectionTypeString: string = (reflection.type as LiteralType).value?.toString()!;
-        let defaultValue = reflection.defaultValue!;
-
-        /** If the default value is string and it's wrapped in ' in the code, the value is wrapped in " and vice-versa */
-        if( (defaultValue[0] === '"' && defaultValue[defaultValue.length - 1] === '"') ||
-            (defaultValue[0] === "'" && defaultValue[defaultValue.length - 1] === "'")
-          ) {
-            defaultValue = defaultValue.slice(1, -1);
-          }
-          
-        if( reflectionTypeString === defaultValue.toString() ) {
-            reflection.type = new LiteralType("")
-        }
-    }
-
     context.finalizeDeclarationReflection(reflection);
 
     return ts.SymbolFlags.Property;

--- a/src/lib/converter/symbols.ts
+++ b/src/lib/converter/symbols.ts
@@ -969,6 +969,23 @@ function convertVariable(
 
     reflection.defaultValue = convertDefaultValue(declaration);
 
+    /** Fix for #2717. If type is the same as value the type is omited */
+    if(reflection.type.type === "literal") {
+        let reflectionTypeString: string = (reflection.type as LiteralType).value?.toString()!;
+        let defaultValue = reflection.defaultValue!;
+
+        /** If the default value is string and it's wrapped in ' in the code, the value is wrapped in " and vice-versa */
+        if( (defaultValue[0] === '"' && defaultValue[defaultValue.length - 1] === '"') ||
+            (defaultValue[0] === "'" && defaultValue[defaultValue.length - 1] === "'")
+          ) {
+            defaultValue = defaultValue.slice(1, -1);
+          }
+          
+        if( reflectionTypeString === defaultValue.toString() ) {
+            reflection.type = new LiteralType("")
+        }
+    }
+
     context.finalizeDeclarationReflection(reflection);
 
     return ts.SymbolFlags.Property;

--- a/src/lib/output/themes/default/partials/member.declaration.tsx
+++ b/src/lib/output/themes/default/partials/member.declaration.tsx
@@ -28,31 +28,33 @@ export function memberDeclaration(context: DefaultThemeRenderContext, props: Dec
     }
 
     const visitor = { reflection: renderTypeDeclaration };
-    
-     /** Fix for #2717. If type is the same as value the type is omited */
-    function shouldRenderType(){
-        if(props.type && props.type.type === "literal"){
+
+    /** Fix for #2717. If type is the same as value the type is omited */
+    function shouldRenderType() {
+        if (props.type && props.type.type === "literal") {
             const typeObject = props.type.toObject();
             const value = typeObject.value;
-            if(!value) { // should be unreachable
+            if (!value) {
+                // should be unreachable
                 return true;
             }
-            if(typeof value === "object") {
+            if (typeof value === "object") {
                 return true;
             }
             const reflectionTypeString: string = value.toString();
             let defaultValue = props.defaultValue!;
-            if(defaultValue){
+            if (defaultValue) {
                 // If the default value is string and it's wrapped in ' in the code, the value is wrapped in " and vice-versa
-                if( (defaultValue[0] === '"' && defaultValue[defaultValue.length - 1] === '"') ||
+                if (
+                    (defaultValue[0] === '"' && defaultValue[defaultValue.length - 1] === '"') ||
                     (defaultValue[0] === "'" && defaultValue[defaultValue.length - 1] === "'")
                 ) {
                     defaultValue = defaultValue.slice(1, -1);
                 }
             }
-            
-            if( reflectionTypeString === defaultValue.toString() ) {
-                return false;    
+
+            if (reflectionTypeString === defaultValue.toString()) {
+                return false;
             }
             return true;
         }

--- a/src/lib/output/themes/default/partials/member.declaration.tsx
+++ b/src/lib/output/themes/default/partials/member.declaration.tsx
@@ -29,34 +29,16 @@ export function memberDeclaration(context: DefaultThemeRenderContext, props: Dec
 
     const visitor = { reflection: renderTypeDeclaration };
 
-    /** Fix for #2717. If type is the same as value the type is omited */
+    /** Fix for #2717. If type is the same as value the type is omitted */
     function shouldRenderType() {
         if (props.type && props.type.type === "literal") {
-            const typeObject = props.type.toObject();
-            const value = typeObject.value;
-            if (!value) {
-                // should be unreachable
-                return true;
-            }
-            if (typeof value === "object") {
-                return true;
-            }
-            const reflectionTypeString: string = value.toString();
-            let defaultValue = props.defaultValue!;
-            if (defaultValue) {
-                // If the default value is string and it's wrapped in ' in the code, the value is wrapped in " and vice-versa
-                if (
-                    (defaultValue[0] === '"' && defaultValue[defaultValue.length - 1] === '"') ||
-                    (defaultValue[0] === "'" && defaultValue[defaultValue.length - 1] === "'")
-                ) {
-                    defaultValue = defaultValue.slice(1, -1);
-                }
-            }
+            const reflectionTypeString = props.type.toString();
 
-            if (reflectionTypeString === defaultValue.toString()) {
+            const defaultValue = props.defaultValue;
+
+            if (defaultValue === undefined || reflectionTypeString === defaultValue.toString()) {
                 return false;
             }
-            return true;
         }
         return true;
     }

--- a/src/lib/output/themes/default/partials/member.declaration.tsx
+++ b/src/lib/output/themes/default/partials/member.declaration.tsx
@@ -28,13 +28,36 @@ export function memberDeclaration(context: DefaultThemeRenderContext, props: Dec
     }
 
     const visitor = { reflection: renderTypeDeclaration };
+    
+     /** Fix for #2717. If type is the same as value the type is omited */
+    function shouldRenderType(){
+        if(props.type && props.type.type === "literal"){
+            let typeObject = props.type.toObject();
+            let reflectionTypeString: string = typeObject.value?.toString()!;
+            let defaultValue = props.defaultValue!;
+            if(defaultValue){
+                // If the default value is string and it's wrapped in ' in the code, the value is wrapped in " and vice-versa
+                if( (defaultValue[0] === '"' && defaultValue[defaultValue.length - 1] === '"') ||
+                    (defaultValue[0] === "'" && defaultValue[defaultValue.length - 1] === "'")
+                ) {
+                    defaultValue = defaultValue.slice(1, -1);
+                }
+            }
+            
+            if( reflectionTypeString === defaultValue.toString() ) {
+                return false;    
+            }
+            return true;
+        }
+        return true;
+    }
 
     return (
         <>
             <div class="tsd-signature">
                 <span class={getKindClass(props)}>{wbr(props.name)}</span>
                 {renderTypeParametersSignature(context, props.typeParameters)}
-                {props.type && (
+                {shouldRenderType() && (
                     <>
                         <span class="tsd-signature-symbol">{!!props.flags.isOptional && "?"}:</span>{" "}
                         {context.type(props.type)}

--- a/src/lib/output/themes/default/partials/member.declaration.tsx
+++ b/src/lib/output/themes/default/partials/member.declaration.tsx
@@ -32,8 +32,15 @@ export function memberDeclaration(context: DefaultThemeRenderContext, props: Dec
      /** Fix for #2717. If type is the same as value the type is omited */
     function shouldRenderType(){
         if(props.type && props.type.type === "literal"){
-            let typeObject = props.type.toObject();
-            let reflectionTypeString: string = typeObject.value?.toString()!;
+            const typeObject = props.type.toObject();
+            const value = typeObject.value;
+            if(!value) { // should be unreachable
+                return true;
+            }
+            if(typeof value === "object") {
+                return true;
+            }
+            const reflectionTypeString: string = value.toString();
             let defaultValue = props.defaultValue!;
             if(defaultValue){
                 // If the default value is string and it's wrapped in ' in the code, the value is wrapped in " and vice-versa


### PR DESCRIPTION
This PR is implementing the enhancement mentioned in #2717. 
When the type is exactly the same thing as the value, the type is not printed to docs.

