### PR TITLE
test merge

### DIFF
--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -537,6 +537,6 @@ export = {
     theme_hierarchy_expand: "Expand",
     theme_hierarchy_collapse: "Collapse",
     theme_search_index_not_available: "The search index is not available",
-    theme_search_no_results_found_for: "No results found for", // for <search query>
+    theme_search_no_results_found_for_0: "No results found for {0}",
     theme_search_placeholder: "Search the docs",
 } as const;

--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -537,6 +537,6 @@ export = {
     theme_hierarchy_expand: "Expand",
     theme_hierarchy_collapse: "Collapse",
     theme_search_index_not_available: "The search index is not available",
-    theme_search_no_results: "No results found",
+    theme_search_no_results_found_for: "No results found for", // for <search query>
     theme_search_placeholder: "Search the docs",
 } as const;

--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -539,5 +539,4 @@ export = {
     theme_search_index_not_available: "The search index is not available",
     theme_search_no_results: "No results found",
     theme_search_placeholder: "Search the docs",
-    theme_search_no_recent_searches: "No recent searches",
 } as const;

--- a/src/lib/internationalization/locales/en.cts
+++ b/src/lib/internationalization/locales/en.cts
@@ -509,7 +509,6 @@ export = {
     theme_generated_using_typedoc: "Generated using TypeDoc", // If this includes "TypeDoc", theme will insert a link at that location.
     // Search
     theme_preparing_search_index: "Preparing search index...",
-    theme_search_index_not_available: "The search index is not available",
     // Left nav bar
     theme_loading: "Loading...",
     // Right nav bar
@@ -537,4 +536,8 @@ export = {
         "This member is normally hidden due to your filter settings.",
     theme_hierarchy_expand: "Expand",
     theme_hierarchy_collapse: "Collapse",
+    theme_search_index_not_available: "The search index is not available",
+    theme_search_no_results: "No results found",
+    theme_search_placeholder: "Search the docs",
+    theme_search_no_recent_searches: "No recent searches",
 } as const;

--- a/src/lib/output/plugins/AssetsPlugin.ts
+++ b/src/lib/output/plugins/AssetsPlugin.ts
@@ -43,8 +43,10 @@ export class AssetsPlugin extends RendererComponent {
             folder: i18n.theme_folder(),
             theme_search_index_not_available:
                 this.application.i18n.theme_search_index_not_available(),
-            theme_search_no_results_found_for:
-                this.application.i18n.theme_search_no_results_found_for(),
+            theme_search_no_results_found_for_0:
+                this.application.i18n.theme_search_no_results_found_for_0(
+                    "{0}",
+                ),
         };
 
         for (const key of getEnumKeys(ReflectionKind)) {

--- a/src/lib/output/plugins/AssetsPlugin.ts
+++ b/src/lib/output/plugins/AssetsPlugin.ts
@@ -43,8 +43,8 @@ export class AssetsPlugin extends RendererComponent {
             folder: i18n.theme_folder(),
             theme_search_index_not_available:
                 this.application.i18n.theme_search_index_not_available(),
-            theme_search_no_results:
-                this.application.i18n.theme_search_no_results(),
+            theme_search_no_results_found_for:
+                this.application.i18n.theme_search_no_results_found_for(),
         };
 
         for (const key of getEnumKeys(ReflectionKind)) {

--- a/src/lib/output/plugins/AssetsPlugin.ts
+++ b/src/lib/output/plugins/AssetsPlugin.ts
@@ -41,6 +41,10 @@ export class AssetsPlugin extends RendererComponent {
             hierarchy_expand: i18n.theme_hierarchy_expand(),
             hierarchy_collapse: i18n.theme_hierarchy_collapse(),
             folder: i18n.theme_folder(),
+            theme_search_index_not_available:
+                this.application.i18n.theme_search_index_not_available(),
+            theme_search_no_results:
+                this.application.i18n.theme_search_no_results(),
         };
 
         for (const key of getEnumKeys(ReflectionKind)) {

--- a/src/lib/output/themes/default/assets/bootstrap.ts
+++ b/src/lib/output/themes/default/assets/bootstrap.ts
@@ -26,3 +26,8 @@ Object.defineProperty(window, "app", { value: app });
 initSearch();
 initNav();
 initHierarchy();
+
+if ("virtualKeyboard" in navigator) {
+    // @ts-ignore
+    navigator.virtualKeyboard.overlaysContent = true;
+}

--- a/src/lib/output/themes/default/assets/typedoc/Application.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Application.ts
@@ -12,6 +12,8 @@ declare global {
             // Kind strings for icons
             folder: string;
             [k: `kind_${number}`]: string;
+            theme_search_index_not_available: string;
+            theme_search_no_results: string;
         };
     }
 }
@@ -50,6 +52,8 @@ window.translations ||= {
     kind_2097152: "Type Alias",
     kind_4194304: "Reference",
     kind_8388608: "Document",
+    theme_search_index_not_available: "The search index is not available",
+    theme_search_no_results: "No results found",
 };
 
 /**

--- a/src/lib/output/themes/default/assets/typedoc/Application.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Application.ts
@@ -13,7 +13,7 @@ declare global {
             folder: string;
             [k: `kind_${number}`]: string;
             theme_search_index_not_available: string;
-            theme_search_no_results_found_for: string;
+            theme_search_no_results_found_for_0: string;
         };
     }
 }
@@ -53,7 +53,7 @@ window.translations ||= {
     kind_4194304: "Reference",
     kind_8388608: "Document",
     theme_search_index_not_available: "The search index is not available",
-    theme_search_no_results_found_for: "No results found for",
+    theme_search_no_results_found_for_0: "No results found for {0}",
 };
 
 /**

--- a/src/lib/output/themes/default/assets/typedoc/Application.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Application.ts
@@ -13,7 +13,7 @@ declare global {
             folder: string;
             [k: `kind_${number}`]: string;
             theme_search_index_not_available: string;
-            theme_search_no_results: string;
+            theme_search_no_results_found_for: string;
         };
     }
 }
@@ -53,7 +53,7 @@ window.translations ||= {
     kind_4194304: "Reference",
     kind_8388608: "Document",
     theme_search_index_not_available: "The search index is not available",
-    theme_search_no_results: "No results found",
+    theme_search_no_results_found_for: "No results found for",
 };
 
 /**

--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -241,14 +241,14 @@ function updateResults(
         const row = state.data.rows[Number(res[i].ref)];
         const icon = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" class="tsd-kind-icon"><use href="#icon-${row.kind}"></use></svg>`;
 
-        // Bold the matched part of the query in the search results
-        let name = boldMatches(row.name, searchText);
+        // Highlight the matched part of the query in the search results
+        let name = highlightMatches(row.name, searchText);
         if (globalThis.DEBUG_SEARCH_WEIGHTS) {
             name += ` (score: ${res[i].score.toFixed(2)})`;
         }
         if (row.parent) {
             name = `<span class="parent">
-                ${boldMatches(row.parent, searchText)}.</span>${name}`;
+                ${highlightMatches(row.parent, searchText)}.</span>${name}`;
         }
 
         const item = document.createElement("li");
@@ -305,7 +305,7 @@ function removeVisualFocus(field: HTMLInputElement) {
     field.setAttribute("aria-activedescendant", "");
 }
 
-function boldMatches(text: string, search: string) {
+function highlightMatches(text: string, search: string) {
     if (search === "") {
         return text;
     }
@@ -319,9 +319,9 @@ function boldMatches(text: string, search: string) {
     while (index != -1) {
         parts.push(
             escapeHtml(text.substring(lastIndex, index)),
-            `<b>${escapeHtml(
+            `<mark>${escapeHtml(
                 text.substring(index, index + lowerSearch.length),
-            )}</b>`,
+            )}</mark>`,
         );
 
         lastIndex = index + lowerSearch.length;

--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -147,10 +147,10 @@ function bindEvents(
                 current?.querySelector("a")?.click();
                 break;
             case "ArrowUp":
-                setCurrentResult(results, field, current, -1);
+                setNextResult(results, field, current, -1);
                 break;
             case "ArrowDown":
-                setCurrentResult(results, field, current, 1);
+                setNextResult(results, field, current, 1);
                 break;
         }
     });
@@ -271,7 +271,7 @@ function updateResults(
 /**
  * Move the highlight within the result set.
  */
-function setCurrentResult(
+function setNextResult(
     results: HTMLElement,
     field: HTMLInputElement,
     current: Element | null,

--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -46,19 +46,12 @@ let resultCount = 0;
 async function updateIndex(state: SearchState, results: HTMLElement) {
     if (!window.searchData) return;
 
-    try {
-        const data: IData = await decompressJson(window.searchData);
+    const data: IData = await decompressJson(window.searchData);
 
-        state.data = data;
-        state.index = Index.load(data.index);
+    state.data = data;
+    state.index = Index.load(data.index);
 
-        results.querySelector("li.state")?.remove();
-    } catch (e) {
-        console.error(e);
-        const message = window.translations.theme_search_index_not_available;
-        const stateEl = createStateEl(message);
-        results.replaceChildren(stateEl);
-    }
+    results.querySelector("li.state")?.remove();
 }
 
 export function initSearch() {
@@ -126,7 +119,7 @@ function bindEvents(
 
         // Get the visually focused element, if any
         const currentId = field.getAttribute("aria-activedescendant");
-        const current = document.getElementById(currentId || "");
+        const current = currentId ? document.getElementById(currentId) : null;
 
         // Remove visual focus on cursor position change
         if (current) {
@@ -295,7 +288,7 @@ function setNextResult(
 
 function removeVisualFocus(field: HTMLInputElement) {
     const currentId = field.getAttribute("aria-activedescendant");
-    const current = document.getElementById(currentId || "");
+    const current = currentId ? document.getElementById(currentId) : null;
 
     current?.setAttribute("aria-selected", "false");
     field.setAttribute("aria-activedescendant", "");

--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -1,7 +1,7 @@
 import { debounce } from "../utils/debounce.js";
 import { Index } from "lunr";
 import { decompressJson } from "../utils/decompress.js";
-import { hideScrollbar, resetScrollbar } from "../utils/modal.js";
+import { openModal, setUpModal } from "../utils/modal.js";
 
 /**
  * Keep this in sync with the interface in src/lib/output/plugins/JavascriptIndexPlugin.ts
@@ -108,10 +108,9 @@ function bindEvents(
     field: HTMLInputElement,
     state: SearchState,
 ) {
-    trigger.addEventListener("click", () => openModal(searchEl));
+    setUpModal(searchEl, "fade-out", { closeOnClick: true });
 
-    searchEl.addEventListener("close", resetScrollbar);
-    searchEl.addEventListener("cancel", resetScrollbar);
+    trigger.addEventListener("click", () => openModal(searchEl));
 
     field.addEventListener(
         "input",
@@ -172,12 +171,6 @@ function bindEvents(
             openModal(searchEl);
         }
     });
-}
-
-function openModal(searchEl: HTMLDialogElement) {
-    if (searchEl.open) return;
-    hideScrollbar();
-    searchEl.showModal();
 }
 
 function updateResults(

--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -2,7 +2,6 @@ import { debounce } from "../utils/debounce.js";
 import { Index } from "lunr";
 import { decompressJson } from "../utils/decompress.js";
 import { openModal, setUpModal } from "../utils/modal.js";
-import { storage } from "../utils/storage.js";
 
 /**
  * Keep this in sync with the interface in src/lib/output/plugins/JavascriptIndexPlugin.ts
@@ -40,17 +39,6 @@ let optionsIdCounter = 0;
 
 let resultCount = 0;
 
-/** Omit `matchData` for compatibility with recent searches */
-type PartialSearch = Omit<Index.Result, "matchData">;
-
-/**
- * Recent search result (which were clicked).
- * Recent searches have their score value set to `0`.
- *
- * Max length: 3
- */
-let recentSearches: PartialSearch[] = [];
-
 /**
  * Populates search data into `state`, if available.
  * Removes deault loading message
@@ -65,8 +53,6 @@ async function updateIndex(state: SearchState, results: HTMLElement) {
         state.index = Index.load(data.index);
 
         results.querySelector("li.state")?.remove();
-        recentSearches = parseRecentSearches();
-        updateResults(results, "", state);
     } catch (e) {
         console.error(e);
         const message = window.translations.theme_search_index_not_available;
@@ -129,7 +115,7 @@ function bindEvents(
     field.addEventListener(
         "input",
         debounce(() => {
-            updateResults(results, field.value.trim(), state);
+            updateResults(results, field, state);
         }, 200),
     );
 
@@ -185,33 +171,11 @@ function bindEvents(
             openModal(searchEl);
         }
     });
-
-    // Track the option being selected
-    results.addEventListener("click", (e) => {
-        const target = (e.target as HTMLElement).closest(
-            'li[role="option"]',
-        ) as HTMLLinkElement | null;
-        if (!target) return;
-
-        const ref = target.dataset.ref || "";
-        const previousIndex = recentSearches.findIndex((el) => el.ref === ref);
-        if (previousIndex === -1) {
-            recentSearches.unshift({ ref, score: 0 });
-        } else if (previousIndex !== 0) {
-            const prev = recentSearches.splice(previousIndex, 1)[0];
-            recentSearches.unshift(prev);
-        }
-
-        if (recentSearches.length > 3) {
-            recentSearches.pop();
-        }
-        setRecentSearches(recentSearches);
-    });
 }
 
 function updateResults(
     results: HTMLElement,
-    searchText: string,
+    query: HTMLInputElement,
     state: SearchState,
 ) {
     // Don't clear results if loading state is not ready,
@@ -221,8 +185,10 @@ function updateResults(
     results.innerHTML = "";
     optionsIdCounter += 1;
 
+    const searchText = query.value.trim();
+
     // Perform a wildcard search
-    let res: PartialSearch[];
+    let res: Index.Result[];
     if (searchText) {
         // Create a wildcard out of space-separated words in the query,
         // ignoring any extra spaces
@@ -234,36 +200,38 @@ function updateResults(
             .join(" ");
         res = state.index.search(searchWithWildcards);
     } else {
-        // Set res as the recent searches
+        // Set empty `res` to prevent getting random results with wildcard search
         // when the `searchText` is empty.
-        res = recentSearches;
+        res = [];
     }
 
     resultCount = res.length;
 
-    if (searchText) {
-        for (let i = 0; i < res.length; i++) {
-            const item = res[i];
-            const row = state.data.rows[Number(item.ref)];
-            let boost = 1;
+    if (res.length === 0) {
+        const item = createStateEl(window.translations.theme_search_no_results);
+        results.appendChild(item);
+        return;
+    }
 
-            // boost by exact match on name
-            if (row.name.toLowerCase().startsWith(searchText.toLowerCase())) {
-                boost *=
-                    1 + 1 / (1 + Math.abs(row.name.length - searchText.length));
-            }
+    for (let i = 0; i < res.length; i++) {
+        const item = res[i];
+        const row = state.data.rows[Number(item.ref)];
+        let boost = 1;
 
-            item.score *= boost;
+        // boost by exact match on name
+        if (row.name.toLowerCase().startsWith(searchText.toLowerCase())) {
+            boost *=
+                1 + 1 / (1 + Math.abs(row.name.length - searchText.length));
         }
 
-        res.sort((a, b) => b.score - a.score);
+        item.score *= boost;
     }
+
+    res.sort((a, b) => b.score - a.score);
 
     const c = Math.min(10, res.length);
     for (let i = 0; i < c; i++) {
         const row = state.data.rows[Number(res[i].ref)];
-        // Ref could be invalid when dealing with localStorage values
-        if (!row) continue;
         const icon = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" class="tsd-kind-icon"><use href="#icon-${row.kind}"></use></svg>`;
 
         // Highlight the matched part of the query in the search results
@@ -280,7 +248,6 @@ function updateResults(
         item.id = `tsd-search:${optionsIdCounter}-${i}`;
         item.role = "option";
         item.ariaSelected = "false";
-        item.dataset.ref = res[i].ref;
         item.classList.value = row.classes ?? "";
 
         const anchor = document.createElement("a");
@@ -291,15 +258,6 @@ function updateResults(
         item.append(anchor);
 
         results.appendChild(item);
-    }
-
-    if (results.childElementCount === 0) {
-        const message = searchText
-            ? window.translations.theme_search_no_results
-            : window.translations.theme_search_no_recent_searches;
-        const item = createStateEl(message);
-        results.appendChild(item);
-        return;
     }
 }
 
@@ -430,45 +388,5 @@ function isKeyboardActive() {
     return (
         activeElement.tagName === "INPUT" &&
         !inputWithoutKeyboard.includes((activeElement as HTMLInputElement).type)
-    );
-}
-
-/**
- * Gets recent searches from localStorage, parses, and returns
- *
- * This implementation in "unforgiving",
- * i.e. the parsed value must match the criteria: string array of length <= 3
- *
- * Returns empty array in case of failure
- * @returns
- */
-function parseRecentSearches() {
-    try {
-        const recent = storage.getItem("tsd-search-recent")!;
-        const parsed = JSON.parse(recent);
-        if (Array.isArray(parsed) && parsed.length <= 3) {
-            return parsed.map((ref) => {
-                if (isNaN(Number(ref))) throw new Error("Invalid ref");
-
-                return {
-                    ref,
-                    score: 0,
-                } satisfies PartialSearch;
-            });
-        }
-        return [];
-    } catch {
-        return [];
-    }
-}
-
-/**
- * Save recentSearches to localStorage.
- * Performs no checks on the argument.
- */
-function setRecentSearches(recent: PartialSearch[]) {
-    storage.setItem(
-        "tsd-search-recent",
-        JSON.stringify(recent.map(({ ref }) => ref)),
     );
 }

--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -211,8 +211,10 @@ function updateResults(
 
     if (res.length === 0 && searchText) {
         const message =
-            window.translations.theme_search_no_results_found_for +
-            ` "<strong>${searchText}</strong>"`;
+            window.translations.theme_search_no_results_found_for_0.replace(
+                "{0}",
+                ` "<strong>${escapeHtml(searchText)}</strong>" `,
+            );
         updateStatusEl(status, message);
         return;
     }

--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -155,33 +155,23 @@ function bindEvents(
         }
     });
 
-    const _removeVisualFocus = () => removeVisualFocus(field);
-    field.addEventListener("change", _removeVisualFocus);
-    field.addEventListener("blur", _removeVisualFocus);
+    field.addEventListener("change", () => removeVisualFocus(field));
+    field.addEventListener("blur", () => removeVisualFocus(field));
 
     /**
-     * Start searching by pressing slash.
+     * Start searching by pressing slash, or Ctrl+K
      */
-    /*
-    document.body.addEventListener("keypress", (e) => {
-        if (e.altKey || e.ctrlKey || e.metaKey) return;
-        if (!field.matches(":focus") && e.key === "/") {
-            e.preventDefault();
-            field.focus();
-        }
-    });
+    document.body.addEventListener("keydown", (e) => {
+        if (e.altKey || e.metaKey || e.shiftKey) return;
 
-    document.body.addEventListener("keyup", (e) => {
-        if (
-            searchEl.classList.contains("has-focus") &&
-            (e.key === "Escape" ||
-                (!results.matches(":focus-within") && !field.matches(":focus")))
-        ) {
-            field.blur();
-            hideSearch(searchEl);
+        const ctrlK = e.ctrlKey && e.key === "k";
+        const slash = !e.ctrlKey && !isKeyboardActive() && e.key === "/";
+
+        if (ctrlK || slash) {
+            e.preventDefault();
+            openModal(searchEl);
         }
     });
-    */
 }
 
 function openModal(searchEl: HTMLDialogElement) {
@@ -367,4 +357,40 @@ function createStateEl(message: string) {
     stateEl.className = "state";
     stateEl.innerHTML = message;
     return stateEl;
+}
+
+/**
+ * <input /> that don't take printable character input from keyboard,
+ * to avoid catching "/" when active.
+ *
+ * based on [MDN: input types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types)
+ */
+const inputWithoutKeyboard = [
+    "button",
+    "checkbox",
+    "file",
+    "hidden",
+    "image",
+    "radio",
+    "range",
+    "reset",
+    "submit",
+];
+
+/** Checks whether keyboard is active, i.e. an input is focused */
+function isKeyboardActive() {
+    const activeElement = document.activeElement as HTMLElement | null;
+    if (!activeElement) return false;
+
+    if (
+        activeElement.isContentEditable ||
+        activeElement.tagName === "TEXTAREA" ||
+        activeElement.tagName === "SEARCH"
+    )
+        return true;
+
+    return (
+        activeElement.tagName === "INPUT" &&
+        !inputWithoutKeyboard.includes((activeElement as HTMLInputElement).type)
+    );
 }

--- a/src/lib/output/themes/default/assets/typedoc/components/Search.ts
+++ b/src/lib/output/themes/default/assets/typedoc/components/Search.ts
@@ -278,6 +278,9 @@ function setNextResult(
         next = current?.previousElementSibling || results.lastElementChild;
     }
 
+    // When only one child is present.
+    if (next === current) return;
+
     // bad markup
     if (!next || next.role !== "option") {
         console.error("Option missing");

--- a/src/lib/output/themes/default/assets/typedoc/utils/modal.ts
+++ b/src/lib/output/themes/default/assets/typedoc/utils/modal.ts
@@ -1,0 +1,29 @@
+/**
+ * @module
+ *
+ * Browsers allow scrolling of page with native dialog, which is a UX issue.
+ *
+ * @see
+ * - https://github.com/whatwg/html/issues/7732
+ * - https://github.com/whatwg/html/issues/7732#issuecomment-2437820350
+ */
+
+/** Fills the gap that scrollbar occupies. Call when the modal is opened */
+export function hideScrollbar() {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
+    // Should be computed *before* body overflow is set to hidden
+    const width = Math.abs(
+        window.innerWidth - document.documentElement.clientWidth,
+    );
+
+    document.body.style.overflow = "hidden";
+
+    // Give padding to element to balance the hidden scrollbar width
+    document.body.style.paddingRight = `${width}px`;
+}
+
+/** Resets style changes made by {@link hideScrollbar} */
+export function resetScrollbar() {
+    document.body.style.removeProperty("overflow");
+    document.body.style.removeProperty("padding-right");
+}

--- a/src/lib/output/themes/default/assets/typedoc/utils/modal.ts
+++ b/src/lib/output/themes/default/assets/typedoc/utils/modal.ts
@@ -4,7 +4,7 @@
  * Browsers allow scrolling of page with native dialog, which is a UX issue.
  *
  * `@starting-style` and `overlay` aren't well supported in FF, and only available in latest versions of chromium,
- * hence, a custom overlay workaround is requierd.
+ * hence, a custom overlay workaround is required.
  *
  * Workaround:
  *

--- a/src/lib/output/themes/default/assets/typedoc/utils/modal.ts
+++ b/src/lib/output/themes/default/assets/typedoc/utils/modal.ts
@@ -3,13 +3,29 @@
  *
  * Browsers allow scrolling of page with native dialog, which is a UX issue.
  *
+ * `@starting-style` and `overlay` aren't well supported in FF, and only available in latest versions of chromium,
+ * hence, a custom overlay workaround is requierd.
+ *
+ * Workaround:
+ *
+ * - Append a custom overlay element (a div) to `document.body`,
+ *   this does **NOT** handle nested modals,
+ *   as the overlay div cannot be in the top layer, which wouldn't overshadow the parent modal.
+ *
+ * - Add exit animation on dialog and overlay, without actually closing them
+ * - Listen for `animationend` event, and close the modal immediately
+ *
  * @see
- * - https://github.com/whatwg/html/issues/7732
- * - https://github.com/whatwg/html/issues/7732#issuecomment-2437820350
+ * - The "[right](https://frontendmasters.com/blog/animating-dialog/)" way to animate modals
+ * - [Workaround](https://github.com/whatwg/html/issues/7732#issuecomment-2437820350) to prevent background scrolling
  */
 
+// Constants
+const CLOSING_CLASS = "closing";
+const OVERLAY_ID = "tsd-overlay";
+
 /** Fills the gap that scrollbar occupies. Call when the modal is opened */
-export function hideScrollbar() {
+function hideScrollbar() {
     // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
     // Should be computed *before* body overflow is set to hidden
     const width = Math.abs(
@@ -23,7 +39,81 @@ export function hideScrollbar() {
 }
 
 /** Resets style changes made by {@link hideScrollbar} */
-export function resetScrollbar() {
+function resetScrollbar() {
     document.body.style.removeProperty("overflow");
     document.body.style.removeProperty("padding-right");
+}
+
+/** Could be popover too */
+type Modal = HTMLDialogElement;
+
+/**
+ * Must be called to setup a modal element properly for entry and exit side-effects.
+ *
+ * Adds event listeners to the modal element, for the closing animation.
+ *
+ * Adds workaround to fix scrolling issues caused by default browser behavior.
+ *
+ * @param closingAnimation Name of `@keyframes` for closing animation
+ * @param options Configure modal behavior
+ * @param options.closeOnEsc Defaults to true
+ * @param options.closeOnClick Closes modal when clicked on overlay, defaults to false.
+ */
+export function setUpModal(
+    modal: Modal,
+    closingAnimation: string,
+    options?: {
+        closeOnEsc?: boolean;
+        closeOnClick?: boolean;
+    },
+) {
+    // Event listener for closing animation
+    modal.addEventListener("animationend", (e) => {
+        if (e.animationName !== closingAnimation) return;
+        modal.classList.remove(CLOSING_CLASS);
+        document.getElementById(OVERLAY_ID)?.remove();
+        modal.close();
+        resetScrollbar();
+    });
+
+    // Override modal cancel behavior, hopefully all browsers have same behavior
+    // > When a `<dialog>` is dismissed with the `Esc` key, both the `cancel` and `close` events are fired.
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/cancel_event
+    modal.addEventListener("cancel", (e) => {
+        e.preventDefault();
+        closeModal(modal);
+    });
+
+    if (options?.closeOnClick) {
+        document.addEventListener(
+            "click",
+            (e) => {
+                if (modal.open && !modal.contains(e.target as HTMLElement)) {
+                    closeModal(modal);
+                }
+            },
+            true, // Disable invoking this handler in bubbling phase
+        );
+    }
+}
+
+export function openModal(modal: Modal) {
+    if (modal.open) return;
+
+    const overlay = document.createElement("div");
+    overlay.id = OVERLAY_ID;
+    document.body.appendChild(overlay);
+
+    modal.showModal();
+    hideScrollbar();
+}
+
+/** Initiates modal closing, by adding a `closing` class that starts the closing animation */
+export function closeModal(modal: Modal) {
+    if (!modal.open) return;
+    const overlay = document.getElementById(OVERLAY_ID);
+    if (overlay) {
+        overlay.classList.add(CLOSING_CLASS);
+    }
+    modal.classList.add(CLOSING_CLASS);
 }

--- a/src/lib/output/themes/default/partials/toolbar.tsx
+++ b/src/lib/output/themes/default/partials/toolbar.tsx
@@ -20,6 +20,23 @@ export const toolbar = (context: DefaultThemeRenderContext, props: PageEvent<Ref
             <button id="tsd-search-trigger" class="tsd-widget" aria-label={context.i18n.theme_search()}>
                 {context.icons.search()}
             </button>
+            <dialog id="tsd-search" aria-label={context.i18n.theme_search()}>
+                <input
+                    role="combobox"
+                    id="tsd-search-input"
+                    aria-controls="tsd-search-results"
+                    aria-autocomplete="list"
+                    aria-expanded="true"
+                    spellcheck={false}
+                    autocapitalize="off"
+                    autocomplete="off"
+                    placeholder={context.i18n.theme_search_placeholder()}
+                />
+
+                <ul role="listbox" id="tsd-search-results">
+                    <li class="state">{context.i18n.theme_preparing_search_index()}</li>
+                </ul>
+            </dialog>
 
             <a
                 href="#"

--- a/src/lib/output/themes/default/partials/toolbar.tsx
+++ b/src/lib/output/themes/default/partials/toolbar.tsx
@@ -7,42 +7,29 @@ import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext.js"
 export const toolbar = (context: DefaultThemeRenderContext, props: PageEvent<Reflection>) => (
     <header class="tsd-page-toolbar">
         <div class="tsd-toolbar-contents container">
-            <div class="table-cell" id="tsd-search">
-                <div class="field">
-                    <label for="tsd-search-field" class="tsd-widget tsd-toolbar-icon search no-caption">
-                        {context.icons.search()}
-                    </label>
-                    <input type="text" id="tsd-search-field" aria-label={context.i18n.theme_search()} />
-                </div>
+            <a href={context.options.getValue("titleLink") || context.relativeURL("index.html")} class="title">
+                {getDisplayName(props.project)}
+            </a>
 
-                <div class="field">
-                    <div id="tsd-toolbar-links">
-                        {Object.entries(context.options.getValue("navigationLinks")).map(([label, url]) => (
-                            <a href={url}>{label}</a>
-                        ))}
-                    </div>
-                </div>
-
-                <ul class="results">
-                    <li class="state loading">{context.i18n.theme_preparing_search_index()}</li>
-                    <li class="state failure">{context.i18n.theme_search_index_not_available()}</li>
-                </ul>
-
-                <a href={context.options.getValue("titleLink") || context.relativeURL("index.html")} class="title">
-                    {getDisplayName(props.project)}
-                </a>
+            <div id="tsd-toolbar-links">
+                {Object.entries(context.options.getValue("navigationLinks")).map(([label, url]) => (
+                    <a href={url}>{label}</a>
+                ))}
             </div>
 
-            <div class="table-cell" id="tsd-widgets">
-                <a
-                    href="#"
-                    class="tsd-widget tsd-toolbar-icon menu no-caption"
-                    data-toggle="menu"
-                    aria-label={context.i18n.theme_menu()}
-                >
-                    {context.icons.menu()}
-                </a>
-            </div>
+            <button id="tsd-search-trigger" class="tsd-widget" aria-label={context.i18n.theme_search()}>
+                {context.icons.search()}
+            </button>
+
+            <a
+                href="#"
+                class="tsd-widget menu"
+                id="tsd-toolbar-menu-trigger"
+                data-toggle="menu"
+                aria-label={context.i18n.theme_menu()}
+            >
+                {context.icons.menu()}
+            </a>
         </div>
     </header>
 );

--- a/src/lib/output/themes/default/partials/toolbar.tsx
+++ b/src/lib/output/themes/default/partials/toolbar.tsx
@@ -31,11 +31,13 @@ export const toolbar = (context: DefaultThemeRenderContext, props: PageEvent<Ref
                     autocapitalize="off"
                     autocomplete="off"
                     placeholder={context.i18n.theme_search_placeholder()}
+                    maxLength={100}
                 />
 
-                <ul role="listbox" id="tsd-search-results">
-                    <li class="state">{context.i18n.theme_preparing_search_index()}</li>
-                </ul>
+                <ul role="listbox" id="tsd-search-results"></ul>
+                <div id="tsd-search-status" aria-live="polite" aria-atomic="true">
+                    <div>{context.i18n.theme_preparing_search_index()}</div>
+                </div>
             </dialog>
 
             <a

--- a/static/style.css
+++ b/static/style.css
@@ -646,6 +646,7 @@
 
     .tsd-breadcrumb {
         margin: 0;
+        margin-top: 1rem;
         padding: 0;
         color: var(--color-text-aside);
     }
@@ -893,7 +894,8 @@
     }
 
     .tsd-navigation.settings {
-        margin: 1rem 0;
+        margin: 0;
+        margin-bottom: 1rem;
     }
     .tsd-navigation > a,
     .tsd-navigation .tsd-accordion-summary {
@@ -1571,6 +1573,10 @@
             --dim-container-main-margin-y: 2rem;
         }
 
+        .tsd-breadcrumb {
+            margin-top: 0;
+        }
+
         .col-sidebar {
             grid-area: sidebar;
         }
@@ -1590,7 +1596,6 @@
             top: calc(
                 var(--dim-header-height) + var(--dim-container-main-margin-y)
             );
-            padding-top: 1rem;
         }
         .site-menu {
             margin-top: 1rem;
@@ -1620,7 +1625,7 @@
         }
 
         .site-menu {
-            margin-top: 1rem;
+            margin-top: 0rem;
         }
 
         .page-menu,

--- a/static/style.css
+++ b/static/style.css
@@ -11,6 +11,8 @@
         --dim-container-main-margin-y: 0rem;
 
         --dim-footer-height: 3.5rem;
+
+        --modal-animation-duration: 0.2s;
     }
 
     :root {
@@ -601,6 +603,16 @@
         border: 0.25rem solid var(--color-icon-background);
     }
 
+    dialog {
+        border: none;
+        outline: none;
+        padding: 0;
+        background-color: var(--color-background);
+    }
+    ::backdrop {
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+
     .tsd-typography {
         line-height: 1.333em;
     }
@@ -1110,101 +1122,86 @@
         margin-bottom: 1rem;
     }
 
-    #tsd-search {
-        transition: background-color 0.2s;
+    #tsd-search[open],
+    #tsd-search[open]::backdrop {
+        animation: fade-in var(--modal-animation-duration) ease-out forwards;
     }
-    #tsd-search .title {
-        position: relative;
-        z-index: 2;
+
+    /* Avoid setting `display` on closed dialog */
+    #tsd-search[open] {
+        display: flex;
+        flex-direction: column;
+        padding: 1rem;
+        width: 32rem;
+        max-width: 90vw;
+        min-height: 8rem;
+        max-height: 50vh;
+        /* Anchor dialog to top */
+        margin-top: 25vh;
+        border-radius: 6px;
     }
-    #tsd-search .field {
-        position: absolute;
-        left: 0;
-        top: 0;
-        right: 2.5rem;
-        height: 100%;
-    }
-    #tsd-search .field input {
+    #tsd-search-input {
         box-sizing: border-box;
-        position: relative;
-        top: -50px;
-        z-index: 1;
         width: 100%;
-        padding: 0 10px;
-        opacity: 0;
+        padding: 0 0.625rem; /* 10px */
         outline: 0;
-        border: 0;
-        background: transparent;
+        border: 2px solid var(--color-accent);
+        background-color: transparent;
         color: var(--color-text);
+        border-radius: 4px;
+        height: 2.5rem;
+        flex: 0 0 auto;
+        font-size: 0.875rem;
+        transition:
+            border-color 0.2s,
+            background-color 0.2s;
     }
-    #tsd-search .field label {
-        position: absolute;
-        overflow: hidden;
-        right: -40px;
+    #tsd-search-input:focus-visible {
+        background: var(--color-accent);
+        border-color: transparent;
     }
-    #tsd-search .field input,
-    #tsd-search .title,
-    #tsd-toolbar-links a {
-        transition: opacity 0.2s;
-    }
-    #tsd-search .results {
-        position: absolute;
-        visibility: hidden;
-        top: 40px;
-        width: 100%;
+    #tsd-search-results {
         margin: 0;
+        margin-top: 0.5rem;
         padding: 0;
         list-style: none;
-        box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        overflow-y: auto;
     }
-    #tsd-search .results li {
+    #tsd-search-results > li[role="option"] {
         background-color: var(--color-background);
-        line-height: initial;
-        padding: 4px;
+        line-height: 1.5;
+        box-sizing: border-box;
+        border-radius: 4px;
     }
-    #tsd-search .results li:nth-child(even) {
+    #tsd-search-results > li[role="option"]:nth-child(even) {
         background-color: var(--color-background-secondary);
     }
-    #tsd-search .results li.state {
-        display: none;
-    }
-    #tsd-search .results li.current:not(.no-results),
-    #tsd-search .results li:hover:not(.no-results) {
+    #tsd-search-results > li[role="option"]:is(:hover, [aria-selected="true"]) {
         background-color: var(--color-accent);
     }
-    #tsd-search .results a {
+    /* It's important that this takes full size of parent `li`, to capture a click on `li` */
+    #tsd-search-results > li[role="option"] > a {
         display: flex;
         align-items: center;
-        padding: 0.25rem;
+        padding: 0.5rem 0.25rem;
         box-sizing: border-box;
+        width: 100%;
     }
-    #tsd-search .results a:before {
-        top: 10px;
+    #tsd-search-results > li[role="option"] > a > .text {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow-wrap: anywhere;
     }
