### PR TITLE
2726 svg text icons

### DIFF
--- a/src/lib/output/plugins/IconsPlugin.tsx
+++ b/src/lib/output/plugins/IconsPlugin.tsx
@@ -11,7 +11,7 @@ const ICONS_JS = `
     function addIcons() {
         if (document.readyState === "loading") return document.addEventListener("DOMContentLoaded", addIcons);
         const svg = document.body.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
-        svg.innerHTML = \`"SVG_HTML"\`;
+        svg.innerHTML = \`SVG_HTML\`;
         svg.style.display = "none";
         if (location.protocol === "file:") updateUseElements();
     }
@@ -49,7 +49,11 @@ export class IconsPlugin extends RendererComponent {
         const icons = (this.owner.theme as DefaultTheme).icons;
 
         for (const [name, icon] of Object.entries(icons)) {
-            children.push(<g id={`icon-${name}`}>{icon.call(icons).children}</g>);
+            children.push(
+                <g id={`icon-${name}`} class="tsd-no-select">
+                    {icon.call(icons).children}
+                </g>,
+            );
         }
 
         const svg = renderElement(<svg xmlns="http://www.w3.org/2000/svg">{children}</svg>);

--- a/src/lib/output/themes/default/partials/icon.tsx
+++ b/src/lib/output/themes/default/partials/icon.tsx
@@ -238,7 +238,7 @@ export const icons: Record<
             >
                 R
             </text>,
-            "#FF4D82", // extract into a CSS variable potentially?
+            "var(--color-ts-reference)",
             true,
         ),
     [ReflectionKind.SetSignature]() {

--- a/src/lib/output/themes/default/partials/icon.tsx
+++ b/src/lib/output/themes/default/partials/icon.tsx
@@ -19,6 +19,15 @@ const kindIcon = (letterPath: JSX.Element, color: string, circular = false) => (
     </svg>
 );
 
+const textIcon = (letter: string, color: string, circular = false) =>
+    kindIcon(
+        <text fill="var(--color-icon-text)" x="50%" y="50%" dominant-baseline="central" text-anchor="middle">
+            {letter}
+        </text>,
+        color,
+        circular,
+    );
+
 export function buildRefIcons<T extends Record<string, () => JSX.Element>>(
     icons: T,
     context: DefaultThemeRenderContext,
@@ -50,239 +59,52 @@ export const icons: Record<
     ReflectionKind | "chevronDown" | "checkbox" | "menu" | "search" | "chevronSmall" | "anchor" | "folder",
     () => JSX.Element
 > = {
-    [ReflectionKind.Accessor]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="6.5"
-                y="17.5"
-            >
-                A
-            </text>,
-            "var(--color-ts-accessor)",
-            true,
-        ),
+    [ReflectionKind.Accessor]: () => textIcon("A", "var(--color-ts-accessor)", true),
     [ReflectionKind.CallSignature]() {
         return this[ReflectionKind.Function]();
     },
-    [ReflectionKind.Class]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="6.5"
-                y="18"
-            >
-                C
-            </text>,
-            "var(--color-ts-class)",
-        ),
-    [ReflectionKind.Constructor]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="6"
-                y="17.5"
-            >
-                C
-            </text>,
-            "var(--color-ts-constructor)",
-            true,
-        ),
+    [ReflectionKind.Class]: () => textIcon("C", "var(--color-ts-class)"),
+    [ReflectionKind.Constructor]: () => textIcon("C", "var(--color-ts-constructor)", true),
     [ReflectionKind.ConstructorSignature]() {
         return this[ReflectionKind.Constructor]();
     },
-    [ReflectionKind.Enum]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="7"
-                y="17.5"
-            >
-                E
-            </text>,
-            "var(--color-ts-enum)",
-        ),
+    [ReflectionKind.Enum]: () => textIcon("E", "var(--color-ts-enum)"),
     [ReflectionKind.EnumMember]() {
         return this[ReflectionKind.Property]();
     },
-    [ReflectionKind.Function]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="7"
-                y="18"
-            >
-                F
-            </text>,
-            "var(--color-ts-function)",
-        ),
+    [ReflectionKind.Function]: () => textIcon("F", "var(--color-ts-function)"),
     [ReflectionKind.GetSignature]() {
         return this[ReflectionKind.Accessor]();
     },
     [ReflectionKind.IndexSignature]() {
         return this[ReflectionKind.Property]();
     },
-    [ReflectionKind.Interface]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="10"
-                y="18"
-            >
-                I
-            </text>,
-            "var(--color-ts-interface)",
-        ),
-    [ReflectionKind.Method]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="5"
-                y="17.5"
-            >
-                M
-            </text>,
-            "var(--color-ts-method)",
-            true,
-        ),
-    [ReflectionKind.Module]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="5"
-                y="17.5"
-            >
-                M
-            </text>,
-            "var(--color-ts-module)",
-        ),
-    [ReflectionKind.Namespace]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="6"
-                y="18"
-            >
-                N
-            </text>,
-            "var(--color-ts-namespace)",
-        ),
+    [ReflectionKind.Interface]: () => textIcon("I", "var(--color-ts-interface)"),
+    [ReflectionKind.Method]: () => textIcon("M", "var(--color-ts-method)", true),
+    [ReflectionKind.Module]: () => textIcon("M", "var(--color-ts-module)"),
+    [ReflectionKind.Namespace]: () => textIcon("N", "var(--color-ts-namespace)"),
     [ReflectionKind.Parameter]() {
         return this[ReflectionKind.Property]();
     },
     [ReflectionKind.Project]() {
         return this[ReflectionKind.Module]();
     },
-    [ReflectionKind.Property]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="7.5"
-                y="18"
-            >
-                P
-            </text>,
-            "var(--color-ts-property)",
-            true,
-        ),
-    [ReflectionKind.Reference]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="7"
-                y="17.5"
-            >
-                R
-            </text>,
-            "var(--color-ts-reference)",
-            true,
-        ),
+    [ReflectionKind.Property]: () => textIcon("P", "var(--color-ts-property)", true),
+    [ReflectionKind.Reference]: () => textIcon("R", "var(--color-ts-reference)", true),
     [ReflectionKind.SetSignature]() {
         return this[ReflectionKind.Accessor]();
     },
-    [ReflectionKind.TypeAlias]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="7"
-                y="17.5"
-            >
-                T
-            </text>,
-            "var(--color-ts-type-alias)",
-        ),
+    [ReflectionKind.TypeAlias]: () => textIcon("T", "var(--color-ts-type-alias)"),
     [ReflectionKind.TypeLiteral]() {
         return this[ReflectionKind.TypeAlias]();
     },
     [ReflectionKind.TypeParameter]() {
         return this[ReflectionKind.TypeAlias]();
     },
-    [ReflectionKind.Variable]: () =>
-        kindIcon(
-            <text
-                fill="var(--color-icon-text)"
-                font-family="var(--icon-font-family)"
-                font-size="var(--icon-font-size)"
-                font-weight="var(--icon-font-weight)"
-                font-style="var(--icon-font-style)"
-                x="7"
-                y="18"
-            >
-                V
-            </text>,
-            "var(--color-ts-variable)",
-        ),
+    [ReflectionKind.Variable]: () => textIcon("V", "var(--color-ts-variable)"),
     [ReflectionKind.Document]: () =>
         kindIcon(
-            <g stroke="var(--color-text)" fill="none" stroke-width="1.5">
+            <g stroke="var(--color-icon-text)" fill="none" stroke-width="1.5">
                 <polygon points="6,5 6,19 18,19, 18,10 13,5" />
                 <line x1="9" y1="9" x2="13" y2="9" />
                 <line x1="9" y1="12" x2="15" y2="12" />
@@ -292,7 +114,7 @@ export const icons: Record<
         ),
     folder: () =>
         kindIcon(
-            <g stroke="var(--color-text)" fill="none" stroke-width="1.5">
+            <g stroke="var(--color-icon-text)" fill="none" stroke-width="1.5">
                 <polygon points="5,5 10,5 12,8 19,8 19,18 5,18" />
             </g>,
             "var(--color-document)",

--- a/src/lib/output/themes/default/partials/icon.tsx
+++ b/src/lib/output/themes/default/partials/icon.tsx
@@ -52,11 +52,18 @@ export const icons: Record<
 > = {
     [ReflectionKind.Accessor]: () =>
         kindIcon(
-            <path
-                d="M8.85 16L11.13 7.24H12.582L14.85 16H13.758L13.182 13.672H10.53L9.954 16H8.85ZM10.746 12.76H12.954L12.282 10.06C12.154 9.548 12.054 9.12 11.982 8.776C11.91 8.432 11.866 8.208 11.85 8.104C11.834 8.208 11.79 8.432 11.718 8.776C11.646 9.12 11.546 9.544 11.418 10.048L10.746 12.76Z"
-                fill="var(--color-text)"
-            />,
-            "#FF4D4D",
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="6.5"
+                y="17.5"
+            >
+                A
+            </text>,
+            "var(--color-ts-accessor)",
             true,
         ),
     [ReflectionKind.CallSignature]() {
@@ -64,19 +71,33 @@ export const icons: Record<
     },
     [ReflectionKind.Class]: () =>
         kindIcon(
-            <path
-                d="M11.898 16.1201C11.098 16.1201 10.466 15.8961 10.002 15.4481C9.53803 15.0001 9.30603 14.3841 9.30603 13.6001V9.64012C9.30603 8.85612 9.53803 8.24012 10.002 7.79212C10.466 7.34412 11.098 7.12012 11.898 7.12012C12.682 7.12012 13.306 7.34812 13.77 7.80412C14.234 8.25212 14.466 8.86412 14.466 9.64012H13.386C13.386 9.14412 13.254 8.76412 12.99 8.50012C12.734 8.22812 12.37 8.09212 11.898 8.09212C11.426 8.09212 11.054 8.22412 10.782 8.48812C10.518 8.75212 10.386 9.13212 10.386 9.62812V13.6001C10.386 14.0961 10.518 14.4801 10.782 14.7521C11.054 15.0161 11.426 15.1481 11.898 15.1481C12.37 15.1481 12.734 15.0161 12.99 14.7521C13.254 14.4801 13.386 14.0961 13.386 13.6001H14.466C14.466 14.3761 14.234 14.9921 13.77 15.4481C13.306 15.8961 12.682 16.1201 11.898 16.1201Z"
-                fill="var(--color-text)"
-            />,
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="6.5"
+                y="18"
+            >
+                C
+            </text>,
             "var(--color-ts-class)",
         ),
     [ReflectionKind.Constructor]: () =>
         kindIcon(
-            <path
-                d="M11.898 16.1201C11.098 16.1201 10.466 15.8961 10.002 15.4481C9.53803 15.0001 9.30603 14.3841 9.30603 13.6001V9.64012C9.30603 8.85612 9.53803 8.24012 10.002 7.79212C10.466 7.34412 11.098 7.12012 11.898 7.12012C12.682 7.12012 13.306 7.34812 13.77 7.80412C14.234 8.25212 14.466 8.86412 14.466 9.64012H13.386C13.386 9.14412 13.254 8.76412 12.99 8.50012C12.734 8.22812 12.37 8.09212 11.898 8.09212C11.426 8.09212 11.054 8.22412 10.782 8.48812C10.518 8.75212 10.386 9.13212 10.386 9.62812V13.6001C10.386 14.0961 10.518 14.4801 10.782 14.7521C11.054 15.0161 11.426 15.1481 11.898 15.1481C12.37 15.1481 12.734 15.0161 12.99 14.7521C13.254 14.4801 13.386 14.0961 13.386 13.6001H14.466C14.466 14.3761 14.234 14.9921 13.77 15.4481C13.306 15.8961 12.682 16.1201 11.898 16.1201Z"
-                fill="var(--color-text)"
-            />,
-            "#4D7FFF",
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="6"
+                y="17.5"
+            >
+                C
+            </text>,
+            "var(--color-ts-constructor)",
             true,
         ),
     [ReflectionKind.ConstructorSignature]() {
@@ -84,10 +105,17 @@ export const icons: Record<
     },
     [ReflectionKind.Enum]: () =>
         kindIcon(
-            <path
-                d="M9.45 16V7.24H14.49V8.224H10.518V10.936H14.07V11.908H10.518V15.016H14.49V16H9.45Z"
-                fill="var(--color-text)"
-            />,
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="7"
+                y="17.5"
+            >
+                E
+            </text>,
             "var(--color-ts-enum)",
         ),
     [ReflectionKind.EnumMember]() {
@@ -95,7 +123,17 @@ export const icons: Record<
     },
     [ReflectionKind.Function]: () =>
         kindIcon(
-            <path d="M9.39 16V7.24H14.55V8.224H10.446V11.128H14.238V12.112H10.47V16H9.39Z" fill="var(--color-text)" />,
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="7"
+                y="18"
+            >
+                F
+            </text>,
             "var(--color-ts-function)",
         ),
     [ReflectionKind.GetSignature]() {
@@ -106,36 +144,63 @@ export const icons: Record<
     },
     [ReflectionKind.Interface]: () =>
         kindIcon(
-            <path
-                d="M9.51 16V15.016H11.298V8.224H9.51V7.24H14.19V8.224H12.402V15.016H14.19V16H9.51Z"
-                fill="var(--color-text)"
-            />,
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="10"
+                y="18"
+            >
+                I
+            </text>,
             "var(--color-ts-interface)",
         ),
     [ReflectionKind.Method]: () =>
         kindIcon(
-            <path
-                d="M9.162 16V7.24H10.578L11.514 10.072C11.602 10.328 11.674 10.584 11.73 10.84C11.794 11.088 11.842 11.28 11.874 11.416C11.906 11.28 11.954 11.088 12.018 10.84C12.082 10.584 12.154 10.324 12.234 10.06L13.122 7.24H14.538V16H13.482V12.82C13.482 12.468 13.49 12.068 13.506 11.62C13.53 11.172 13.558 10.716 13.59 10.252C13.622 9.78 13.654 9.332 13.686 8.908C13.726 8.476 13.762 8.1 13.794 7.78L12.366 12.16H11.334L9.894 7.78C9.934 8.092 9.97 8.456 10.002 8.872C10.042 9.28 10.078 9.716 10.11 10.18C10.142 10.636 10.166 11.092 10.182 11.548C10.206 12.004 10.218 12.428 10.218 12.82V16H9.162Z"
-                fill="var(--color-text)"
-            />,
-            "#FF4DB8",
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="5"
+                y="17.5"
+            >
+                M
+            </text>,
+            "var(--color-ts-method)",
             true,
         ),
-    [ReflectionKind.Module]() {
-        return kindIcon(
-            <path
-                d="M9.162 16V7.24H10.578L11.514 10.072C11.602 10.328 11.674 10.584 11.73 10.84C11.794 11.088 11.842 11.28 11.874 11.416C11.906 11.28 11.954 11.088 12.018 10.84C12.082 10.584 12.154 10.324 12.234 10.06L13.122 7.24H14.538V16H13.482V12.82C13.482 12.468 13.49 12.068 13.506 11.62C13.53 11.172 13.558 10.716 13.59 10.252C13.622 9.78 13.654 9.332 13.686 8.908C13.726 8.476 13.762 8.1 13.794 7.78L12.366 12.16H11.334L9.894 7.78C9.934 8.092 9.97 8.456 10.002 8.872C10.042 9.28 10.078 9.716 10.11 10.18C10.142 10.636 10.166 11.092 10.182 11.548C10.206 12.004 10.218 12.428 10.218 12.82V16H9.162Z"
-                fill="var(--color-text)"
-            />,
+    [ReflectionKind.Module]: () =>
+        kindIcon(
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="5"
+                y="17.5"
+            >
+                M
+            </text>,
             "var(--color-ts-module)",
-        );
-    },
+        ),
     [ReflectionKind.Namespace]: () =>
         kindIcon(
-            <path
-                d="M9.33 16V7.24H10.77L13.446 14.74C13.43 14.54 13.41 14.296 13.386 14.008C13.37 13.712 13.354 13.404 13.338 13.084C13.33 12.756 13.326 12.448 13.326 12.16V7.24H14.37V16H12.93L10.266 8.5C10.282 8.692 10.298 8.936 10.314 9.232C10.33 9.52 10.342 9.828 10.35 10.156C10.366 10.476 10.374 10.784 10.374 11.08V16H9.33Z"
-                fill="var(--color-text)"
-            />,
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="6"
+                y="18"
+            >
+                N
+            </text>,
             "var(--color-ts-namespace)",
         ),
     [ReflectionKind.Parameter]() {
@@ -146,19 +211,33 @@ export const icons: Record<
     },
     [ReflectionKind.Property]: () =>
         kindIcon(
-            <path
-                d="M9.354 16V7.24H12.174C12.99 7.24 13.638 7.476 14.118 7.948C14.606 8.412 14.85 9.036 14.85 9.82C14.85 10.604 14.606 11.232 14.118 11.704C13.638 12.168 12.99 12.4 12.174 12.4H10.434V16H9.354ZM10.434 11.428H12.174C12.646 11.428 13.022 11.284 13.302 10.996C13.59 10.7 13.734 10.308 13.734 9.82C13.734 9.324 13.59 8.932 13.302 8.644C13.022 8.356 12.646 8.212 12.174 8.212H10.434V11.428Z"
-                fill="var(--color-text)"
-            />,
-            "#FF984D",
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="7.5"
+                y="18"
+            >
+                P
+            </text>,
+            "var(--color-ts-property)",
             true,
         ),
     [ReflectionKind.Reference]: () =>
         kindIcon(
-            <path
-                d="M10.354 17V8.24H13.066C13.586 8.24 14.042 8.348 14.434 8.564C14.826 8.772 15.13 9.064 15.346 9.44C15.562 9.816 15.67 10.256 15.67 10.76C15.67 11.352 15.514 11.86 15.202 12.284C14.898 12.708 14.482 13 13.954 13.16L15.79 17H14.518L12.838 13.28H11.434V17H10.354ZM11.434 12.308H13.066C13.514 12.308 13.874 12.168 14.146 11.888C14.418 11.6 14.554 11.224 14.554 10.76C14.554 10.288 14.418 9.912 14.146 9.632C13.874 9.352 13.514 9.212 13.066 9.212H11.434V12.308Z"
-                fill="var(--color-text)"
-            />,
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="7"
+                y="17.5"
+            >
+                R
+            </text>,
             "#FF4D82", // extract into a CSS variable potentially?
             true,
         ),
@@ -167,7 +246,17 @@ export const icons: Record<
     },
     [ReflectionKind.TypeAlias]: () =>
         kindIcon(
-            <path d="M11.31 16V8.224H8.91V7.24H14.79V8.224H12.39V16H11.31Z" fill="var(--color-text)" />,
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="7"
+                y="17.5"
+            >
+                T
+            </text>,
             "var(--color-ts-type-alias)",
         ),
     [ReflectionKind.TypeLiteral]() {
@@ -178,15 +267,22 @@ export const icons: Record<
     },
     [ReflectionKind.Variable]: () =>
         kindIcon(
-            <path
-                d="M11.106 16L8.85 7.24H9.966L11.454 13.192C11.558 13.608 11.646 13.996 11.718 14.356C11.79 14.708 11.842 14.976 11.874 15.16C11.906 14.976 11.954 14.708 12.018 14.356C12.09 13.996 12.178 13.608 12.282 13.192L13.758 7.24H14.85L12.582 16H11.106Z"
-                fill="var(--color-text)"
-            />,
+            <text
+                fill="var(--color-icon-text)"
+                font-family="var(--icon-font-family)"
+                font-size="var(--icon-font-size)"
+                font-weight="var(--icon-font-weight)"
+                font-style="var(--icon-font-style)"
+                x="7"
+                y="18"
+            >
+                V
+            </text>,
             "var(--color-ts-variable)",
         ),
     [ReflectionKind.Document]: () =>
         kindIcon(
-            <g stroke="var(--color-text)" fill="var(--color-icon-background)">
+            <g stroke="var(--color-icon-text)" fill="var(--color-icon-background)">
                 <polygon points="6,5 6,19 18,19, 18,9 15,5" />
                 <line x1="9" y1="9" x2="14" y2="9" />
                 <line x1="9" y1="12" x2="15" y2="12" />
@@ -198,7 +294,7 @@ export const icons: Record<
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
             <path
                 d="M4.93896 8.531L12 15.591L19.061 8.531L16.939 6.409L12 11.349L7.06098 6.409L4.93896 8.531Z"
-                fill="var(--color-text)"
+                fill="var(--color-icon-text)"
             />
         </svg>
     ),
@@ -206,7 +302,7 @@ export const icons: Record<
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
             <path
                 d="M1.5 5.50969L8 11.6609L14.5 5.50969L12.5466 3.66086L8 7.96494L3.45341 3.66086L1.5 5.50969Z"
-                fill="var(--color-text)"
+                fill="var(--color-icon-text)"
             />
         </svg>
     ),
@@ -226,7 +322,7 @@ export const icons: Record<
     menu: () => (
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
             {["3", "7", "11"].map((y) => (
-                <rect x="1" y={y} width="14" height="2" fill="var(--color-text)" />
+                <rect x="1" y={y} width="14" height="2" fill="var(--color-icon-text)" />
             ))}
         </svg>
     ),
@@ -234,7 +330,7 @@ export const icons: Record<
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
             <path
                 d="M15.7824 13.833L12.6666 10.7177C12.5259 10.5771 12.3353 10.499 12.1353 10.499H11.6259C12.4884 9.39596 13.001 8.00859 13.001 6.49937C13.001 2.90909 10.0914 0 6.50048 0C2.90959 0 0 2.90909 0 6.49937C0 10.0896 2.90959 12.9987 6.50048 12.9987C8.00996 12.9987 9.39756 12.4863 10.5008 11.6239V12.1332C10.5008 12.3332 10.5789 12.5238 10.7195 12.6644L13.8354 15.7797C14.1292 16.0734 14.6042 16.0734 14.8948 15.7797L15.7793 14.8954C16.0731 14.6017 16.0731 14.1267 15.7824 13.833ZM6.50048 10.499C4.29094 10.499 2.50018 8.71165 2.50018 6.49937C2.50018 4.29021 4.28781 2.49976 6.50048 2.49976C8.71001 2.49976 10.5008 4.28708 10.5008 6.49937C10.5008 8.70852 8.71314 10.499 6.50048 10.499Z"
-                fill="var(--color-text)"
+                fill="var(--color-icon-text)"
             />
         </svg>
     ),

--- a/src/lib/utils/jsx.elements.ts
+++ b/src/lib/utils/jsx.elements.ts
@@ -124,6 +124,7 @@ export interface IntrinsicElements {
     polyline: JsxPolylineElementProps;
     line: JsxLineElementProps;
     use: JsxUseElementProps;
+    text: JsxTextElementProps;
 }
 
 export const JsxFragment = Symbol();
@@ -943,9 +944,9 @@ export interface JsxSvgPresentationProps {
     "font-size"?: string;
     "font-size-adjust"?: "none" | number;
     "font-stretch"?: string;
-    "font-style"?: "normal" | "italic" | "oblique";
+    "font-style"?: "normal" | "italic" | "oblique" | string;
     "font-variant"?: string;
-    "font-weight"?: "normal" | "bold" | "bolder" | "lighter" | number;
+    "font-weight"?: "normal" | "bold" | "bolder" | "lighter" | number | string;
     "image-rendering"?: "auto" | "optimizeSpeed" | "optimizeQuality";
     "letter-spacing"?: string;
     "lighting-color"?: string;
@@ -1168,4 +1169,17 @@ export interface JsxUseElementProps
     y?: string | number;
     width?: string | number;
     height?: string | number;
+}
+
+/**
+ * Properties permitted on the `<text>` element.
+ *
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
+ */
+export interface JsxTextElementProps
+    extends JsxSvgCoreProps,
+        JsxSvgStyleProps,
+        JsxSvgPresentationProps {
+    x?: string | number;
+    y?: string | number;
 }

--- a/src/lib/utils/jsx.elements.ts
+++ b/src/lib/utils/jsx.elements.ts
@@ -1174,7 +1174,7 @@ export interface JsxUseElementProps
 /**
  * Properties permitted on the `<text>` element.
  *
- * Reference: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text
  */
 export interface JsxTextElementProps
     extends JsxSvgCoreProps,

--- a/static/style.css
+++ b/static/style.css
@@ -31,6 +31,7 @@
     --light-color-ts-constructor: #4d7fff;
     --light-color-ts-property: #ff984d;
     --light-color-ts-method: #ff4db8;
+    --light-color-ts-reference: #ff4d82;
     --light-color-ts-call-signature: var(--light-color-ts-method);
     --light-color-ts-index-signature: var(--light-color-ts-property);
     --light-color-ts-constructor-signature: var(--light-color-ts-constructor);
@@ -79,6 +80,7 @@
     --dark-color-ts-constructor: #4d7fff;
     --dark-color-ts-property: #ff984d;
     --dark-color-ts-method: #ff4db8;
+    --dark-color-ts-reference: #ff4d82;
     --dark-color-ts-call-signature: var(--dark-color-ts-method);
     --dark-color-ts-index-signature: var(--dark-color-ts-property);
     --dark-color-ts-constructor-signature: var(--dark-color-ts-constructor);
@@ -135,6 +137,7 @@
         --color-ts-constructor: var(--light-color-ts-constructor);
         --color-ts-property: var(--light-color-ts-property);
         --color-ts-method: var(--light-color-ts-method);
+        --color-ts-reference: var(--light-color-ts-reference);
         --color-ts-call-signature: var(--light-color-ts-call-signature);
         --color-ts-index-signature: var(--light-color-ts-index-signature);
         --color-ts-constructor-signature: var(
@@ -186,6 +189,7 @@
         --color-ts-constructor: var(--dark-color-ts-constructor);
         --color-ts-property: var(--dark-color-ts-property);
         --color-ts-method: var(--dark-color-ts-method);
+        --color-ts-reference: var(--dark-color-ts-reference);
         --color-ts-call-signature: var(--dark-color-ts-call-signature);
         --color-ts-index-signature: var(--dark-color-ts-index-signature);
         --color-ts-constructor-signature: var(
@@ -243,6 +247,7 @@ body {
     --color-ts-constructor: var(--light-color-ts-constructor);
     --color-ts-property: var(--light-color-ts-property);
     --color-ts-method: var(--light-color-ts-method);
+    --color-ts-reference: var(--light-color-ts-reference);
     --color-ts-call-signature: var(--light-color-ts-call-signature);
     --color-ts-index-signature: var(--light-color-ts-index-signature);
     --color-ts-constructor-signature: var(
@@ -291,6 +296,7 @@ body {
     --color-ts-constructor: var(--dark-color-ts-constructor);
     --color-ts-property: var(--dark-color-ts-property);
     --color-ts-method: var(--dark-color-ts-method);
+    --color-ts-reference: var(--dark-color-ts-reference);
     --color-ts-call-signature: var(--dark-color-ts-call-signature);
     --color-ts-index-signature: var(--dark-color-ts-index-signature);
     --color-ts-constructor-signature: var(
@@ -1284,6 +1290,9 @@ img {
 }
 .tsd-kind-method {
     color: var(--color-ts-method);
+}
+.tsd-kind-reference {
+    color: var(--color-ts-reference);
 }
 .tsd-kind-call-signature {
     color: var(--color-ts-call-signature);

--- a/static/style.css
+++ b/static/style.css
@@ -97,8 +97,9 @@
     --dark-external-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='10' height='10'><path fill-opacity='0' stroke='%23fff' stroke-width='10' d='m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z'/></svg>");
     --dark-color-scheme: dark;
 
-    --icon-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
-        Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+    --icon-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+        "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji",
+        "Segoe UI Emoji";
     --icon-font-size: 16px;
     --icon-font-weight: normal;
     --icon-font-style: normal;

--- a/static/style.css
+++ b/static/style.css
@@ -96,13 +96,6 @@
 
     --dark-external-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='10' height='10'><path fill-opacity='0' stroke='%23fff' stroke-width='10' d='m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z'/></svg>");
     --dark-color-scheme: dark;
-
-    --icon-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
-        "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji",
-        "Segoe UI Emoji";
-    --icon-font-size: 16px;
-    --icon-font-weight: normal;
-    --icon-font-style: normal;
 }
 
 @media (prefers-color-scheme: light) {
@@ -910,16 +903,18 @@ a.tsd-index-link {
     margin-bottom: 0.75rem;
 }
 
+.tsd-no-select {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
 .tsd-kind-icon {
     margin-right: 0.5rem;
     width: 1.25rem;
     height: 1.25rem;
     min-width: 1.25rem;
     min-height: 1.25rem;
-}
-.tsd-kind-icon path {
-    transform-origin: center;
-    transform: scale(1.1);
 }
 .tsd-signature > .tsd-kind-icon {
     margin-right: 0.8rem;

--- a/static/style.css
+++ b/static/style.css
@@ -28,16 +28,16 @@
     --light-color-ts-function: #572be7;
     --light-color-ts-class: #1f70c2;
     --light-color-ts-interface: #108024;
-    --light-color-ts-constructor: var(--light-color-ts-class);
-    --light-color-ts-property: var(--light-color-ts-variable);
-    --light-color-ts-method: var(--light-color-ts-function);
+    --light-color-ts-constructor: #4d7fff;
+    --light-color-ts-property: #ff984d;
+    --light-color-ts-method: #ff4db8;
     --light-color-ts-call-signature: var(--light-color-ts-method);
     --light-color-ts-index-signature: var(--light-color-ts-property);
     --light-color-ts-constructor-signature: var(--light-color-ts-constructor);
     --light-color-ts-parameter: var(--light-color-ts-variable);
     /* type literal not included as links will never be generated to it */
     --light-color-ts-type-parameter: #a55c0e;
-    --light-color-ts-accessor: var(--light-color-ts-property);
+    --light-color-ts-accessor: #ff4d4d;
     --light-color-ts-get-signature: var(--light-color-ts-accessor);
     --light-color-ts-set-signature: var(--light-color-ts-accessor);
     --light-color-ts-type-alias: #d51270;
@@ -76,16 +76,16 @@
     --dark-color-ts-function: #a280ff;
     --dark-color-ts-class: #8ac4ff;
     --dark-color-ts-interface: #6cff87;
-    --dark-color-ts-constructor: var(--dark-color-ts-class);
-    --dark-color-ts-property: var(--dark-color-ts-variable);
-    --dark-color-ts-method: var(--dark-color-ts-function);
+    --dark-color-ts-constructor: #4d7fff;
+    --dark-color-ts-property: #ff984d;
+    --dark-color-ts-method: #ff4db8;
     --dark-color-ts-call-signature: var(--dark-color-ts-method);
     --dark-color-ts-index-signature: var(--dark-color-ts-property);
     --dark-color-ts-constructor-signature: var(--dark-color-ts-constructor);
     --dark-color-ts-parameter: var(--dark-color-ts-variable);
     /* type literal not included as links will never be generated to it */
     --dark-color-ts-type-parameter: #e07d13;
-    --dark-color-ts-accessor: var(--dark-color-ts-property);
+    --dark-color-ts-accessor: #ff4d4d;
     --dark-color-ts-get-signature: var(--dark-color-ts-accessor);
     --dark-color-ts-set-signature: var(--dark-color-ts-accessor);
     --dark-color-ts-type-alias: #ff6492;

--- a/static/style.css
+++ b/static/style.css
@@ -4,11 +4,18 @@
     --light-color-background-secondary: #eff0f1;
     --light-color-warning-text: #222;
     --light-color-background-warning: #e6e600;
-    --light-color-icon-background: var(--light-color-background);
     --light-color-accent: #c5c7c9;
     --light-color-active-menu-item: var(--light-color-accent);
     --light-color-text: #222;
     --light-color-text-aside: #6e6e6e;
+
+    --light-color-icon-background: var(--light-color-background);
+    --light-color-icon-text: var(--light-color-text);
+
+    /* these are used in the code below but never defined. Making a guess */
+    --light-color-comment-tag-text: var(--light-color-text);
+    --light-color-comment-tag: var(--light-color-background);
+
     --light-color-link: #1f70c2;
     --light-color-focus-outline: #3584e4;
 
@@ -46,11 +53,18 @@
     --dark-color-background-secondary: #1e2024;
     --dark-color-background-warning: #bebe00;
     --dark-color-warning-text: #222;
-    --dark-color-icon-background: var(--dark-color-background-secondary);
     --dark-color-accent: #9096a2;
     --dark-color-active-menu-item: #5d5d6a;
     --dark-color-text: #f5f5f5;
     --dark-color-text-aside: #dddddd;
+
+    --dark-color-icon-background: var(--dark-color-background-secondary);
+    --dark-color-icon-text: var(--dark-color-text);
+
+    /* these are used in the code below but never defined. Making a guess */
+    --dark-color-comment-tag-text: var(--dark-color-text);
+    --dark-color-comment-tag: var(--dark-color-background);
+
     --dark-color-link: #00aff4;
     --dark-color-focus-outline: #4c97f2;
 
@@ -82,6 +96,12 @@
 
     --dark-external-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='10' height='10'><path fill-opacity='0' stroke='%23fff' stroke-width='10' d='m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z'/></svg>");
     --dark-color-scheme: dark;
+
+    --icon-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+        Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+    --icon-font-size: 16px;
+    --icon-font-weight: normal;
+    --icon-font-style: normal;
 }
 
 @media (prefers-color-scheme: light) {
@@ -90,15 +110,23 @@
         --color-background-secondary: var(--light-color-background-secondary);
         --color-background-warning: var(--light-color-background-warning);
         --color-warning-text: var(--light-color-warning-text);
-        --color-icon-background: var(--light-color-icon-background);
         --color-accent: var(--light-color-accent);
         --color-active-menu-item: var(--light-color-active-menu-item);
         --color-text: var(--light-color-text);
         --color-text-aside: var(--light-color-text-aside);
+
+        --color-icon-background: var(--light-color-icon-background);
+        --color-icon-text: var(--light-color-icon-text);
+
+        /* these are used in the code below but never defined. Making a guess */
+        --color-comment-tag-text: var(--light-color-text);
+        --color-comment-tag: var(--light-color-background);
+
         --color-link: var(--light-color-link);
         --color-focus-outline: var(--light-color-focus-outline);
 
         --color-ts-keyword: var(--light-color-ts-keyword);
+        --color-ts-project: var(--light-color-ts-project);
         --color-ts-module: var(--light-color-ts-module);
         --color-ts-namespace: var(--light-color-ts-namespace);
         --color-ts-enum: var(--light-color-ts-enum);
@@ -134,15 +162,23 @@
         --color-background-secondary: var(--dark-color-background-secondary);
         --color-background-warning: var(--dark-color-background-warning);
         --color-warning-text: var(--dark-color-warning-text);
-        --color-icon-background: var(--dark-color-icon-background);
         --color-accent: var(--dark-color-accent);
         --color-active-menu-item: var(--dark-color-active-menu-item);
         --color-text: var(--dark-color-text);
         --color-text-aside: var(--dark-color-text-aside);
+
+        --color-icon-background: var(--dark-color-icon-background);
+        --color-icon-text: var(--dark-color-icon-text);
+
+        /* these are used in the code below but never defined. Making a guess */
+        --color-comment-tag-text: var(--dark-color-text);
+        --color-comment-tag: var(--dark-color-background);
+
         --color-link: var(--dark-color-link);
         --color-focus-outline: var(--dark-color-focus-outline);
 
         --color-ts-keyword: var(--dark-color-ts-keyword);
+        --color-ts-project: var(--dark-color-ts-project);
         --color-ts-module: var(--dark-color-ts-module);
         --color-ts-namespace: var(--dark-color-ts-namespace);
         --color-ts-enum: var(--dark-color-ts-enum);
@@ -190,10 +226,17 @@ body {
     --color-active-menu-item: var(--light-color-active-menu-item);
     --color-text: var(--light-color-text);
     --color-text-aside: var(--light-color-text-aside);
+    --color-icon-text: var(--light-color-icon-text);
+
+    /* these are used in the code below but never defined. Making a guess */
+    --color-comment-tag-text: var(--light-color-text);
+    --color-comment-tag: var(--light-color-background);
+
     --color-link: var(--light-color-link);
     --color-focus-outline: var(--light-color-focus-outline);
 
     --color-ts-keyword: var(--light-color-ts-keyword);
+    --color-ts-project: var(--light-color-ts-project);
     --color-ts-module: var(--light-color-ts-module);
     --color-ts-namespace: var(--light-color-ts-namespace);
     --color-ts-enum: var(--light-color-ts-enum);
@@ -232,10 +275,17 @@ body {
     --color-active-menu-item: var(--dark-color-active-menu-item);
     --color-text: var(--dark-color-text);
     --color-text-aside: var(--dark-color-text-aside);
+    --color-icon-text: var(--dark-color-icon-text);
+
+    /* these are used in the code below but never defined. Making a guess */
+    --color-comment-tag-text: var(--dark-color-text);
+    --color-comment-tag: var(--dark-color-background);
+
     --color-link: var(--dark-color-link);
     --color-focus-outline: var(--dark-color-focus-outline);
 
     --color-ts-keyword: var(--dark-color-ts-keyword);
+    --color-ts-project: var(--dark-color-ts-project);
     --color-ts-module: var(--dark-color-ts-module);
     --color-ts-namespace: var(--dark-color-ts-namespace);
     --color-ts-enum: var(--dark-color-ts-enum);
@@ -439,7 +489,6 @@ pre {
 
 pre {
     position: relative;
-    white-space: pre;
     white-space: pre-wrap;
     word-wrap: break-word;
     padding: 10px;
@@ -1254,9 +1303,6 @@ img {
 .tsd-kind-parameter {
     color: var(--color-ts-parameter);
 }
-.tsd-kind-type-literal {
-    color: var(--color-ts-type-literal);
-}
 .tsd-kind-type-parameter {
     color: var(--color-ts-type-parameter);
 }
@@ -1435,7 +1481,7 @@ img {
     }
 
     .site-menu {
-        margin-top: 1rem 0;
+        margin-top: 1rem;
     }
 
     .page-menu,

--- a/static/style.css
+++ b/static/style.css
@@ -12,7 +12,6 @@
     --light-color-icon-background: var(--light-color-background);
     --light-color-icon-text: var(--light-color-text);
 
-    /* these are used in the code below but never defined. Making a guess */
     --light-color-comment-tag-text: var(--light-color-text);
     --light-color-comment-tag: var(--light-color-background);
 
@@ -61,7 +60,6 @@
     --dark-color-icon-background: var(--dark-color-background-secondary);
     --dark-color-icon-text: var(--dark-color-text);
 
-    /* these are used in the code below but never defined. Making a guess */
     --dark-color-comment-tag-text: var(--dark-color-text);
     --dark-color-comment-tag: var(--dark-color-background);
 
@@ -118,7 +116,6 @@
         --color-icon-background: var(--light-color-icon-background);
         --color-icon-text: var(--light-color-icon-text);
 
-        /* these are used in the code below but never defined. Making a guess */
         --color-comment-tag-text: var(--light-color-text);
         --color-comment-tag: var(--light-color-background);
 
@@ -170,7 +167,6 @@
         --color-icon-background: var(--dark-color-icon-background);
         --color-icon-text: var(--dark-color-icon-text);
 
-        /* these are used in the code below but never defined. Making a guess */
         --color-comment-tag-text: var(--dark-color-text);
         --color-comment-tag: var(--dark-color-background);
 
@@ -228,7 +224,6 @@ body {
     --color-text-aside: var(--light-color-text-aside);
     --color-icon-text: var(--light-color-icon-text);
 
-    /* these are used in the code below but never defined. Making a guess */
     --color-comment-tag-text: var(--light-color-text);
     --color-comment-tag: var(--light-color-background);
 
@@ -277,7 +272,6 @@ body {
     --color-text-aside: var(--dark-color-text-aside);
     --color-icon-text: var(--dark-color-icon-text);
 
-    /* these are used in the code below but never defined. Making a guess */
     --color-comment-tag-text: var(--dark-color-text);
     --color-comment-tag: var(--dark-color-background);
 


### PR DESCRIPTION
Resolves: https://github.com/TypeStrong/typedoc/issues/2726

## Description
Update SVG icons to use `<text>` elements for the letters instead of pathing the letter shapes. This allows size/font/etc to be adjusted in accordance with the styling/theme being developed, so icons are easier to read/identify and are more accessible.

Out of the box, icons now look like this:
<img width="277" alt="Screenshot 2024-10-08 at 10 42 11 AM" src="https://github.com/user-attachments/assets/917a4aa7-5b03-4bc4-b348-fde90e09b03e">

The definition for an icon goes from looking like:
```ts
    [ReflectionKind.Accessor]: () =>
        kindIcon(
            <path
                d="M8.85 16L11.13 7.24H12.582L14.85 16H13.758L13.182 13.672H10.53L9.954 16H8.85ZM10.746 12.76H12.954L12.282 10.06C12.154 9.548 12.054 9.12 11.982 8.776C11.91 8.432 11.866 8.208 11.85 8.104C11.834 8.208 11.79 8.432 11.718 8.776C11.646 9.12 11.546 9.544 11.418 10.048L10.746 12.76Z"
                fill="var(--color-text)"
            />,
            "#FF4D4D",
            true,
        ),
