### PR TITLE
Replaced fetch() with direct data access

### DIFF
--- a/src/lib/output/plugins/HierarchyPlugin.ts
+++ b/src/lib/output/plugins/HierarchyPlugin.ts
@@ -3,8 +3,6 @@ import { RendererComponent } from "../components.js";
 import { RendererEvent } from "../events.js";
 import { writeFile } from "../../utils/index.js";
 import { DefaultTheme } from "../themes/default/DefaultTheme.js";
-import { gzip } from "zlib";
-import { promisify } from "util";
 
 import type { Renderer } from "../index.js";
 import {
@@ -13,8 +11,7 @@ import {
     getUniquePath,
 } from "../themes/lib.js";
 import type { DeclarationReflection } from "../../models/index.js";
-
-const gzipP = promisify(gzip);
+import { compressJson } from "../../utils/compress.js";
 
 interface JsonHierarchyElement {
     name: string;
@@ -102,13 +99,9 @@ export class HierarchyPlugin extends RendererComponent {
             "hierarchy.js",
         );
 
-        const gz = await gzipP(Buffer.from(JSON.stringify(hierarchy)));
-
         await writeFile(
             hierarchyJs,
-            `window.hierarchyData = "data:application/octet-stream;base64,${gz.toString(
-                "base64",
-            )}"`,
+            `window.hierarchyData = "${await compressJson(hierarchy)}"`,
         );
     }
 }

--- a/src/lib/output/plugins/JavascriptIndexPlugin.ts
+++ b/src/lib/output/plugins/JavascriptIndexPlugin.ts
@@ -12,13 +12,10 @@ import { RendererComponent } from "../components.js";
 import { IndexEvent, RendererEvent } from "../events.js";
 import { Option, writeFile } from "../../utils/index.js";
 import { DefaultTheme } from "../themes/default/DefaultTheme.js";
-import { gzip } from "zlib";
-import { promisify } from "util";
 import type { Renderer } from "../index.js";
 import { GroupPlugin } from "../../converter/plugins/GroupPlugin.js";
 import { CategoryPlugin } from "../../converter/plugins/CategoryPlugin.js";