-    #tsd-search .results span.parent {
+    #tsd-search-results > li[role="option"] > a .parent {
         color: var(--color-text-aside);
-        font-weight: normal;
     }
-    #tsd-search.has-focus {
-        background-color: var(--color-accent);
-    }
-    #tsd-search.has-focus .field input {
-        top: 0;
-        opacity: 1;
-    }
-    #tsd-search.has-focus .title,
-    #tsd-search.has-focus #tsd-toolbar-links a {
-        z-index: 0;
-        opacity: 0;
-    }
-    #tsd-search.has-focus .results {
-        visibility: visible;
-    }
-    #tsd-search.loading .results li.state.loading {
-        display: block;
-    }
-    #tsd-search.failure .results li.state.failure {
-        display: block;
+    #tsd-search-results > li.state {
+        flex: 1;
+        display: grid;
+        place-content: center;
     }
 
     .tsd-signature {

--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,19 @@
 @layer typedoc {
     :root {
+        --dim-toolbar-contents-height: 2.5rem;
+        --dim-toolbar-border-bottom-width: 1px;
+        --dim-header-height: calc(
+            var(--dim-toolbar-border-bottom-width) +
+                var(--dim-toolbar-contents-height)
+        );
+
+        /* 0rem For mobile; unit is required for calculation in `calc` */
+        --dim-container-main-margin-y: 0rem;
+
+        --dim-footer-height: 3.5rem;
+    }
+
+    :root {
         /* Light */
         --light-color-background: #f2f4f8;
         --light-color-background-secondary: #eff0f1;
@@ -421,16 +435,19 @@
         border-top: 1px solid var(--color-accent);
         padding-top: 1rem;
         padding-bottom: 1rem;
-        max-height: 3.5rem;
+        max-height: var(--dim-footer-height);
     }
     footer > p {
         margin: 0 1em;
     }
 
     .container-main {
-        margin: 0 auto;
+        margin: var(--dim-container-main-margin-y) auto;
         /* toolbar, footer, margin */
-        min-height: calc(100vh - 41px - 56px - 4rem);
+        min-height: calc(
+            100svh - var(--dim-header-height) - var(--dim-footer-height) - 2 *
+                var(--dim-container-main-margin-y)
+        );
     }
 
     @keyframes fade-in {
@@ -1257,7 +1274,8 @@
         width: 100%;
         color: var(--color-text);
         background: var(--color-background-secondary);
-        border-bottom: 1px var(--color-accent) solid;
+        border-bottom: var(--dim-toolbar-border-bottom-width)
+            var(--color-accent) solid;
         transition: transform 0.3s ease-in-out;
     }
     .tsd-page-toolbar a {
@@ -1273,7 +1291,7 @@
     .tsd-page-toolbar .tsd-toolbar-contents {
         display: flex;
         justify-content: space-between;
-        height: 2.5rem;
+        height: var(--dim-toolbar-contents-height);
         margin: 0 auto;
     }
     .tsd-page-toolbar .table-cell {
@@ -1550,7 +1568,7 @@
             display: grid;
             grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
             grid-template-areas: "sidebar content";
-            margin: 2rem auto;
+            --dim-container-main-margin-y: 2rem;
         }
 
         .col-sidebar {
@@ -1563,10 +1581,15 @@
     }
     @media (min-width: 770px) and (max-width: 1399px) {
         .col-sidebar {
-            max-height: calc(100vh - 2rem - 42px);
+            max-height: calc(
+                100vh - var(--dim-header-height) - var(--dim-footer-height) - 2 *
+                    var(--dim-container-main-margin-y)
+            );
             overflow: auto;
             position: sticky;
-            top: 42px;
+            top: calc(
+                var(--dim-header-height) + var(--dim-container-main-margin-y)
+            );
             padding-top: 1rem;
         }
         .site-menu {
@@ -1602,10 +1625,15 @@
 
         .page-menu,
         .site-menu {
-            max-height: calc(100vh - 2rem - 42px);
+            max-height: calc(
+                100vh - var(--dim-header-height) - var(--dim-footer-height) - 2 *
+                    var(--dim-container-main-margin-y)
+            );
             overflow: auto;
             position: sticky;
-            top: 42px;
+            top: calc(
+                var(--dim-header-height) + var(--dim-container-main-margin-y)
+            );
         }
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -253,10 +253,6 @@
         color-scheme: var(--color-scheme);
     }
 
-    body {
-        margin: 0;
-    }
-
     :root[data-theme="light"] {
         --color-background: var(--light-color-background);
         --color-background-secondary: var(--light-color-background-secondary);
@@ -469,29 +465,6 @@
             opacity: 0;
         }
     }
-    @keyframes fade-in-delayed {
-        0% {
-            opacity: 0;
-        }
-        33% {
-            opacity: 0;
-        }
-        100% {
-            opacity: 1;
-        }
-    }
-    @keyframes fade-out-delayed {
-        0% {
-            opacity: 1;
-            visibility: visible;
-        }
-        66% {
-            opacity: 0;
-        }
-        100% {
-            opacity: 0;
-        }
-    }
     @keyframes pop-in-from-right {
         from {
             transform: translate(100%, 0);
@@ -515,6 +488,7 @@
             Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
         font-size: 16px;
         color: var(--color-text);
+        margin: 0;
     }
 
     a {

--- a/static/style.css
+++ b/static/style.css
@@ -609,8 +609,21 @@
         padding: 0;
         background-color: var(--color-background);
     }
-    ::backdrop {
+    dialog::backdrop {
+        display: none;
+    }
+    #tsd-overlay {
         background-color: rgba(0, 0, 0, 0.5);
+        position: fixed;
+        z-index: 9999;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        animation: fade-in var(--modal-animation-duration) forwards;
+    }
+    #tsd-overlay.closing {
+        animation-name: fade-out;
     }
 
     .tsd-typography {
@@ -1122,9 +1135,11 @@
         margin-bottom: 1rem;
     }
 
-    #tsd-search[open],
-    #tsd-search[open]::backdrop {
+    #tsd-search[open] {
         animation: fade-in var(--modal-animation-duration) ease-out forwards;
+    }
+    #tsd-search[open].closing {
+        animation-name: fade-out;
     }
 
     /* Avoid setting `display` on closed dialog */

--- a/static/style.css
+++ b/static/style.css
@@ -548,12 +548,6 @@
         border-left: 4px solid gray;
     }
 
