### PR TITLE
Add mechanism to extend the JSX namespace for custom elements (and attributes)

### DIFF
--- a/site/development/themes.md
+++ b/site/development/themes.md
@@ -108,40 +108,40 @@ export function load(app: Application) {
 
 Start by writing a `jsx.d.ts` file somewhere.
 
-```ts
+````ts
 // src/jsx.d.ts
-import { JSX as TypeDocJSX } from 'typedoc'
+import { JSX as TypeDocJSX } from "typedoc";
 
-declare module 'typedoc' {
-  namespace JSX {
+declare module "typedoc" {
     namespace JSX {
-      interface IntrinsicAttributes {
-        popover?: boolean
-        popovertarget?: string
-        popovertargetaction?: 'hide' | 'show' | 'toggle'
-      }
-      interface IntrinsicElements {
-        // add your custom elements here, ie:
-        /**
-         * @example
-         * ```tsx
-         * <drop-down trigger="#my-trigger" class="header-menu">
-         *   <button>Option #1</button>
-         *   <button>Option #2</button>
-         * </drop-down>
-         * ```
-         */
-        'drop-down': IntrinsicAttributes & {
-          /**
-           * A query selector, ie: '#my-trigger'
-           */
-          trigger: string
+        namespace JSX {
+            interface IntrinsicAttributes {
+                popover?: boolean;
+                popovertarget?: string;
+                popovertargetaction?: "hide" | "show" | "toggle";
+            }
+            interface IntrinsicElements {
+                // add your custom elements here, ie:
+                /**
+                 * @example
+                 * ```tsx
+                 * <drop-down trigger="#my-trigger" class="header-menu">
+                 *   <button>Option #1</button>
+                 *   <button>Option #2</button>
+                 * </drop-down>
+                 * ```
+                 */
+                "drop-down": IntrinsicAttributes & {
+                    /**
+                     * A query selector, ie: '#my-trigger'
+                     */
+                    trigger: string;
+                };
+            }
         }
-      }
     }
-  }
 }
-```
+````
 
 Then in your plugin entry point, reference the `jsx.d.ts` file with a triple-slash directive.
 

--- a/site/development/themes.md
+++ b/site/development/themes.md
@@ -103,3 +103,51 @@ export function load(app: Application) {
 ```
 
 [RendererHooks]: https://typedoc.org/api/interfaces/RendererHooks.html
+
+## Registering your own custom elements/attributes
+
+Start by writing a `jsx.d.ts` file somewhere.
+
+```ts
+// src/jsx.d.ts
+import { JSX as TypeDocJSX } from 'typedoc'
+
+declare module 'typedoc' {
+  namespace JSX {
+    namespace JSX {
+      interface IntrinsicAttributes {
+        popover?: boolean
+        popovertarget?: string
+        popovertargetaction?: 'hide' | 'show' | 'toggle'
+      }
+      interface IntrinsicElements {
+        // add your custom elements here, ie:
+        /**
+         * @example
+         * ```tsx
+         * <drop-down trigger="#my-trigger" class="header-menu">
+         *   <button>Option #1</button>
+         *   <button>Option #2</button>
+         * </drop-down>
+         * ```
+         */
+        'drop-down': IntrinsicAttributes & {
+          /**
+           * A query selector, ie: '#my-trigger'
+           */
+          trigger: string
+        }
+      }
+    }
+  }
+}
+```
+
+Then in your plugin entry point, reference the `jsx.d.ts` file with a triple-slash directive.
+
+```ts
+// src/index.ts
+/// <reference types="./jsx.d.ts" />
+
+export function load(app: Application) { … }
+```

--- a/src/lib/utils/jsx.elements.ts
+++ b/src/lib/utils/jsx.elements.ts
@@ -192,12 +192,12 @@ export interface JsxHtmlGlobalProps {
      *
      * See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for more details
      */
-    popover?: boolean | 'auto' | 'manual'
+    popover?: boolean | "auto" | "manual";
     /**
      * It must be the popover element id, see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
      */
-    popovertarget?: string
-    popovertargetaction?: 'hide' | 'show' | 'toggle'
+    popovertarget?: string;
+    popovertargetaction?: "hide" | "show" | "toggle";
 }
 
 /**

--- a/src/lib/utils/jsx.elements.ts
+++ b/src/lib/utils/jsx.elements.ts
@@ -185,6 +185,19 @@ export interface JsxHtmlGlobalProps {
     tabIndex?: number;
     title?: string;
     translate?: boolean;
+
+    // popover attributes
+    /**
+     * Default: 'auto'. true and 'auto' are equivalent
+     *
+     * See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for more details
+     */
+    popover?: boolean | 'auto' | 'manual'
+    /**
+     * It must be the popover element id, see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
+     */
+    popovertarget?: string
+    popovertargetaction?: 'hide' | 'show' | 'toggle'
 }
 
 /**

--- a/src/lib/utils/jsx.ts
+++ b/src/lib/utils/jsx.ts
@@ -51,7 +51,11 @@ export function Raw(_props: { html: string }) {
  * @hidden
  */
 export declare namespace JSX {
-    export { IntrinsicElements, JsxElement as Element, JsxHtmlGlobalProps as IntrinsicAttributes };
+    export {
+        IntrinsicElements,
+        JsxElement as Element,
+        JsxHtmlGlobalProps as IntrinsicAttributes,
+    };
 }
 
 const voidElements = new Set([

--- a/src/lib/utils/jsx.ts
+++ b/src/lib/utils/jsx.ts
@@ -20,6 +20,7 @@ import type {
     JsxElement,
     JsxChildren,
     JsxComponent,
+    JsxHtmlGlobalProps,
 } from "./jsx.elements.js";
 import { JsxFragment } from "./jsx.elements.js";
 
@@ -50,7 +51,7 @@ export function Raw(_props: { html: string }) {
  * @hidden
  */
 export declare namespace JSX {
-    export { IntrinsicElements, JsxElement as Element };
+    export { IntrinsicElements, JsxElement as Element, JsxHtmlGlobalProps as IntrinsicAttributes };
 }
 
 const voidElements = new Set([


### PR DESCRIPTION
Hey folks!

I would like to start by thanking you for this amazing package 🙏. To be honest, so far I have always avoided using TypeDoc only because I never found a theme that I liked, so I figured I'd build one!
And here is ➡️ https://github.com/SacDeNoeuds/typedoc-unhoax-theme/

I tried covering as much stuff as I could, if you find anything that needs updating I'm all ears 😊 

Anyway, in the process of making the theme, I wanted to use the (quite new) [popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) and figured I could not extend the JSX namespace, hence this PR.

The content:
- Exposing the `JsxHtmlGlobalProps` interface under `JSX.IntrinsicAttributes`.
- Documenting how to add your custom elements/attributes as plugin developer.
- Adding the popover attributes to the `JsxHtmlGlobalProps` interface.

I hope it helps.