### PR TITLE
Don't warn for excluded external links in comments

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -689,7 +689,11 @@ export class Application extends AbstractComponent<
         }
 
         if (checks.invalidLink) {
-            validateLinks(project, this.logger);
+            validateLinks(
+                project,
+                this.logger,
+                this.options.getValue("excludeExternals"),
+            );
         }
 
         if (checks.unusedMergeModuleWith) {

--- a/src/test/converter2/issues/gh2853.ts
+++ b/src/test/converter2/issues/gh2853.ts
@@ -1,0 +1,4 @@
+/**
+ * {@link Generator}
+ */
+export const bug = 123;

--- a/src/test/issues.c2.test.ts
+++ b/src/test/issues.c2.test.ts
@@ -1728,6 +1728,7 @@ describe("Issue Tests", () => {
         const project = convert();
         app.options.setValue("validation", false);
         app.options.setValue("validation", { invalidLink: true });
+        app.options.setValue("excludeExternals", false);
         app.validate(project);
         logger.expectMessage(
             'warn: Failed to resolve link to "Generator" in comment for bug',
@@ -1788,6 +1789,7 @@ describe("Issue Tests", () => {
 
     it("#2700a correctly parses links to global properties", () => {
         const project = convert();
+        app.options.setValue("excludeExternals", false);
         app.options.setValue("validation", {
             invalidLink: true,
             notDocumented: false,
@@ -2030,6 +2032,17 @@ describe("Issue Tests", () => {
         equal(
             url.children?.map((c) => c.name),
             ["customMethod"],
+        );
+    });
+
+    it("#2853 no warnings on @link tags to excluded externals", () => {
+        const project = convert();
+        app.options.setValue("validation", false);
+        app.options.setValue("validation", { invalidLink: true });
+        app.options.setValue("excludeExternals", true);
+        app.validate(project);
+        logger.expectNoMessage(
+            'warn: Failed to resolve link to "Generator" in comment for bug',
         );
     });
 });


### PR DESCRIPTION
Warnings are still generated for non-working links in non-comment sources, since those won't be resolved by VSCode.  But comment links aren't warned about if externals are excluded. (#2853)

(I'm not sure whether this is the proper solution, my view of things is way too narrow.  So any feedback you can offer here would be great.)