-    button {
-        border: none;
-        appearance: none;
-        background-color: transparent;
-    }
-
     img {
         max-width: 100%;
     }
@@ -1323,9 +1317,11 @@
         width: 2.5rem;
         transition:
             opacity 0.1s,
-            background-color 0.2s;
+            background-color 0.1s;
         text-align: center;
         cursor: pointer;
+        border: none;
+        background-color: transparent;
     }
     .tsd-widget:hover {
         opacity: 0.9;

--- a/static/style.css
+++ b/static/style.css
@@ -19,12 +19,15 @@
         /* Light */
         --light-color-background: #f2f4f8;
         --light-color-background-secondary: #eff0f1;
-        --light-color-warning-text: #222;
+        /* Not to be confused with [:active](https://developer.mozilla.org/en-US/docs/Web/CSS/:active) */
+        --light-color-background-active: #d6d8da;
         --light-color-background-warning: #e6e600;
+        --light-color-warning-text: #222;
         --light-color-accent: #c5c7c9;
-        --light-color-active-menu-item: var(--light-color-accent);
+        --light-color-active-menu-item: var(--light-color-background-active);
         --light-color-text: #222;
-        --light-color-text-aside: #6e6e6e;
+        --light-color-contrast-text: #000;
+        --light-color-text-aside: #5e5e5e;
 
         --light-color-icon-background: var(--light-color-background);
         --light-color-icon-text: var(--light-color-text);
@@ -72,15 +75,20 @@
 
         --light-external-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='10' height='10'><path fill-opacity='0' stroke='%23000' stroke-width='10' d='m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z'/></svg>");
         --light-color-scheme: light;
+    }
 
