### PR TITLE
chore: remove internal comment from jsdoc

### DIFF
--- a/src/lib/utils/options/readers/typedoc.ts
+++ b/src/lib/utils/options/readers/typedoc.ts
@@ -14,10 +14,9 @@ import type { TranslatedString } from "../../../internationalization/internation
 
 /**
  * Obtains option values from typedoc.json
- *
- * Changes need to happen here at some point. I think we should follow ESLint's new config
- * system eventually: https://eslint.org/blog/2022/08/new-config-system-part-1/
  */
+// Changes need to happen here at some point. I think we should follow ESLint's new config
+// system eventually: https://eslint.org/blog/2022/08/new-config-system-part-1/
 export class TypeDocReader implements OptionsReader {
     /**
      * Should run before the tsconfig reader so that it can specify a tsconfig file to read.


### PR DESCRIPTION
Removes the following comment from jsdoc

> Changes need to happen here at some point. I think we should follow ESLint's new config system eventually: [https://eslint.org/blog/2022/08/new-config-system-part-1/](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)

![image](https://github.com/user-attachments/assets/357d9be6-0a4b-4326-b3d7-dba92fc6cb25)
