### PR TITLE
Update Chinese translations

### DIFF
--- a/src/lib/internationalization/locales/zh.cts
+++ b/src/lib/internationalization/locales/zh.cts
@@ -307,6 +307,8 @@ export = localeUtils.buildIncompleteTranslation({
     help_headings: "确定标题是否需要被渲染",
     help_sluggerConfiguration: "确定渲染的 HTML 中锚点的确定方式",
     help_navigation: "确定导航侧边栏的组织方式",
+    help_includeHierarchySummary:
+        "如果设置，反射的层级一览将被渲染至概述页面。默认为 `true`",
     help_visibilityFilters:
         "根据修饰符标签指定内置过滤器和附加过滤器的默认可见性",
     help_searchCategoryBoosts: "配置搜索以提高所选类别的相关性",
@@ -459,6 +461,8 @@ export = localeUtils.buildIncompleteTranslation({
     theme_type_declaration: "类型声明",
     theme_index: "索引",
     theme_hierarchy: "层级",
+    theme_hierarchy_summary: "层级一览",
+    theme_hierarchy_view_summary: "查看层级一览",
     theme_implemented_by: "实现于",
     theme_defined_in: "定义于",
     theme_implementation_of: "实现了",
@@ -487,6 +491,8 @@ export = localeUtils.buildIncompleteTranslation({
     theme_copy: "复制",
     theme_copied: "已复制！",
     theme_normally_hidden: "由于您的过滤器设置，该成员已被隐藏。",
+    theme_hierarchy_expand: "展开",
+    theme_hierarchy_collapse: "折叠",
 
     tag_defaultValue: "默认值",
     tag_deprecated: "已被弃用",

--- a/src/test/Repository.test.ts
+++ b/src/test/Repository.test.ts
@@ -137,7 +137,7 @@ describe("Repository", function () {
 
             git(project.cwd, "init", "-b", "test");
             git(project.cwd, "add", ".");
-            git(project.cwd, "commit", "-m", "Test commit");
+            git(project.cwd, "commit", "-m", "Test commit", "--no-gpg-sign");
             git(
                 project.cwd,
                 "remote",
@@ -181,7 +181,7 @@ describe("RepositoryManager - git enabled", () => {
         function createRepo(path: string) {
             git(path, "init", "-b", "test");
             git(path, "add", ".");
-            git(path, "commit", "-m", "Test commit");
+            git(path, "commit", "-m", "Test commit", "--no-gpg-sign");
         }
 
         fix = tempdirProject();


### PR DESCRIPTION
This PR also fixes an issue that prevented tests from passing on my computer (I have configured `commit.gpgsign=true`). It should have no impact on users who have not configured this option.

```
  924 passing (12s)
  3 pending
  1 failing

  1) Repository
       getURL
         Handles replacements:

      AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

+ '61d295e45877efe14af902f64b7c1e994820dc02/61d295e4/test.js/1'
- 'b53cc55bcdd9bc5920787a1d4a4a15fa24123b04/b53cc55b/test.js/1'
      + expected - actual

      -61d295e45877efe14af902f64b7c1e994820dc02/61d295e4/test.js/1
      +b53cc55bcdd9bc5920787a1d4a4a15fa24123b04/b53cc55b/test.js/1

      at Context.<anonymous> (src\test\Repository.test.ts:158:13)
      at process.processImmediate (node:internal/timers:478:21)
```