+    :root {
         /* Dark */
         --dark-color-background: #2b2e33;
         --dark-color-background-secondary: #1e2024;
+        /* Not to be confused with [:active](https://developer.mozilla.org/en-US/docs/Web/CSS/:active) */
+        --dark-color-background-active: #5d5d6a;
         --dark-color-background-warning: #bebe00;
         --dark-color-warning-text: #222;
         --dark-color-accent: #9096a2;
-        --dark-color-active-menu-item: #5d5d6a;
+        --dark-color-active-menu-item: var(--dark-color-background-active);
         --dark-color-text: #f5f5f5;
+        --dark-color-contrast-text: #ffffff;
         --dark-color-text-aside: #dddddd;
 
         --dark-color-icon-background: var(--dark-color-background-secondary);
@@ -135,11 +143,13 @@
             --color-background-secondary: var(
                 --light-color-background-secondary
             );
+            --color-background-active: var(--light-color-background-active);
             --color-background-warning: var(--light-color-background-warning);
             --color-warning-text: var(--light-color-warning-text);
             --color-accent: var(--light-color-accent);
             --color-active-menu-item: var(--light-color-active-menu-item);
             --color-text: var(--light-color-text);
+            --color-contrast-text: var(--light-color-contrast-text);
             --color-text-aside: var(--light-color-text-aside);
 
             --color-icon-background: var(--light-color-icon-background);
@@ -195,11 +205,13 @@
             --color-background-secondary: var(
                 --dark-color-background-secondary
             );
+            --color-background-active: var(--dark-color-background-active);
             --color-background-warning: var(--dark-color-background-warning);
             --color-warning-text: var(--dark-color-warning-text);
             --color-accent: var(--dark-color-accent);
             --color-active-menu-item: var(--dark-color-active-menu-item);
             --color-text: var(--dark-color-text);
+            --color-contrast-text: var(--dark-color-contrast-text);
             --color-text-aside: var(--dark-color-text-aside);
 
             --color-icon-background: var(--dark-color-icon-background);
@@ -256,12 +268,14 @@
     :root[data-theme="light"] {
         --color-background: var(--light-color-background);
         --color-background-secondary: var(--light-color-background-secondary);
+        --color-background-active: var(--light-color-background-active);
         --color-background-warning: var(--light-color-background-warning);
         --color-warning-text: var(--light-color-warning-text);
         --color-icon-background: var(--light-color-icon-background);
         --color-accent: var(--light-color-accent);
         --color-active-menu-item: var(--light-color-active-menu-item);
         --color-text: var(--light-color-text);
+        --color-contrast-text: var(--light-color-contrast-text);
         --color-text-aside: var(--light-color-text-aside);
         --color-icon-text: var(--light-color-icon-text);
 
@@ -311,12 +325,14 @@
     :root[data-theme="dark"] {
         --color-background: var(--dark-color-background);
         --color-background-secondary: var(--dark-color-background-secondary);
+        --color-background-active: var(--dark-color-background-active);
         --color-background-warning: var(--dark-color-background-warning);
         --color-warning-text: var(--dark-color-warning-text);
         --color-icon-background: var(--dark-color-icon-background);
         --color-accent: var(--dark-color-accent);
         --color-active-menu-item: var(--dark-color-active-menu-item);
         --color-text: var(--dark-color-text);
+        --color-contrast-text: var(--dark-color-contrast-text);
         --color-text-aside: var(--dark-color-text-aside);
         --color-icon-text: var(--dark-color-icon-text);
 
@@ -939,6 +955,7 @@
     .tsd-navigation a.current,
     .tsd-page-navigation a.current {
         background: var(--color-active-menu-item);
+        color: var(--color-contrast-text);
     }
     .tsd-navigation a:hover,
     .tsd-page-navigation a:hover {
@@ -1140,11 +1157,12 @@
             background-color 0.2s;
     }
     #tsd-search-input:focus-visible {
-        background: var(--color-accent);
+        background-color: var(--color-background-active);
         border-color: transparent;
+        color: var(--color-contrast-text);
     }
-    #tsd-search-input:focus-visible::placeholder {
-        color: var(--color-text);
+    #tsd-search-input::placeholder {
+        color: inherit;
         opacity: 0.8;
     }
     #tsd-search-results {
@@ -1169,7 +1187,8 @@
         background-color: var(--color-background-secondary);
     }
     #tsd-search-results > li:is(:hover, [aria-selected="true"]) {