```

to
```ts
    [ReflectionKind.Accessor]: () =>
        kindIcon(
            <text
                fill="var(--color-icon-text)"
                font-family="var(--icon-font-family)"
                font-size="var(--icon-font-size)"
                font-weight="var(--icon-font-weight)"
                font-style="var(--icon-font-style)"
                x="6.5"
                y="17.5"
            >
                A
            </text>,
            "var(--color-ts-accessor)",
            true,
        ),
```

## Additional Changes
- Font family/size/weight/style are adjustable on each text icon
    - css properties for `--icon-font-family`, `--icon-font-size`, `--icon-font-weight`, `--icon-font-style` added to control those values
- Outline colors on multiple icons set to the `--color-ts-xyz` value rather than a hard coded color code
    - `--color-ts-xyz` properties that did not use the same color code as the hard coded icon updated to use that code
- Fill color on icons changed from `--color-text` to `--color-icon-text` to allow the icons to be managed independently of the text on the page.
- The following properties were being used in the stylesheet but not defined. Their definitions have been added
    - `--color-comment-tag-text`, `--color-comment-tag`, and `--color-ts-project`
- Use of `--color-ts-type-literal` removed, as there are comments earlier in the stylesheet explicitly stating it is not being defined for a reason
- Removed extra `white-space` property in `pre` tag style definition.
- Removed extraneous `0` from the end of the `margin-top` property in `.site-menu` style definition
- Css property for `--color-ts-reference` defined and used in icon definition