### PR TITLE
Fix `undefined` hrefs for excluded external refs

### DIFF
--- a/src/lib/output/themes/MarkedPlugin.tsx
+++ b/src/lib/output/themes/MarkedPlugin.tsx
@@ -179,11 +179,13 @@ export class MarkedPlugin extends ContextAwareRendererComponent {
                                 if (useHtml) {
                                     const text = part.tag === "@linkcode" ? `<code>${part.text}</code>` : part.text;
                                     result.push(
-                                        `<a href="${url}"${kindClass ? ` class="${kindClass}"` : ""}>${text}</a>`,
+                                        url
+                                            ? `<a href="${url}"${kindClass ? ` class="${kindClass}"` : ""}>${text}</a>`
+                                            : part.text,
                                     );
                                 } else {
                                     const text = part.tag === "@linkcode" ? "`" + part.text + "`" : part.text;
-                                    result.push(`[${text}](${url})`);
+                                    result.push(url ? `[${text}](${url})` : text);
                                 }
                             } else {
                                 result.push(part.text);


### PR DESCRIPTION
See #2853.  This fixes the broken links part by putting back in the undefined checks that were removed in 0.27.5.