-        background-color: var(--color-accent);
+        background-color: var(--color-background-active);
+        color: var(--color-contrast-text);
     }
     /* It's important that this takes full size of parent `li`, to capture a click on `li` */
     #tsd-search-results > li > a {

--- a/static/style.css
+++ b/static/style.css
@@ -1198,6 +1198,11 @@
     #tsd-search-results > li[role="option"] > a .parent {
         color: var(--color-text-aside);
     }
+    #tsd-search-results > li[role="option"] > a mark {
+        color: inherit;
+        background-color: inherit;
+        font-weight: bold;
+    }
     #tsd-search-results > li.state {
         flex: 1;
         display: grid;

--- a/static/style.css
+++ b/static/style.css
@@ -572,6 +572,35 @@
         border-left: 4px solid gray;
     }
 
+    button {
+        border: none;
+        appearance: none;
+        background-color: transparent;
+    }
+
+    img {
+        max-width: 100%;
+    }
+
+    * {
+        scrollbar-width: thin;
+        scrollbar-color: var(--color-accent) var(--color-icon-background);
+    }
+
+    *::-webkit-scrollbar {
+        width: 0.75rem;
+    }
+
+    *::-webkit-scrollbar-track {
+        background: var(--color-icon-background);
+    }
+
+    *::-webkit-scrollbar-thumb {
+        background-color: var(--color-accent);
+        border-radius: 999rem;
+        border: 0.25rem solid var(--color-icon-background);
+    }
+
     .tsd-typography {
         line-height: 1.333em;
     }
