### PR TITLE
Make clearing TypeDoc fields from local storage optional

### DIFF
--- a/site/development/local-storage.md
+++ b/site/development/local-storage.md
@@ -10,7 +10,7 @@ To disable local storage, use:
 
 `window.TypeDoc.disableLocalStorage();`
 
-**Note:** Disabling local storage will clear its contents.
+**Note:** Optionally, passing `true`, `window.TypeDoc.disableLocalStorage(true);`, will clear TypeDoc contents from the local storage.
 
 To enable local storage, use:
 

--- a/site/development/local-storage.md
+++ b/site/development/local-storage.md
@@ -10,10 +10,14 @@ To disable local storage, use:
 
 `window.TypeDoc.disableLocalStorage();`
 
-**Note:** Optionally, passing `true`, `window.TypeDoc.disableLocalStorage(true);`, will clear TypeDoc contents from the local storage.
+**Note:** Disabling local storage will clear its contents.
 
 To enable local storage, use:
 
 `window.TypeDoc.enableLocalStorage();`
 
 **Note:** Local storage is enabled by default.
+
+To disable local storage without clearing it, use:
+
+`window.TypeDoc.disableWritingLocalStorage();`

--- a/src/lib/output/themes/default/assets/typedoc/Application.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Application.ts
@@ -24,8 +24,8 @@ declare global {
 }
 
 window.TypeDoc ||= {
-    disableLocalStorage: () => {
-        storage.disable();
+    disableLocalStorage: (clearStorage: boolean = false) => {
+        storage.disable(clearStorage);
     },
     enableLocalStorage: () => {
         storage.enable();

--- a/src/lib/output/themes/default/assets/typedoc/Application.ts
+++ b/src/lib/output/themes/default/assets/typedoc/Application.ts
@@ -17,6 +17,7 @@ declare global {
             [k: `kind_${number}`]: string;
         };
         TypeDoc: {
+            disableWritingLocalStorage: () => void;
             disableLocalStorage: () => void;
             enableLocalStorage: () => void;
         };
@@ -24,8 +25,11 @@ declare global {
 }
 
 window.TypeDoc ||= {
-    disableLocalStorage: (clearStorage: boolean = false) => {
-        storage.disable(clearStorage);
+    disableWritingLocalStorage() {
+        storage.disableWritingLocalStorage();
+    },
+    disableLocalStorage: () => {
+        storage.disable();
     },
     enableLocalStorage: () => {
         storage.enable();

--- a/src/lib/output/themes/default/assets/typedoc/utils/storage.ts
+++ b/src/lib/output/themes/default/assets/typedoc/utils/storage.ts
@@ -29,11 +29,33 @@ try {
 export const storage = {
     getItem: (key: string) => _storage.getItem(key),
     setItem: (key: string, value: string) => _storage.setItem(key, value),
-    disable() {
-        localStorage.clear();
+    disable(clearStorage: boolean =  false) {
+        if (clearStorage) { removeTypeDocStorage();}
         _storage = noOpStorageImpl;
     },
     enable() {
         _storage = localStorageImpl;
     },
 };
+
+function removeTypeDocStorage() {
+    const keysToRemove = [
+        "filter-protected",
+        "filter-inherited",
+        "filter-external",
+        "tsd-theme",
+    ];
+    const regex = /^tsd-accordion-/;
+
+    try {
+        const keys: string[] = [];
+
+        Object.keys(localStorage).forEach(key => {
+            if (keysToRemove.includes(key) || regex.test(key)) {
+                localStorage.removeItem(key);
+            }
+        });
+    } catch {
+        // Silently ignore any errors
+    }
+}

--- a/src/lib/output/themes/default/assets/typedoc/utils/storage.ts
+++ b/src/lib/output/themes/default/assets/typedoc/utils/storage.ts
@@ -29,8 +29,8 @@ try {
 export const storage = {
     getItem: (key: string) => _storage.getItem(key),
     setItem: (key: string, value: string) => _storage.setItem(key, value),
-    disable(clearStorage: boolean =  false) {
-        if (clearStorage) { removeTypeDocStorage();}
+    disable(clearStorage: boolean = false) {
+        if (clearStorage) removeTypeDocStorage();
         _storage = noOpStorageImpl;
     },
     enable() {

--- a/src/lib/output/themes/default/assets/typedoc/utils/storage.ts
+++ b/src/lib/output/themes/default/assets/typedoc/utils/storage.ts
@@ -29,33 +29,14 @@ try {
 export const storage = {
     getItem: (key: string) => _storage.getItem(key),
     setItem: (key: string, value: string) => _storage.setItem(key, value),
-    disable(clearStorage: boolean = false) {
-        if (clearStorage) removeTypeDocStorage();
+    disableWritingLocalStorage() {
+        _storage = noOpStorageImpl;
+    },
+    disable() {
+        localStorage.clear();
         _storage = noOpStorageImpl;
     },
     enable() {
         _storage = localStorageImpl;
     },
 };
-
-function removeTypeDocStorage() {
-    const keysToRemove = [
-        "filter-protected",
-        "filter-inherited",
-        "filter-external",
-        "tsd-theme",
-    ];
-    const regex = /^tsd-accordion-/;
-
-    try {
-        const keys: string[] = [];
-
-        Object.keys(localStorage).forEach(key => {
-            if (keysToRemove.includes(key) || regex.test(key)) {
-                localStorage.removeItem(key);
-            }
-        });
-    } catch {
-        // Silently ignore any errors
-    }
-}


### PR DESCRIPTION
### Changes
***
Amends the process for removing TypeDoc related fields from local storage, and makes the removal of those fields optional through a boolean parameter (defaulting to false).

**Goal:**
Remove only TypeDoc local storage keys when toggling `disablingLocalStorage` usage, rather than clearing the local storage.

#### Rationale Behind Changes:
***
#2872 introduced the option to disable local storage. 

When using this option, the local storage is cleared in its entirety through `localStorage.clear()`. As a side effect, any strictly necessary, or otherwise categorized cookies are also deleted. This functionality should be limited to remove only TypeDoc specific fields, or in the default case not remove any of the fields.