### PR TITLE
Closes #2790 allow png favicon

### DIFF
--- a/site/options/output.md
+++ b/site/options/output.md
@@ -262,7 +262,7 @@ Create a CNAME file in the output directory with the specified text.
 $ typedoc --favicon favicon.ico
 ```
 
-Specify a `favicon.ico` or `favicon.svg` file to reference as the site favicon.
+Specify a `.ico`, `.png` or `.svg` file to reference as the site favicon.
 
 ## sourceLinkExternal
 

--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -268,8 +268,7 @@ export = {
         "Path to the readme file that should be displayed on the index page. Pass `none` to disable the index page and start the documentation on the globals page",
     help_cname:
         "Set the CNAME file text, it's useful for custom domains on GitHub Pages",
-    help_favicon:
-        "Path to a .ico, .png or .svg file to include as the site icon",
+    help_favicon: "Path to favicon to include as the site icon",
     help_sourceLinkExternal:
         "Specifies that source links should be treated as external links to be opened in a new tab",
     help_markdownLinkExternal:
@@ -388,8 +387,8 @@ export = {
         "hostedBaseUrl must start with http:// or https://",
     useHostedBaseUrlForAbsoluteLinks_requires_hostedBaseUrl:
         "The useHostedBaseUrlForAbsoluteLinks option requires that hostedBaseUrl be set",
-    favicon_must_be_ico_or_svg:
-        "Favicon file must be either a .ico, .png or .svg",
+    favicon_must_have_one_of_the_following_extensions_0:
+        "Favicon must have on of the following extensions: {0}",
     option_0_must_be_an_object: "The '{0}' option must be a non-array object",
     option_0_must_be_a_function: "The '{0}' option must be a function",
     option_0_must_be_object_with_urls: `{0} must be an object with string labels as keys and URL values`,

--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -388,7 +388,8 @@ export = {
         "hostedBaseUrl must start with http:// or https://",
     useHostedBaseUrlForAbsoluteLinks_requires_hostedBaseUrl:
         "The useHostedBaseUrlForAbsoluteLinks option requires that hostedBaseUrl be set",
-    favicon_must_be_ico_or_svg: "Favicon file must be either a .ico, .png or .svg",
+    favicon_must_be_ico_or_svg:
+        "Favicon file must be either a .ico, .png or .svg",
     option_0_must_be_an_object: "The '{0}' option must be a non-array object",
     option_0_must_be_a_function: "The '{0}' option must be a function",
     option_0_must_be_object_with_urls: `{0} must be an object with string labels as keys and URL values`,

--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -269,7 +269,7 @@ export = {
     help_cname:
         "Set the CNAME file text, it's useful for custom domains on GitHub Pages",
     help_favicon:
-        "Path to a favicon.ico or favicon.svg to include as the site icon",
+        "Path to a .ico, .png or .svg file to include as the site icon",
     help_sourceLinkExternal:
         "Specifies that source links should be treated as external links to be opened in a new tab",
     help_markdownLinkExternal:
@@ -388,7 +388,7 @@ export = {
         "hostedBaseUrl must start with http:// or https://",
     useHostedBaseUrlForAbsoluteLinks_requires_hostedBaseUrl:
         "The useHostedBaseUrlForAbsoluteLinks option requires that hostedBaseUrl be set",
-    favicon_must_be_ico_or_svg: "Favicon file must be either a .ico or .svg",
+    favicon_must_be_ico_or_svg: "Favicon file must be either a .ico, .png or .svg",
     option_0_must_be_an_object: "The '{0}' option must be a non-array object",
     option_0_must_be_a_function: "The '{0}' option must be a function",
     option_0_must_be_object_with_urls: `{0} must be an object with string labels as keys and URL values`,

--- a/src/lib/internationalization/locales/zh.cts
+++ b/src/lib/internationalization/locales/zh.cts
@@ -279,7 +279,7 @@ export = localeUtils.buildIncompleteTranslation({
     help_readme:
         "应显示在索引页上的自述文件路径。传递“none”以禁用索引页并在全局页上启动文档",
     help_cname: "设置 CNAME 文件文本，这对于 GitHub Pages 上的自定义域很有用",
-    help_favicon: "作为站点图标包含的 favicon.ico 或 favicon.svg 的路径",
+    help_favicon: "作为站点图标包含的 favicon 的路径",
     help_sourceLinkExternal:
         "指定哪些源代码链接应被视为外部链接，并在新选项卡中打开",
     help_markdownLinkExternal:
@@ -371,7 +371,6 @@ export = localeUtils.buildIncompleteTranslation({
         "hostingBaseUrl 必须以 http:// 或 https:// 开头",
     useHostedBaseUrlForAbsoluteLinks_requires_hostedBaseUrl:
         "useHostedBaseUrlForAbsoluteLinks 选项要求设置 hostingBaseUrl",
-    favicon_must_be_ico_or_svg: "Favicon 文件必须是一个 .ico 或 .svg 文件",
     option_0_must_be_an_object: "“{0}”选项必须是非数组对象",
     option_0_must_be_a_function: "‘{0}’ 选项必须是一个函数",
     option_0_must_be_object_with_urls:

--- a/src/lib/output/plugins/AssetsPlugin.ts
+++ b/src/lib/output/plugins/AssetsPlugin.ts
@@ -43,13 +43,8 @@ export class AssetsPlugin extends RendererComponent {
     private onRenderBegin(event: RendererEvent) {
         const dest = join(event.outputDirectory, "assets");
 
-        switch (extname(this.favicon)) {
-            case ".ico":
-                copySync(this.favicon, join(dest, "favicon.ico"));
-                break;
-            case ".svg":
-                copySync(this.favicon, join(dest, "favicon.svg"));
-                break;
+        if ([".ico", ".png", ".svg"].includes(extname(this.favicon))) {
+            copySync(this.favicon, join(dest, "favicon" + extname(this.favicon)));
         }
 
         if (this.customCss) {

--- a/src/lib/output/plugins/AssetsPlugin.ts
+++ b/src/lib/output/plugins/AssetsPlugin.ts
@@ -44,7 +44,10 @@ export class AssetsPlugin extends RendererComponent {
         const dest = join(event.outputDirectory, "assets");
 
         if ([".ico", ".png", ".svg"].includes(extname(this.favicon))) {
-            copySync(this.favicon, join(dest, "favicon" + extname(this.favicon)));
+            copySync(
+                this.favicon,
+                join(dest, "favicon" + extname(this.favicon)),
+            );
         }
 
         if (this.customCss) {

--- a/src/lib/output/themes/default/layouts/default.tsx
+++ b/src/lib/output/themes/default/layouts/default.tsx
@@ -13,6 +13,8 @@ function favicon(context: DefaultThemeRenderContext) {
     switch (extname(fav)) {
         case ".ico":
             return <link rel="icon" href={context.relativeURL("assets/favicon.ico", true)} />;
+        case ".png":
+            return <link rel="icon" href={context.relativeURL("assets/favicon.png", true)} type="image/png" />;
         case ".svg":
             return <link rel="icon" href={context.relativeURL("assets/favicon.svg", true)} type="image/svg+xml" />;
         default:

--- a/src/lib/utils/options/sources/typedoc.ts
+++ b/src/lib/utils/options/sources/typedoc.ts
@@ -473,7 +473,7 @@ export function addTypeDocOptions(options: Pick<Options, "addDeclaration">) {
         name: "favicon",
         help: (i18n) => i18n.help_favicon(),
         validate(value, i18n) {
-            if (![".ico", ".svg"].includes(extname(value))) {
+            if (![".ico", ".png", ".svg"].includes(extname(value))) {
                 throw new Error(i18n.favicon_must_be_ico_or_svg());
             }
         },

--- a/src/lib/utils/options/sources/typedoc.ts
+++ b/src/lib/utils/options/sources/typedoc.ts
@@ -473,8 +473,13 @@ export function addTypeDocOptions(options: Pick<Options, "addDeclaration">) {
         name: "favicon",
         help: (i18n) => i18n.help_favicon(),
         validate(value, i18n) {
-            if (![".ico", ".png", ".svg"].includes(extname(value))) {
-                throw new Error(i18n.favicon_must_be_ico_or_svg());
+            const allowedExtension = [".ico", ".png", ".svg"];
+            if (!allowedExtension.includes(extname(value))) {
+                throw new Error(
+                    i18n.favicon_must_have_one_of_the_following_extensions_0(
+                        allowedExtension.join(", "),
+                    ),
+                );
             }
         },
         type: ParameterType.Path,


### PR DESCRIPTION
Solves #2790 Adds "png" to the list of allowed extensions for the favicon option

I didn't see unit tests related to this option, did I missed them ?

~~TODO : change the chinese messages~~