@@ -1178,22 +1207,6 @@
         display: block;
     }
 
-    #tsd-toolbar-links {
-        position: absolute;
-        top: 0;
-        right: 2rem;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-    }
-    #tsd-toolbar-links a {
-        margin-left: 1.5rem;
-    }
-    #tsd-toolbar-links a:hover {
-        text-decoration: underline;
-    }
-
     .tsd-signature {
         margin: 0 0 1rem 0;
         padding: 1rem 0.5rem;
@@ -1282,72 +1295,45 @@
     }
     .tsd-page-toolbar a {
         color: var(--color-text);
-        text-decoration: none;
     }
-    .tsd-page-toolbar a.title {
-        font-weight: bold;
-    }
-    .tsd-page-toolbar a.title:hover {
-        text-decoration: underline;
-    }
-    .tsd-page-toolbar .tsd-toolbar-contents {
+    .tsd-toolbar-contents {
         display: flex;
-        justify-content: space-between;
+        align-items: center;
         height: var(--dim-toolbar-contents-height);
         margin: 0 auto;
     }
-    .tsd-page-toolbar .table-cell {
-        position: relative;
-        white-space: nowrap;
-        line-height: 40px;
+    .tsd-toolbar-contents > .title {
+        font-weight: bold;
+        margin-right: auto;
     }
-    .tsd-page-toolbar .table-cell:first-child {
-        width: 100%;
-    }
-    .tsd-page-toolbar .tsd-toolbar-icon {
-        box-sizing: border-box;
-        line-height: 0;
-        padding: 12px 0;
+    #tsd-toolbar-links {
+        display: flex;
+        align-items: center;
+        gap: 1.5rem;
+        margin-right: 1rem;
     }
 
     .tsd-widget {
+        box-sizing: border-box;
         display: inline-block;
-        overflow: hidden;
         opacity: 0.8;
-        height: 40px;
+        height: 2.5rem;
+        width: 2.5rem;
         transition:
             opacity 0.1s,
             background-color 0.2s;
-        vertical-align: bottom;
+        text-align: center;
         cursor: pointer;
     }
     .tsd-widget:hover {
         opacity: 0.9;
     }
-    .tsd-widget.active {
+    .tsd-widget:active {
         opacity: 1;
         background-color: var(--color-accent);
     }
-    .tsd-widget.no-caption {
-        width: 40px;
-    }
-    .tsd-widget.no-caption:before {
-        margin: 0;
-    }
-
-    .tsd-widget.options,
-    .tsd-widget.menu {
+    #tsd-toolbar-menu-trigger {
         display: none;
-    }
-    input[type="checkbox"] + .tsd-widget:before {
-        background-position: -120px 0;
-    }
-    input[type="checkbox"]:checked + .tsd-widget:before {
-        background-position: -160px 0;
-    }
-
-    img {
-        max-width: 100%;
     }
 
     .tsd-member-summary-name {
@@ -1457,41 +1443,26 @@
         color: var(--color-text);
     }
 
-    * {
-        scrollbar-width: thin;
-        scrollbar-color: var(--color-accent) var(--color-icon-background);
-    }
-
-    *::-webkit-scrollbar {
-        width: 0.75rem;
-    }
-
-    *::-webkit-scrollbar-track {
-        background: var(--color-icon-background);
-    }
-
-    *::-webkit-scrollbar-thumb {
-        background-color: var(--color-accent);
-        border-radius: 999rem;
-        border: 0.25rem solid var(--color-icon-background);
-    }
-
     /* mobile */
     @media (max-width: 769px) {
-        .tsd-widget.options,
-        .tsd-widget.menu {
+        #tsd-toolbar-menu-trigger {
             display: inline-block;
+            /* temporary fix to vertically align, for compatibilty */
+            line-height: 2.5;
+        }
+        #tsd-toolbar-links {
+            display: none;
         }
 
         .container-main {
             display: flex;
         }
-        html .col-content {
+        .col-content {
             float: none;
             max-width: 100%;
             width: 100%;
         }
-        html .col-sidebar {
+        .col-sidebar {
             position: fixed !important;
             overflow-y: auto;
             -webkit-overflow-scrolling: touch;
@@ -1506,10 +1477,10 @@
             background-color: var(--color-background);
             transform: translate(100%, 0);
         }
-        html .col-sidebar > *:last-child {
+        .col-sidebar > *:last-child {
             padding-bottom: 20px;
         }
-        html .overlay {
+        .overlay {
             content: "";
             display: block;
             position: fixed;
@@ -1555,9 +1526,6 @@
         }
         .has-menu .tsd-navigation {
             max-height: 100%;
-        }
-        #tsd-toolbar-links {
-            display: none;
         }
         .tsd-navigation .tsd-nav-link {
             display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -1155,7 +1155,6 @@
     }
     #tsd-search-results {
         margin: 0;
-        margin-top: 0.5rem;
         padding: 0;
         list-style: none;
         flex: 1 1 auto;
@@ -1163,43 +1162,50 @@
         flex-direction: column;
         overflow-y: auto;
     }
-    #tsd-search-results > li[role="option"] {
+    #tsd-search-results:not(:empty) {
+        margin-top: 0.5rem;
+    }
+    #tsd-search-results > li {
         background-color: var(--color-background);
         line-height: 1.5;
         box-sizing: border-box;
         border-radius: 4px;
     }
-    #tsd-search-results > li[role="option"]:nth-child(even) {
+    #tsd-search-results > li:nth-child(even) {
         background-color: var(--color-background-secondary);
     }
-    #tsd-search-results > li[role="option"]:is(:hover, [aria-selected="true"]) {
+    #tsd-search-results > li:is(:hover, [aria-selected="true"]) {
         background-color: var(--color-accent);
     }
     /* It's important that this takes full size of parent `li`, to capture a click on `li` */
-    #tsd-search-results > li[role="option"] > a {
+    #tsd-search-results > li > a {
         display: flex;
         align-items: center;
         padding: 0.5rem 0.25rem;
         box-sizing: border-box;
         width: 100%;
     }
