### PR TITLE
fix: Support `elementSummaries` for inlined union members

### DIFF
--- a/src/test/converter2/issues/gh2933.ts
+++ b/src/test/converter2/issues/gh2933.ts
@@ -1,0 +1,21 @@
+/**
+ * @inline
+ */
+type TestReturn =
+    /**
+     * An apple a day keeps the doctor away.
+     */
+    | { kind: 'apple', isHealthy: true }
+    /**
+     * A donut a day keeps the doctor not away.
+     */
+    | { kind: 'sweets', isHealthy: false }
+
+/**
+ * Returns a random value
+ */
+export function test(): TestReturn {
+    return Math.random() > 0.5
+        ? { kind: 'apple', isHealthy: true }
+        : { kind: 'sweets', isHealthy: false };
+}

--- a/src/test/issues.c2.test.ts
+++ b/src/test/issues.c2.test.ts
@@ -2115,4 +2115,19 @@ describe("Issue Tests", () => {
         const EdgeCases = query(project, "EdgeCases");
         equal(EdgeCases.typeParameters?.map(t => t.type?.toString()), ["number", undefined]);
     });
+
+    it('#2933 support elementSummaries for inlined union members', () => {
+        const project = convert();
+        const test = query(project, "test");
+        const sig = test.signatures?.[0];
+
+        equal(sig?.type?.type, "union");
+        equal(sig.type.types.length, 2);
+
+        equal(sig.type.elementSummaries?.length, 2);
+        equal(sig.type.elementSummaries.map(Comment.combineDisplayParts), [
+            "An apple a day keeps the doctor away.",
+            "A donut a day keeps the doctor not away."
+        ])
+    })
 });


### PR DESCRIPTION
Hello!

I've noticed a bug for a use case like this:

```ts
/**
 * @inline
 */
type TestReturn =
    /**
     * An apple a day keeps the doctor away.
     */
    | { kind: 'apple', isHealthy: true }
    /**
     * A donut a day keeps the doctor not away.
     */
    | { kind: 'sweets', isHealthy: false }

/**
 * Returns a random value
 */
export function test(): TestReturn {
    return Math.random() > 0.5
        ? { kind: 'apple', isHealthy: true }
        : { kind: 'sweets', isHealthy: false };
}
```

The `type.types` inside the signature doesn't receive the `elementSummaries` for the union type. I'm adding a failing test in this PR first to showcase the problem and show that it fails.

I'll spend some time to see if I can find the fix in this (so far unfamiliar) codebase. If not, I'll let you know 👍 