### PR TITLE
Create dedicated html outputShortcut

### DIFF
--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -221,7 +221,10 @@ export = {
         "If a symbol is exported multiple times, ignore all but the first export",
     help_externalSymbolLinkMappings:
         "Define custom links for symbols not included in the documentation",
-    help_out: "Specify the location the documentation should be written to",
+    help_out:
+        "Specify the location the documentation for the default output should be written to",
+    help_html:
+        "Specify the location where the html documentation should be written to. For the default theme, this is equivalent to the out option",
     help_json:
         "Specify the location and filename a JSON file describing the project is written to",
     help_pretty:

--- a/src/lib/internationalization/locales/jp.cts
+++ b/src/lib/internationalization/locales/jp.cts
@@ -234,7 +234,9 @@ export = localeUtils.buildIncompleteTranslation({
         "シンボルが複数回エクスポートされた場合、最初のエクスポート以外はすべて無視されます。",
     help_externalSymbolLinkMappings:
         "ドキュメントに含まれていないシンボルのカスタムリンクを定義する",
-    help_out: "ドキュメントを書き込む場所を指定します",
+    help_out: "デフォルトの出力ドキュメントを保存する場所を指定してください。",
+    help_html:
+        "HTMLドキュメントを保存する場所を指定してください。デフォルトテーマでは、これは out オプションと同等です。",
     help_json:
         "プロジェクトを説明するJSONファイルが書き込まれる場所とファイル名を指定します",
     help_pretty: "出力JSONをタブでフォーマットするかどうかを指定します",

--- a/src/lib/internationalization/locales/ko.cts
+++ b/src/lib/internationalization/locales/ko.cts
@@ -86,7 +86,9 @@ export = localeUtils.buildIncompleteTranslation({
         "심볼이 여러 번 내보내진 경우 첫 번째 내보내기를 제외하고 모두 무시합니다",
     help_externalSymbolLinkMappings:
         "문서에 포함되지 않은 심볼에 대한 사용자 정의 링크를 정의합니다",
-    help_out: "문서가 쓰여질 위치를 지정합니다",
+    help_out: "기본 출력 문서가 작성될 위치를 지정하세요.",
+    help_html:
+        "HTML 문서가 작성될 위치를 지정하세요. 기본 테마의 경우, 이는 out 옵션과 동일합니다.",
     help_json: "프로젝트를 설명하는 JSON 파일의 위치와 파일 이름을 지정합니다",
     help_pretty: "출력 JSON을 탭으로 포맷팅할 지 여부를 지정합니다",
     help_emit:

--- a/src/lib/internationalization/locales/zh.cts
+++ b/src/lib/internationalization/locales/zh.cts
@@ -227,7 +227,8 @@ export = localeUtils.buildIncompleteTranslation({
     help_excludeReferences:
         "如果一个符号被导出多次，则忽略除第一次导出之外的所有导出",
     help_externalSymbolLinkMappings: "为文档中未包含的符号定义自定义链接",
-    help_out: "指定文档应写入的位置",
+    help_out: "指定默认输出文档的保存位置。",
+    help_html: "指定HTML文档的保存位置。对于默认主题，这相当于out选项。",
     help_json: "指定描述项目的 JSON 文件写入的位置和文件名",
     help_pretty: "指定输出 JSON 是否应使用制表符进行格式化",
     help_emit: "指定 TypeDoc 应发出的内容，“docs”、“both”或“none”",

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -136,8 +136,9 @@ export interface TypeDocOptionMap {
 
     // Output
     outputs: ManuallyValidatedOption<Array<OutputSpecification>>;
-    out: string; // shortcut for defining an output
-    json: string; // shortcut for defining an output
+    out: string; // default output directory
+    html: string; // shortcut for defining html output
+    json: string; // shortcut for defining json output
     pretty: boolean;
     emit: typeof EmitStrategy;
     theme: string;

--- a/src/lib/utils/options/sources/typedoc.ts
+++ b/src/lib/utils/options/sources/typedoc.ts
@@ -276,11 +276,17 @@ export function addTypeDocOptions(options: Pick<Options, "addDeclaration">) {
     });
     options.addDeclaration({
         name: "out",
-        outputShortcut: "html",
         help: (i18n) => i18n.help_out(),
         type: ParameterType.Path,
         hint: ParameterHint.Directory,
         defaultValue: "./docs",
+    });
+    options.addDeclaration({
+        name: "html",
+        outputShortcut: "html",
+        help: (i18n) => i18n.help_html(),
+        type: ParameterType.Path,
+        hint: ParameterHint.Directory,
     });
     options.addDeclaration({
         name: "json",


### PR DESCRIPTION
@Gerrit0 Thanks for the great work on the beta release. I have been working against it to prepare typedoc-plugin-markdown when it lands. I hope this PR makes sense but let me know what you think.

## Summary / Purpose

While updating typedoc-plugin-markdown to properly utilize the "outputs" implementation  as per https://github.com/TypeStrong/typedoc/issues/2597 (which is fantastic by the way) I have stumbled upon a bit on an issue.

The issue is that the "html" outputShortcut is bound to the "out" declaration. By reading the above thread I think the initial intention was perhaps to rename the option? 

> "_The --out option will be replaced with a --html option._". 

I understand that this is a significant breaking change, so I see the importance of preserving the out option. Ideally, though, I would prefer to avoid introducing a plugin breaking change of requiring a "markdown" option to be specified (instead of the generic "out" option) in order to generate the markdown docs. As it stands there is no way around this.

## Proposal

I propose to preserve the existing "out" option as a basic path declaration and to introduce a dedicated "html" outputShortcut. To the end user this will have no effect, as the Outputs class will assume that no shortcut has been specified and apply the html output as the default output. 

However this also means that I can create a markdown output and set it as the default and preserve the existing behaviour of the "out" option.

ie something like this:

```
app.options.addDeclaration({
    name: 'markdown',
    outputShortcut: 'markdown',
    help: (i18n) => i18n.help_markdown(),
    type: ParameterType.Path,
    hint: ParameterHint.Directory,
    defaultValue: './docs',
  });

app.outputs.addOutput('markdown', async (out, project) => {
    await customMarkdownRenderer(out, project)
  });

  app.outputs.setDefaultOutput(() => {
    return {
      name: 'markdown',
      path: app.options.getValue('out'),
    };
  });
```

Then when outputs are specified in config, the dedicated shortcuts will be picked up so the existing behaviour is preserved here too:

```
 "outputs": [
        {
            "name": "html",
            "path": "../html-docs"
        },
        {
            "name": "markdown",
            "path": "../markdown-doc",
        }
    ],
```

## Changes

The changes are pretty simple:

- removed outputShortcut key from the "out" option.
- added a dedicated "html" outputShortcut
- updated help text (put the translation through chat gpt so not sure of the accuracy)