-    #tsd-search-results > li[role="option"] > a > .text {
+    #tsd-search-results > li > a > .text {
         flex: 1 1 auto;
         min-width: 0;
         overflow-wrap: anywhere;
     }
-    #tsd-search-results > li[role="option"] > a .parent {
+    #tsd-search-results > li > a .parent {
         color: var(--color-text-aside);
     }
-    #tsd-search-results > li[role="option"] > a mark {
+    #tsd-search-results > li > a mark {
         color: inherit;
         background-color: inherit;
         font-weight: bold;
     }
-    #tsd-search-results > li.state {
+    #tsd-search-status {
         flex: 1;
         display: grid;
         place-content: center;
+        text-align: center;
+        overflow-wrap: anywhere;
+    }
+    #tsd-search-status:not(:empty) {
         min-height: 6rem;
     }
 

--- a/static/style.css
+++ b/static/style.css
@@ -1123,7 +1123,6 @@
         padding: 1rem;
         width: 32rem;
         max-width: 90vw;
-        min-height: 8rem;
         max-height: calc(100vh - env(keyboard-inset-height, 0px) - 25vh);
         /* Anchor dialog to top */
         margin-top: 10vh;
@@ -1201,6 +1200,7 @@
         flex: 1;
         display: grid;
         place-content: center;
