### PR TITLE
Watch documents, readme, and CSS (#2675)

### DIFF
--- a/bin/typedoc
+++ b/bin/typedoc
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 //@ts-check
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-import("../dist/lib/cli.js");
+const { fork } = require("child_process");
+
+function main() {
+    fork(__dirname + "/../dist/lib/cli.js", process.argv.slice(2), {
+        stdio: "inherit",
+    }).on("exit", (code) => {
+        // Watch restart required? Fork a new child
+        if (code === 7) main();
+        else process.exit(code || 0);
+    });
+}
+
+main();

--- a/site/options/other.md
+++ b/site/options/other.md
@@ -18,16 +18,6 @@ configuration files, files imported by `@include`/`@includeCode`, and any
 files explicitly registered by plugins as needing to be watched, as well
 as all your TypeScript source files.
 
-Note, however, that if you are defining your typedoc configuration using an ESM
-module (`.mjs`, or `.js` in a `"type": "module"` project) on Windows, typedoc
-will not be able to reload it when it changes, due to the way node's import
-caching works on Windows. (And if your configuration files import or require
-other modules, those modules won't be reloaded either, regardless of platform!)
-
-In such cases, you'll need to either switch to a .cjs file, manually restart
-the build, or use an external watcher like `onchange` to restart typedoc when
-relevant files change.
-
 ## preserveWatchOutput
 
 ```bash

--- a/site/options/other.md
+++ b/site/options/other.md
@@ -13,9 +13,20 @@ $ typedoc --watch
 Use TypeScript's incremental compiler to watch source files for changes and
 build the docs on change. May be combined with `--emit`.
 
-Note: This mode will only detect changes to files watched by the TypeScript
-compiler. Changes to other files (`README.md`, imported files with `@include` or
-`@includeCode`) will not cause a rebuild.
+This mode detects changes to project documents, readme, custom JS/CSS,
+configuration files, files imported by `@include`/`@includeCode`, and any
+files explicitly registered by plugins as needing to be watched, as well
+as all your TypeScript source files.
+
+Note, however, that if you are defining your typedoc configuration using an ESM
+module (`.mjs`, or `.js` in a `"type": "module"` project) on Windows, typedoc
+will not be able to reload it when it changes, due to the way node's import
+caching works on Windows.  (And if your configuration files import or require
+other modules, those modules won't be reloaded either, regardless of platform!)
+
+In such cases, you'll need to either switch to a .cjs file, manually restart
+the build, or use an external watcher like `onchange` to restart typedoc when
+relevant files change.
 
 ## preserveWatchOutput
 

--- a/site/options/other.md
+++ b/site/options/other.md
@@ -21,7 +21,7 @@ as all your TypeScript source files.
 Note, however, that if you are defining your typedoc configuration using an ESM
 module (`.mjs`, or `.js` in a `"type": "module"` project) on Windows, typedoc
 will not be able to reload it when it changes, due to the way node's import
-caching works on Windows.  (And if your configuration files import or require
+caching works on Windows. (And if your configuration files import or require
 other modules, those modules won't be reloaded either, regardless of platform!)
 
 In such cases, you'll need to either switch to a .cjs file, manually restart

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -552,7 +552,7 @@ export class Application extends AbstractComponent<
             this.logger.verbose(
                 `Watching ${nicePath(path)}, shouldRestart=${shouldRestart}`,
             );
-            if (!this.watchers.has(path)) return;
+            if (this.watchers.has(path)) return;
             this.watchers.set(
                 path,
                 host.watchFile(

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -506,7 +506,7 @@ export class Application extends AbstractComponent<
 
         let successFinished = true;
         let currentProgram: ts.Program | undefined;
-        let watches: ts.FileWatcher[] = []
+        let watches: ts.FileWatcher[] = [];
 
         const runSuccess = () => {
             if (!currentProgram) {
@@ -529,24 +529,27 @@ export class Application extends AbstractComponent<
                     return;
                 }
                 const project = this.converter.convert(entryPoints);
-                watches.forEach(w => w.close())
-                watches = []
+                watches.forEach((w) => w.close());
+                watches = [];
                 const lastProgram = currentProgram;
-                const addWatch = (path: string) => void watches.push(host.watchFile(path, () => {
-                    if (!currentProgram) {
-                        currentProgram = lastProgram
-                        if (successFinished) runSuccess()
-                    }
-                }))
-                for(const d of project.documents || []) {
-                    const path = project.files.getReflectionPath(d)
-                    if (path) addWatch(path)
+                const addWatch = (path: string) =>
+                    void watches.push(
+                        host.watchFile(path, () => {
+                            if (!currentProgram) {
+                                currentProgram = lastProgram;
+                                if (successFinished) runSuccess();
+                            }
+                        }),
+                    );
+                for (const d of project.documents || []) {
+                    const path = project.files.getReflectionPath(d);
+                    if (path) addWatch(path);
                 }
-                const css = this.options.getValue("customCss")
-                if (css) addWatch(css)
-                const js = this.options.getValue("customJs")
-                if (js) addWatch(js)
-                if (project.readmeFile) addWatch(project.readmeFile)
+                const css = this.options.getValue("customCss");
+                if (css) addWatch(css);
+                const js = this.options.getValue("customJs");
+                if (js) addWatch(js);
+                if (project.readmeFile) addWatch(project.readmeFile);
                 currentProgram = undefined;
                 successFinished = false;
                 void success(project).then(() => {

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -445,7 +445,7 @@ export class Application extends AbstractComponent<
     /**
      * Register that the current build depends on a file, so that in watch mode
      * the build will be repeated.  Has no effect if a watch build is not
-     * running.
+     * running, or if the file has already been registered.
      *
      * @param path The file to watch.  It does not need to exist, and you should
      * in fact register files you look for, but which do not exist, so that if
@@ -550,9 +550,9 @@ export class Application extends AbstractComponent<
 
         this._watchFile = (path: string, shouldRestart = false) => {
             this.logger.verbose(
-                `Watching ${path}, shouldRestart=${shouldRestart}`,
+                `Watching ${nicePath(path)}, shouldRestart=${shouldRestart}`,
             );
-            this.watchers.get(path)?.close();
+            if (!this.watchers.has(path)) return;
             this.watchers.set(
                 path,
                 host.watchFile(

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -32,8 +32,8 @@ async function main() {
         if (exitCode !== ExitCodes.Watching) {
             app.logger.verbose(`Full run took ${Date.now() - start}ms`);
             logRunSummary(app.logger);
-            process.exit(exitCode);
         }
+        process.exit(exitCode);
     } catch (error) {
         console.error("TypeDoc exiting with unexpected error:");
         console.error(error);
@@ -73,11 +73,12 @@ async function run(app: td.Application) {
     }
 
     if (app.options.getValue("watch")) {
-        app.convertAndWatch(async (project) => {
+        return (await app.convertAndWatch(async (project) => {
             app.validate(project);
             await app.generateOutputs(project);
-        }, main);
-        return ExitCodes.Watching;
+        }))
+            ? ExitCodes.Watching
+            : ExitCodes.OptionError;
     }
 
     const project = await app.convert();

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -76,7 +76,7 @@ async function run(app: td.Application) {
         app.convertAndWatch(async (project) => {
             app.validate(project);
             await app.generateOutputs(project);
-        });
+        }, main);
         return ExitCodes.Watching;
     }
 

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -676,6 +676,7 @@ export class Converter extends AbstractComponent<Application, ConverterEvents> {
             frontmatter,
         );
 
+        this.application.watchFile(file.fileName);
         parent.addChild(docRefl);
         parent.project.registerReflection(docRefl, undefined, file.fileName);
         this.trigger(ConverterEvents.CREATE_DOCUMENT, undefined, docRefl);

--- a/src/lib/converter/plugins/IncludePlugin.ts
+++ b/src/lib/converter/plugins/IncludePlugin.ts
@@ -63,6 +63,7 @@ export class IncludePlugin extends ConverterComponent {
             }
 
             const file = path.resolve(relative, part.text.trim());
+            this.application.watchFile(file);
             if (included.includes(file) && part.tag === "@include") {
                 this.logger.error(
                     this.logger.i18n.include_0_in_1_specified_2_circular_include_3(
@@ -73,7 +74,6 @@ export class IncludePlugin extends ConverterComponent {
                     ),
                 );
             } else if (isFile(file)) {
-                this.application.watchFile(file);
                 const text = fs.readFileSync(file, "utf-8");
                 if (part.tag === "@include") {
                     const sf = new MinimalSourceFile(text, file);

--- a/src/lib/converter/plugins/IncludePlugin.ts
+++ b/src/lib/converter/plugins/IncludePlugin.ts
@@ -73,6 +73,7 @@ export class IncludePlugin extends ConverterComponent {
                     ),
                 );
             } else if (isFile(file)) {
+                this.application.watchFile(file);
                 const text = fs.readFileSync(file, "utf-8");
                 if (part.tag === "@include") {
                     const sf = new MinimalSourceFile(text, file);

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -135,7 +135,7 @@ export class PackagePlugin extends ConverterComponent {
             );
 
             project.readme = content;
-            project.readmeFile = this.readmeFile;
+            this.application.watchFile(this.readmeFile);
 
             // This isn't ideal, but seems better than figuring out the readme
             // path over in the include plugin...

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -135,6 +135,7 @@ export class PackagePlugin extends ConverterComponent {
             );
 
             project.readme = content;
+            project.readmeFile = this.readmeFile
 
             // This isn't ideal, but seems better than figuring out the readme
             // path over in the include plugin...

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -135,7 +135,7 @@ export class PackagePlugin extends ConverterComponent {
             );
 
             project.readme = content;
-            project.readmeFile = this.readmeFile
+            project.readmeFile = this.readmeFile;
 
             // This isn't ideal, but seems better than figuring out the readme
             // path over in the include plugin...

--- a/src/lib/converter/plugins/PackagePlugin.ts
+++ b/src/lib/converter/plugins/PackagePlugin.ts
@@ -98,6 +98,7 @@ export class PackagePlugin extends ConverterComponent {
 
         if (this.readme) {
             // Readme path provided, read only that file.
+            this.application.watchFile(this.readme);
             try {
                 this.readmeContents = readFile(this.readme);
                 this.readmeFile = this.readme;
@@ -119,6 +120,7 @@ export class PackagePlugin extends ConverterComponent {
             if (result) {
                 this.readmeFile = result.file;
                 this.readmeContents = result.content;
+                this.application.watchFile(this.readmeFile);
             }
         }
     }
@@ -135,7 +137,6 @@ export class PackagePlugin extends ConverterComponent {
             );
 
             project.readme = content;
-            this.application.watchFile(this.readmeFile);
 
             // This isn't ideal, but seems better than figuring out the readme
             // path over in the include plugin...

--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -15,6 +15,11 @@ export = {
         "The provided tsconfig file looks like a solution style tsconfig, which is not supported in watch mode",
     strategy_not_supported_in_watch_mode:
         "entryPointStrategy must be set to either resolve or expand for watch mode",
+    file_0_changed_but_cant_restart:
+        "File {0} changed but no restart callback was given; please restart manually",
+    file_0_changed_restarting:
+        "Configuration file {0} changed: full restart required...",
+    file_0_changed_rebuilding: "File {0} changed: rebuilding output...",
     found_0_errors_and_1_warnings: "Found {0} errors and {1} warnings",
 
     output_0_could_not_be_generated:

--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -15,8 +15,6 @@ export = {
         "The provided tsconfig file looks like a solution style tsconfig, which is not supported in watch mode",
     strategy_not_supported_in_watch_mode:
         "entryPointStrategy must be set to either resolve or expand for watch mode",
-    file_0_changed_but_cant_restart:
-        "File {0} changed but no restart callback was given; please restart manually",
     file_0_changed_restarting:
         "Configuration file {0} changed: full restart required...",
     file_0_changed_rebuilding: "File {0} changed: rebuilding output...",

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -69,11 +69,6 @@ export class ProjectReflection extends ContainerReflection {
     readme?: CommentDisplayPart[];
 
     /**
-     * The path to the readme.md file, if found
-     */
-    readmeFile?: string;
-
-    /**
      * Object which describes where to find content for relative links.
      */
     readonly files: FileRegistry;

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -69,6 +69,11 @@ export class ProjectReflection extends ContainerReflection {
     readme?: CommentDisplayPart[];
 
     /**
+     * The path to the readme.md file, if found
+     */
+    readmeFile?: string
+
+    /**
      * Object which describes where to find content for relative links.
      */
     readonly files: FileRegistry;

--- a/src/lib/models/reflections/project.ts
+++ b/src/lib/models/reflections/project.ts
@@ -71,7 +71,7 @@ export class ProjectReflection extends ContainerReflection {
     /**
      * The path to the readme.md file, if found
      */
-    readmeFile?: string
+    readmeFile?: string;
 
     /**
      * Object which describes where to find content for relative links.

--- a/src/lib/output/plugins/AssetsPlugin.ts
+++ b/src/lib/output/plugins/AssetsPlugin.ts
@@ -52,6 +52,7 @@ export class AssetsPlugin extends RendererComponent {
 
         if (this.customCss) {
             if (existsSync(this.customCss)) {
+                this.application.watchFile(this.customCss);
                 copySync(this.customCss, join(dest, "custom.css"));
             } else {
                 this.application.logger.error(
@@ -64,6 +65,7 @@ export class AssetsPlugin extends RendererComponent {
 
         if (this.customJs) {
             if (existsSync(this.customJs)) {
+                this.application.watchFile(this.customJs);
                 copySync(this.customJs, join(dest, "custom.js"));
             } else {
                 this.application.logger.error(

--- a/src/lib/output/plugins/AssetsPlugin.ts
+++ b/src/lib/output/plugins/AssetsPlugin.ts
@@ -51,8 +51,8 @@ export class AssetsPlugin extends RendererComponent {
         }
 
         if (this.customCss) {
+            this.application.watchFile(this.customCss);
             if (existsSync(this.customCss)) {
-                this.application.watchFile(this.customCss);
                 copySync(this.customCss, join(dest, "custom.css"));
             } else {
                 this.application.logger.error(
@@ -64,8 +64,8 @@ export class AssetsPlugin extends RendererComponent {
         }
 
         if (this.customJs) {
+            this.application.watchFile(this.customJs);
             if (existsSync(this.customJs)) {
-                this.application.watchFile(this.customJs);
                 copySync(this.customJs, join(dest, "custom.js"));
             } else {
                 this.application.logger.error(

--- a/src/lib/utils/options/options.ts
+++ b/src/lib/utils/options/options.ts
@@ -56,8 +56,14 @@ export interface OptionsReader {
      * @param container the options container that provides declarations
      * @param logger logger to be used to report errors
      * @param cwd the directory which should be treated as the current working directory for option file discovery
+     * @param usedFile a callback to track files that were read or whose existence was checked, for purposes of restarting a build when watching files
      */
-    read(container: Options, logger: Logger, cwd: string): void | Promise<void>;
+    read(
+        container: Options,
+        logger: Logger,
+        cwd: string,
+        usedFile: (file: string) => void,
+    ): void | Promise<void>;
 }
 
 const optionSnapshots = new WeakMap<
@@ -194,9 +200,13 @@ export class Options {
         insertOrderSorted(this._readers, reader);
     }
 
-    async read(logger: Logger, cwd = process.cwd()) {
+    async read(
+        logger: Logger,
+        cwd = process.cwd(),
+        usedFile: (path: string) => void = () => {},
+    ) {
         for (const reader of this._readers) {
-            await reader.read(this, logger, cwd);
+            await reader.read(this, logger, cwd, usedFile);
         }
     }
 

--- a/src/lib/utils/options/readers/package-json.ts
+++ b/src/lib/utils/options/readers/package-json.ts
@@ -16,8 +16,13 @@ export class PackageJsonReader implements OptionsReader {
 
     name = "package-json";
 
-    read(container: Options, logger: Logger, cwd: string): void {
-        const result = discoverPackageJson(cwd);
+    read(
+        container: Options,
+        logger: Logger,
+        cwd: string,
+        usedFile: (path: string) => void,
+    ): void {
+        const result = discoverPackageJson(cwd, usedFile);
 
         if (!result) {
             return;

--- a/src/lib/utils/options/readers/tsconfig.ts
+++ b/src/lib/utils/options/readers/tsconfig.ts
@@ -75,10 +75,15 @@ export class TSConfigReader implements OptionsReader {
 
     private seenTsdocPaths = new Set<string>();
 
-    read(container: Options, logger: Logger, cwd: string): void {
+    read(
+        container: Options,
+        logger: Logger,
+        cwd: string,
+        usedFile?: (path: string) => void,
+    ): void {
         const file = container.getValue("tsconfig") || cwd;
 
-        let fileToRead = findTsConfigFile(file);
+        let fileToRead = findTsConfigFile(file, usedFile);
 
         if (!fileToRead) {
             // If the user didn't give us this option, we shouldn't complain about not being able to find it.

--- a/src/lib/utils/options/readers/typedoc.ts
+++ b/src/lib/utils/options/readers/typedoc.ts
@@ -100,7 +100,7 @@ export class TypeDocReader implements OptionsReader {
                     const esmPath = pathToFileURL(file).toString();
                     // Cache-bust for reload on watch
                     fileContent = await (
-                        await import(esmPath + "?" + Date.now())
+                        await import(`${esmPath}?${Date.now()}`)
                     ).default;
                 }
             } catch (error) {

--- a/src/lib/utils/tsconfig.ts
+++ b/src/lib/utils/tsconfig.ts
@@ -3,10 +3,16 @@ import { isFile, isDir, readFile } from "./fs.js";
 import type { Logger } from "./loggers.js";
 import { createRequire } from "module";
 
-export function findTsConfigFile(path: string): string | undefined {
+export function findTsConfigFile(
+    path: string,
+    usedFile?: (path: string) => void,
+): string | undefined {
     let fileToRead: string | undefined = path;
     if (isDir(fileToRead)) {
-        fileToRead = ts.findConfigFile(path, isFile);
+        fileToRead = ts.findConfigFile(
+            path,
+            (file) => (usedFile?.(file), isFile(file)),
+        );
     }
 
     if (!fileToRead || !isFile(fileToRead)) {


### PR DESCRIPTION
This PR is a proof-of-concept for enhanced watch support, covering:

- Project README
- Project documents
- Custom CSS file
- Custom JS file
- Config files
- `@include`/`@includeCode` files
- package.json
- Anything registered by plugins as a file to watch

with both soft and hard restarts.

It does *not* currently support:

- Reloading changed plugins
- Reloading modules imported or require'd from within config files
- Reloading ESM config files on Windows

