### PR TITLE
Add divs around individual tags

### DIFF
--- a/src/lib/output/themes/default/partials/comment.tsx
+++ b/src/lib/output/themes/default/partials/comment.tsx
@@ -39,12 +39,14 @@ export function commentTags(context: DefaultThemeRenderContext, props: Reflectio
 
                     return (
                         <>
-                            <h4 class="tsd-anchor-link">
-                                <a id={anchor} class="tsd-anchor"></a>
-                                {name}
-                                {anchorIcon(context, anchor)}
-                            </h4>
-                            <Raw html={context.markdown(item.content)} />
+                            <div class={`tsd-tag-${name}`}>
+                                <h4 class="tsd-anchor-link">
+                                    <a id={anchor} class="tsd-anchor"></a>
+                                    {name}
+                                    {anchorIcon(context, anchor)}
+                                </h4>
+                                <Raw html={context.markdown(item.content)} />
+                            </div>
                         </>
                     );
                 })}


### PR DESCRIPTION
Resolves: https://github.com/TypeStrong/typedoc/issues/2723

## Description
Wraps tags in `comment.tsx` in a div and includes a css class of the specific tag being displayed. Doing this allows for more targeted styling of individual tags.

When generating documentation, output of tags on a page goes from:

```html
<div class="tsd-comment tsd-typography">
  <h4 class="tsd-anchor-link">
    <a id="Todo" class="tsd-anchor"></a>
    Todo
    <a href="#Todo" aria-label="Permalink" class="tsd-anchor-icon">
      <svg viewBox="0 0 24 24">
        <use href="../assets/icons.svg#icon-anchor"></use>
      </svg>
    </a>
  </h4>
  <p>Some task to accomplish in the future</p>
</div>
```

to:

```html
<div class="tsd-comment tsd-typography">
  <div class="tsd-tag-Todo">
    <h4 class="tsd-anchor-link">
      <a id="Todo" class="tsd-anchor"></a>
      Todo
      <a href="#Todo" aria-label="Permalink" class="tsd-anchor-icon">
        <svg viewBox="0 0 24 24">
          <use href="../assets/icons.svg#icon-anchor"></use>
        </svg>
      </a>
    </h4>
    <p>Some task to accomplish in the future</p>
  </div>
</div>
```

Note: both of the above code snippets are formatted for ease of reading.