+        min-height: 6rem;
     }
 
     .tsd-signature {

--- a/static/style.css
+++ b/static/style.css
@@ -1124,10 +1124,11 @@
         width: 32rem;
         max-width: 90vw;
         min-height: 8rem;
-        max-height: 50vh;
+        max-height: calc(100vh - env(keyboard-inset-height, 0px) - 25vh);
         /* Anchor dialog to top */
-        margin-top: 25vh;
+        margin-top: 10vh;
         border-radius: 6px;
+        will-change: max-height;
     }
     #tsd-search-input {
         box-sizing: border-box;

--- a/static/style.css
+++ b/static/style.css
@@ -1150,6 +1150,10 @@
         background: var(--color-accent);
         border-color: transparent;
     }
+    #tsd-search-input:focus-visible::placeholder {
+        color: var(--color-text);
+        opacity: 0.8;
+    }
     #tsd-search-results {
         margin: 0;
         margin-top: 0.5rem;


### PR DESCRIPTION
- **Update docs for TypeDoc import**
- **Enable CI for Node 23**
- **Disable node type stripping**
- **only set option on Node 23**
- **Fix handling of defaulted type arguments**
- **Add docs for packages mode options locations**
- **Clarify that entry points are globs, #2825**
- **Watch documents, readme, and CSS (#2675)**
- **Reformat**
- **Full watch support**
- **Lint fix**
- **Lint docs**
- **Improve config file handling; nicepath debug info**
- **Unconditional watches + require() fallback**
- **Fix logic error**
- **Move jp to ja to comply with ISO 639-1**
- **Re-add jp as alias of ja to keep compatibility**
- **Fork and reload for config changes**
- **POC: support regions in @includeCode**
- **Add language-dependant regions and line number syntax + docs & logs**
- **lint**
- **Support regions for `@include` + warn on empty regions + cleanup**
- **Improve docs**
- **regexp-escape the `target` before using it in regular expressions**
- **Clean up notes/warning in site docs**
- **Add unit tests for include/includeCode with regions**
- **Note that region feature also works on `@inline`**
- **Fix #2842**
- **Watch readme and includes even if not found**
- **Only treat symbols as external if all declarations are external**
- **Support multiple regions in `@include` and `@includeCode`**
- **Update changelog**
- **Update bug report template to set type:Bug**
- **Update feature request template to use feature issue type**
- **Deprecate "jp"**
- **Improve messages for unsupported languages**
- **Tag-based visibilityFilter supports signatures**
- **Update Chinese translations**
- **Fix constant rebuilds in watch mode**
- **Fix dropdown arrow**
- **Label icon SVGs**
- **Fix potential duplicate class names**
- **POC: support regions in @includeCode**
- **Add language-dependant regions and line number syntax + docs & logs**
- **lint**
- **Support regions for `@include` + warn on empty regions + cleanup**
- **Improve docs**
- **regexp-escape the `target` before using it in regular expressions**
- **Clean up notes/warning in site docs**
- **Add unit tests for include/includeCode with regions**
- **Note that region feature also works on `@inline`**
- **Fix #2842**
- **Only treat symbols as external if all declarations are external**
- **Update changelog**
- **Enable sponsoring**
- **Enable discussions**
- **Rename discussions link**
- **Bump version to 0.27.7**
- **Update changelog for release**
- **Fix `getSupportedLanguages` returning langs without translations**
- **Prettier.**
- **Support URLs in favicons**
- **Fix `undefined` hrefs for excluded external refs**
- **Add css variables for dimensions, and use svh units**
- **Fix excess/absent margins and padding.**
- **Fix tab order of toolbar and remove unused selectors. **Breaks search****
- **Add more search related 118n strings, and inject more strings in js script**
- **Implement search component as combobox, with minimal functionality**
- **Add global keyboard listeners for opening modal**
- **rename `setCurrentResult` to `setNextResult`**
- **Use semantic element `mark` for highlighting search matches**
- **Add exit animation for modals, using custom overlay**
- **Remove unused keyframes. Merge `body` selectors**
- **Adjust max-height with virtual keyboard, in mobiles**
- **fix placeholder text color on focus search input**
- **Remove min-height from search dialog and set it to `.state`**
- **fix single element edge case in `setNextResult`**
- **Show recent searches when the search query is empty**
- **Completely revert "recent searches" feature.**
- **Fix typo and refactor search.ts code**
- **Fix invalid search message implementation**
- **Add placeholder for no_results i18n string**
- **remove global button styles and add it to tsd-widget**
- **Improve text contrast, satisfying WCAG level AA**
