### PR TITLE
Use same chevron on index

### DIFF
--- a/src/lib/output/themes/default/partials/icon.tsx
+++ b/src/lib/output/themes/default/partials/icon.tsx
@@ -61,6 +61,7 @@ export interface Icons extends Record<ReflectionKind, () => JSX.Element> {
     checkbox(): JSX.Element;
     menu(): JSX.Element;
     search(): JSX.Element;
+    /** @deprecated */
     chevronSmall(): JSX.Element;
     anchor(): JSX.Element;
     folder(): JSX.Element;

--- a/src/lib/output/themes/default/partials/index.tsx
+++ b/src/lib/output/themes/default/partials/index.tsx
@@ -56,7 +56,7 @@ export function index(context: DefaultThemeRenderContext, props: ContainerReflec
                 <section class="tsd-panel tsd-index-panel">
                     <details class="tsd-index-content tsd-accordion" open={true}>
                         <summary class="tsd-accordion-summary tsd-index-summary">
-                            {context.icons.chevronSmall()}
+                            {context.icons.chevronDown()}
                             <h5 class="tsd-index-heading uppercase">
                                 {i18n.theme_index()}
                             </h5>


### PR DESCRIPTION
This is a very minor issue I noticed while working on a custom theme. Most of the site uses `chevronDown`, but for some reason the index uses `chevronSmall`. It looks weird when everything is collapsed and they don't match.

## Before

<img width="214" alt="image" src="https://github.com/user-attachments/assets/bbc6e65f-8490-4a9a-b27f-92149af28ee8" />

## After

<img width="222" alt="Screenshot 2025-04-02 at 10 37 45 AM" src="https://github.com/user-attachments/assets/9c343f9f-f500-47b5-b9c7-c555d7e72b3c" />