-
-const gzipP = promisify(gzip);
+import { compressJson } from "../../utils/compress.js";
 
 /**
  * Keep this in sync with the interface in src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -152,17 +149,13 @@ export class JavascriptIndexPlugin extends RendererComponent {
             "search.js",
         );
 
-        const jsonData = JSON.stringify({
+        const data = {
             rows,
             index,
-        });
-        const data = await gzipP(Buffer.from(jsonData));
-
+        };
         await writeFile(
             jsonFileName,
-            `window.searchData = "data:application/octet-stream;base64,${data.toString(
-                "base64",
-            )}";`,
+            `window.searchData = "${await compressJson(data)}";`,
         );
 
         if (

--- a/src/lib/output/plugins/NavigationPlugin.ts
+++ b/src/lib/output/plugins/NavigationPlugin.ts
@@ -3,11 +3,8 @@ import { RendererComponent } from "../components.js";
 import { RendererEvent } from "../events.js";
 import { writeFile } from "../../utils/index.js";
 import { DefaultTheme } from "../themes/default/DefaultTheme.js";
-import { gzip } from "zlib";
-import { promisify } from "util";
 import type { Renderer } from "../index.js";
-
-const gzipP = promisify(gzip);
+import { compressJson } from "../../utils/compress.js";
 
 export class NavigationPlugin extends RendererComponent {
     constructor(owner: Renderer) {
@@ -34,13 +31,10 @@ export class NavigationPlugin extends RendererComponent {
         const nav = (this.owner.theme as DefaultTheme).getNavigation(
             event.project,
         );
-        const gz = await gzipP(Buffer.from(JSON.stringify(nav)));
 
         await writeFile(
             navigationJs,
-            `window.navigationData = "data:application/octet-stream;base64,${gz.toString(
-                "base64",
-            )}"`,
+            `window.navigationData = "${await compressJson(nav)}"`,
         );
     }
 }

--- a/src/lib/output/themes/default/assets/typedoc/Hierarchy.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Hierarchy.ts
@@ -1,3 +1,5 @@
+import { decompressJson } from "./utils/decompress";
+
 declare global {
     interface Window {
         // Base64 encoded data url, gzipped, JSON encoded JsonHierarchy
@@ -106,14 +108,8 @@ async function buildHierarchyToggle() {
     );
     if (!container || !window.hierarchyData) return;
 
-    const res = await fetch(window.hierarchyData);
-    const data = await res.arrayBuffer();
-    const json = new Blob([data])
-        .stream()
-        .pipeThrough(new DecompressionStream("gzip"));
-
     const baseReflId = +container.dataset.refl!;
-    const hierarchy: JsonHierarchy = await new Response(json).json();
+    const hierarchy: JsonHierarchy = await decompressJson(window.hierarchyData);
 
     const collapsedHierarchy = container.querySelector("ul")!;
     const expandedHierarchy = document.createElement("ul");

--- a/src/lib/output/themes/default/assets/typedoc/Navigation.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Navigation.ts
@@ -1,3 +1,5 @@
+import { decompressJson } from "./utils/decompress";
+
 export interface NavigationElement {
     text: string;
     path?: string;
@@ -27,12 +29,9 @@ async function buildNav() {
     const container = document.getElementById("tsd-nav-container");
     if (!container || !window.navigationData) return;
 
-    const res = await fetch(window.navigationData);
-    const data = await res.arrayBuffer();
-    const json = new Blob([data])
-        .stream()
-        .pipeThrough(new DecompressionStream("gzip"));
-    const nav: NavigationElement[] = await new Response(json).json();
+    const nav: NavigationElement[] = await decompressJson(
+        window.navigationData,
+    );
 
     BASE_URL = document.documentElement.dataset.base!;
     if (!BASE_URL.endsWith("/")) BASE_URL += "/";

--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -1,5 +1,6 @@
 import { debounce } from "../utils/debounce.js";
 import { Index } from "lunr";
+import { decompressJson } from "../utils/decompress.js";
 
 /**
  * Keep this in sync with the interface in src/lib/output/plugins/JavascriptIndexPlugin.ts
@@ -35,11 +36,7 @@ interface SearchState {
 async function updateIndex(state: SearchState, searchEl: HTMLElement) {
     if (!window.searchData) return;
 
-    const res = await fetch(window.searchData);
-    const json = new Blob([await res.arrayBuffer()])
-        .stream()
-        .pipeThrough(new DecompressionStream("gzip"));
-    const data: IData = await new Response(json).json();
+    const data: IData = await decompressJson(window.searchData);
 
     state.data = data;
     state.index = Index.load(data.index);

--- a/src/lib/output/themes/default/assets/typedoc/utils/decompress.ts
+++ b/src/lib/output/themes/default/assets/typedoc/utils/decompress.ts
@@ -1,0 +1,15 @@
+/**
+ * Decompresses Base64-encoded Gzip data and parses it into a JSON object.
+ *
+ * @param base64 - The Base64-encoded string representing the Gzip-compressed JSON string.
+ * @returns A promise that resolves to the parsed JSON object.
+ */
+export async function decompressJson(base64: string) {
+    const binaryData = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+    const blob = new Blob([binaryData]);
+    const decompressedStream = blob
+        .stream()
+        .pipeThrough(new DecompressionStream("gzip"));
+    const decompressedText = await new Response(decompressedStream).text();
+    return JSON.parse(decompressedText);
+}

--- a/src/lib/utils/compress.ts
+++ b/src/lib/utils/compress.ts
@@ -1,0 +1,15 @@
+import { gzip } from "zlib";
+import { promisify } from "util";
+
+const gzipP = promisify(gzip);
+
+/**
+ * Compresses a JSON-serializable object into a Base64-encoded Gzip string.
+ *
+ * @param data - The JSON-serializable object to compress.
+ * @returns A promise that resolves to a Base64-encoded string of the Gzip-compressed data.
+ */
+export async function compressJson(data: any) {
+    const gz = await gzipP(Buffer.from(JSON.stringify(data)));
+    return gz.toString("base64");
+}


### PR DESCRIPTION
Addresses https://github.com/TypeStrong/typedoc/issues/2794

This PR updates the handling of the search index, navigation, and hierarchy data by removing the use of the Fetch API.  This retains compression benefits while ensuring full compatibility with strict CSP environments.