### PR TITLE
fix(createNormalizedUrl): replace String.fromCharCode by String.fromCodePoint

### DIFF
--- a/src/lib/utils/html.ts
+++ b/src/lib/utils/html.ts
@@ -72,7 +72,7 @@ export function createNormalizedUrl(url: string) {
         codePoints[i] = Chars.UNDERSCORE;
     }
 
-    return String.fromCharCode(...codePoints);
+    return String.fromCodePoint(...codePoints);
 }
 
 const enum Chars {

--- a/src/test/utils/html.test.ts
+++ b/src/test/utils/html.test.ts
@@ -288,4 +288,12 @@ describe("createNormalizedUrl", () => {
     it("Permits Chinese characters", () => {
         equal(createNormalizedUrl("文档"), "文档");
     });
+
+    it("Permits Emoji characters", () => {
+        equal(createNormalizedUrl("🐌 Foo 🪐.md"), "🐌_Foo_🪐.md");
+    });
+    
+    it("Permits UTF8 characters", () => {
+        equal(createNormalizedUrl("◉ bar⚐.md"), "◉_bar⚐.md");
+    });
 });

--- a/src/test/utils/html.test.ts
+++ b/src/test/utils/html.test.ts
@@ -292,7 +292,7 @@ describe("createNormalizedUrl", () => {
     it("Permits Emoji characters", () => {
         equal(createNormalizedUrl("🐌 Foo 🪐.md"), "🐌_Foo_🪐.md");
     });
-    
+
     it("Permits UTF8 characters", () => {
         equal(createNormalizedUrl("◉ bar⚐.md"), "◉_bar⚐.md");
     });


### PR DESCRIPTION

https://github.com/TypeStrong/typedoc/issues/2905