### PR TITLE
Introducing TypeDoc Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Documentation generator for TypeScript projects.
 
 [![CI](https://github.com/TypeStrong/typedoc/workflows/CI/badge.svg)](https://github.com/TypeStrong/typedoc/actions)
-[![NPM Version](https://img.shields.io/npm/v/typedoc?color=33cd56&logo=npm)](https://www.npmjs.com/package/typedoc)
+[![NPM Version](https://img.shields.io/npm/v/typedoc?color=33cd56&logo=npm)](https://www.npmjs.com/package/typedoc) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20TypeDoc%20Guru-006BFF)](https://gurubase.io/g/typedoc)
 
 ## Documentation
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [TypeDoc Guru](https://gurubase.io/g/typedoc) to Gurubase. TypeDoc Guru uses the data from this repo and data from the [docs](https://typedoc.org) to answer questions by leveraging the LLM.

In this PR, I showcased the "TypeDoc Guru", which highlights that TypeDoc now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable TypeDoc Guru in Gurubase, just let me know that's totally fine.
