### PR TITLE
Deprecate "jp"

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -297,6 +297,11 @@ export class Application extends AbstractComponent<
             this.logger.info(
                 "You can define/override local locales with the `locales` option, or contribute them to TypeDoc!" as TranslatedString,
             );
+} else if (this.lang === "jp") {
+            this.logger.warn(
+                // Only Japanese see this. Meaning: "jp" is going to be removed in the future. Please designate "ja" instead.
+                "「jp」は将来削除されます。代わりに「ja」を指定してください。" as TranslatedString,
+            );
         }
 
         if (

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -286,10 +286,10 @@ export class Application extends AbstractComponent<
         if (!this.internationalization.hasTranslations(this.lang)) {
             // Not internationalized as by definition we don't know what to include here.
             this.logger.warn(
-                `Options specified "${this.lang}" as the language to use, but TypeDoc does not support it.` as TranslatedString,
+                `Options specified "${this.lang}" as the language to use, but TypeDoc cannot provide translations for it.` as TranslatedString,
             );
             this.logger.info(
-                ("The supported languages are:\n\t" +
+                ("The languages that translations are available for are:\n\t" +
                     this.internationalization
                         .getSupportedLanguages()
                         .join("\n\t")) as TranslatedString,
@@ -297,7 +297,7 @@ export class Application extends AbstractComponent<
             this.logger.info(
                 "You can define/override local locales with the `locales` option, or contribute them to TypeDoc!" as TranslatedString,
             );
-} else if (this.lang === "jp") {
+        } else if (this.lang === "jp") {
             this.logger.warn(
                 // Only Japanese see this. Meaning: "jp" is going to be removed in the future. Please designate "ja" instead.
                 "「jp」は将来削除されます。代わりに「ja」を指定してください。" as TranslatedString,

--- a/src/lib/internationalization/internationalization.ts
+++ b/src/lib/internationalization/internationalization.ts
@@ -302,9 +302,9 @@ export class Internationalization {
      */
     getSupportedLanguages(): string[] {
         return unique([
-            ...readdirSync(
-                join(fileURLToPath(import.meta.url), "../locales"),
-            ).map((x) => x.substring(0, x.indexOf("."))),
+            ...readdirSync(join(fileURLToPath(import.meta.url), "../locales"))
+                .map((x) => x.substring(0, x.indexOf(".")))
+                .filter((x) => x !== "jp"),
             ...this.allTranslations.keys(),
         ]).sort();
     }


### PR DESCRIPTION
- Hide "jp" from available languages
- Add Japanese messages for those who chose "jp" instead of "ja" (you can remove them after it turns to be unnecessary)
- Tweak message for unsupported languages (doesn't support → can't provide translations)