### PR TITLE
fix: Markdown link parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ title: Changelog
 ### Bug Fixes
 
 - Attempting to highlight a supported language which is not enabled is now a warning, not an error, #2956.
+- Improved compatibility with CommonMark's link parsing, #2959.
 
 ## v0.28.5 (2025-05-26)
 

--- a/src/lib/converter/comments/textParser.ts
+++ b/src/lib/converter/comments/textParser.ts
@@ -328,6 +328,10 @@ function isRelativePath(link: string) {
 function findLabelEnd(text: string, pos: number) {
     while (pos < text.length) {
         switch (text[pos]) {
+            case "\\":
+                ++pos;
+                if (pos < text.length && text[pos] === "\n") return pos;
+                break;
             case "\n":
             case "]":
             case "[":

--- a/src/lib/converter/comments/textParser.ts
+++ b/src/lib/converter/comments/textParser.ts
@@ -19,7 +19,6 @@ interface TextParserData {
     sourcePath: NormalizedPath;
     token: Token;
     pos: number;
-    i18n: TranslationProxy;
     warning: (msg: TranslatedString, token: Token) => void;
     files: FileRegistry;
     atNewLine: boolean;
@@ -84,7 +83,6 @@ export function textContent(
         sourcePath,
         token,
         pos: 0, // relative to the token
-        i18n,
         warning,
         files: files,
         atNewLine,

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -1562,13 +1562,14 @@ describe("Comment Parser", () => {
         );
     });
 
-    it("Recognizes markdown links which contain escapes in the label", () => {
+    it("Recognizes markdown links which contain parentheses and escapes in the label", () => {
         const comment = getComment(String.raw`/**
-            * [\[brackets\]](./relative.md)
+            * [(parens) \[brackets\]](./relative.md)
             *
             * [
             *  multi-line
             *  \[brackets\]
+            *  (parens)
             * ](
             *   ./relative.md
             *   )
@@ -1584,9 +1585,9 @@ describe("Comment Parser", () => {
         equal(
             comment.summary,
             [
-                { kind: "text", text: String.raw`[\[brackets\]](` },
+                { kind: "text", text: String.raw`[(parens) \[brackets\]](` },
                 link,
-                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n](\n  ` },
+                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n (parens)\n](\n  ` },
                 link,
                 { kind: "text", text: "\n  )" },
             ] satisfies CommentDisplayPart[],
@@ -1818,13 +1819,14 @@ describe("Raw Comment Parser", () => {
         files = undefined!;
     });
 
-    it("Recognizes markdown links which contain escapes in the label", () => {
+    it("Recognizes markdown links which contain parentheses and escapes in the label", () => {
         const comment = getComment(dedent(String.raw`
-            [\[brackets\]](./relative.md)
+            [(parens) \[brackets\]](./relative.md)
 
             [
              multi-line
              \[brackets\]
+             (parens)
             ](
               ./relative.md
               )
@@ -1840,9 +1842,9 @@ describe("Raw Comment Parser", () => {
         equal(
             comment.content,
             [
-                { kind: "text", text: String.raw`[\[brackets\]](` },
+                { kind: "text", text: String.raw`[(parens) \[brackets\]](` },
                 link,
-                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n](\n  ` },
+                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n (parens)\n](\n  ` },
                 link,
                 { kind: "text", text: "\n  )" },
             ] satisfies CommentDisplayPart[],

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -1500,6 +1500,26 @@ describe("Comment Parser", () => {
         );
     });
 
+    it("Recognizes markdown links which contain escapes in the label", () => {
+        const comment = getComment(String.raw`/**
+            * [\[brackets\]](./relative.md)
+            */`);
+
+        equal(
+            comment.summary,
+            [
+                { kind: "text", text: String.raw`[\[brackets\]](` },
+                {
+                    kind: "relative-link",
+                    text: "./relative.md",
+                    target: 1,
+                    targetAnchor: undefined,
+                },
+                { kind: "text", text: ")" },
+            ] satisfies CommentDisplayPart[],
+        );
+    });
+
     it("Recognizes markdown reference definition blocks", () => {
         const comment = getComment(`/**
             * [1]: ./example.md

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -1565,18 +1565,27 @@ describe("Comment Parser", () => {
     it("Recognizes markdown links which contain escapes in the label", () => {
         const comment = getComment(String.raw`/**
             * [\[brackets\]](./relative.md)
+            *
+            * [
+            *  multi-line
+            *  \[brackets\]
+            * ](./relative.md)
             */`);
+
+        const link = {
+            kind: "relative-link",
+            text: "./relative.md",
+            target: 1,
+            targetAnchor: undefined,
+        } as const;
 
         equal(
             comment.summary,
             [
                 { kind: "text", text: String.raw`[\[brackets\]](` },
-                {
-                    kind: "relative-link",
-                    text: "./relative.md",
-                    target: 1,
-                    targetAnchor: undefined,
-                },
+                link,
+                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n](` },
+                link,
                 { kind: "text", text: ")" },
             ] satisfies CommentDisplayPart[],
         );
@@ -1808,18 +1817,29 @@ describe("Raw Comment Parser", () => {
     });
 
     it("Recognizes markdown links which contain escapes in the label", () => {
-        const comment = getComment(String.raw`[\[brackets\]](./relative.md)`);
+        const comment = getComment(dedent(String.raw`
+            [\[brackets\]](./relative.md)
+
+            [
+             multi-line
+             \[brackets\]
+            ](./relative.md)
+            `));
+
+        const link = {
+            kind: "relative-link",
+            text: "./relative.md",
+            target: 1,
+            targetAnchor: undefined,
+        } as const;
 
         equal(
             comment.content,
             [
                 { kind: "text", text: String.raw`[\[brackets\]](` },
-                {
-                    kind: "relative-link",
-                    text: "./relative.md",
-                    target: 1,
-                    targetAnchor: undefined,
-                },
+                link,
+                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n](` },
+                link,
                 { kind: "text", text: ")" },
             ] satisfies CommentDisplayPart[],
         );

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -1569,7 +1569,9 @@ describe("Comment Parser", () => {
             * [
             *  multi-line
             *  \[brackets\]
-            * ](./relative.md)
+            * ](
+            *   ./relative.md
+            *   )
             */`);
 
         const link = {
@@ -1584,9 +1586,9 @@ describe("Comment Parser", () => {
             [
                 { kind: "text", text: String.raw`[\[brackets\]](` },
                 link,
-                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n](` },
+                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n](\n  ` },
                 link,
-                { kind: "text", text: ")" },
+                { kind: "text", text: "\n  )" },
             ] satisfies CommentDisplayPart[],
         );
     });
@@ -1823,7 +1825,9 @@ describe("Raw Comment Parser", () => {
             [
              multi-line
              \[brackets\]
-            ](./relative.md)
+            ](
+              ./relative.md
+              )
             `));
 
         const link = {
@@ -1838,9 +1842,9 @@ describe("Raw Comment Parser", () => {
             [
                 { kind: "text", text: String.raw`[\[brackets\]](` },
                 link,
-                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n](` },
+                { kind: "text", text: `)\n\n[\n multi-line\n ${String.raw`\[brackets\]`}\n](\n  ` },
                 link,
-                { kind: "text", text: ")" },
+                { kind: "text", text: "\n  )" },
             ] satisfies CommentDisplayPart[],
         );
     });

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -1600,6 +1600,7 @@ describe("Comment Parser", () => {
             const embedded = `/**\n${lines.map(line => " * " + line).join("\n")}\n */`;
             return getComment(embedded);
         };
+
         for (const { input, expect } of generateLinkTitleCases()) {
             const comment = embedInComment(input);
             equal(comment.summary, expect, `input: ${JSON.stringify(input)}`);
@@ -1799,9 +1800,8 @@ describe("Raw Comment Parser", () => {
         commentStyle: "jsdoc",
     };
 
-    let files: FileRegistry;
     function getComment(text: string) {
-        files = new FileRegistry();
+        const files = new FileRegistry();
         const logger = new TestLogger();
         const content = lexCommentString(text);
         const comment = parseCommentString(
@@ -1814,10 +1814,6 @@ describe("Raw Comment Parser", () => {
         logger.expectNoOtherMessages();
         return comment;
     }
-
-    afterEach(() => {
-        files = undefined!;
-    });
 
     it("Recognizes markdown links which contain parentheses and escapes in the label", () => {
         const comment = getComment(dedent(String.raw`
@@ -1860,7 +1856,7 @@ describe("Raw Comment Parser", () => {
 });
 
 describe("Markdown Link Title Generation", () => {
-    const inputs = [] as string[];
+    const inputs: string[] = [];
     for (const { input } of generateLinkTitleCases()) {
         inputs.push(input);
     }


### PR DESCRIPTION
Fixes #2959

Improves alignment with [CommonMark](https://spec.commonmark.org/0.31.2/#links), although does not include support for unescaped nesting.

Can be reviewed commit-by-commit.