### PR TITLE
Allow hyphenated JSDoc tags

### DIFF
--- a/src/lib/converter/comments/blockLexer.ts
+++ b/src/lib/converter/comments/blockLexer.ts
@@ -263,7 +263,7 @@ function* lexBlockComment2(
                 if (lookahead !== pos + 1) {
                     while (
                         lookahead < end &&
-                        /[a-z0-9]/i.test(file[lookahead])
+                        /[a-z0-9-]/i.test(file[lookahead])
                     ) {
                         lookahead++;
                     }

--- a/src/lib/converter/comments/lineLexer.ts
+++ b/src/lib/converter/comments/lineLexer.ts
@@ -179,7 +179,7 @@ function* lexLineComments2(
                 if (lookahead !== pos + 1) {
                     while (
                         lookahead < end &&
-                        /[a-z0-9]/i.test(file[lookahead])
+                        /[a-z0-9-]/i.test(file[lookahead])
                     ) {
                         lookahead++;
                     }

--- a/src/lib/converter/comments/rawLexer.ts
+++ b/src/lib/converter/comments/rawLexer.ts
@@ -176,7 +176,7 @@ function* lexCommentString2(
                 if (lookahead !== pos + 1) {
                     while (
                         lookahead < end &&
-                        /[a-z0-9]/i.test(file[lookahead])
+                        /[a-z0-9-]/i.test(file[lookahead])
                     ) {
                         lookahead++;
                     }

--- a/src/lib/utils-common/validation.ts
+++ b/src/lib/utils-common/validation.ts
@@ -120,5 +120,5 @@ export function optional<T extends Schema>(x: T): Optional<T> {
 }
 
 export function isTagString(x: unknown): x is `@${string}` {
-    return typeof x === "string" && /^@[a-zA-Z][a-zA-Z0-9]*$/.test(x);
+    return typeof x === "string" && /^@[a-z][a-z0-9-]*$/i.test(x);
 }

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -186,7 +186,7 @@ describe("Block Comment Lexer", () => {
     });
 
     it("Should recognize tags", () => {
-        const tokens = lex("/* @tag @a @abc234 */");
+        const tokens = lex("/* @tag @a @abc234 @abc-234 */");
 
         equal(tokens, [
             { kind: TokenSyntaxKind.Tag, text: "@tag", pos: 3 },
@@ -194,6 +194,8 @@ describe("Block Comment Lexer", () => {
             { kind: TokenSyntaxKind.Tag, text: "@a", pos: 8 },
             { kind: TokenSyntaxKind.Text, text: " ", pos: 10 },
             { kind: TokenSyntaxKind.Tag, text: "@abc234", pos: 11 },
+            { kind: TokenSyntaxKind.Text, text: " ", pos: 18 },
+            { kind: TokenSyntaxKind.Tag, text: "@abc-234", pos: 19 },
         ]);
     });
 
@@ -641,7 +643,7 @@ describe("Line Comment Lexer", () => {
     });
 
     it("Should recognize tags", () => {
-        const tokens = lex("// @tag @a @abc234");
+        const tokens = lex("// @tag @a @abc234 @abc-234");
 
         equal(tokens, [
             { kind: TokenSyntaxKind.Tag, text: "@tag", pos: 3 },
@@ -649,6 +651,8 @@ describe("Line Comment Lexer", () => {
             { kind: TokenSyntaxKind.Tag, text: "@a", pos: 8 },
             { kind: TokenSyntaxKind.Text, text: " ", pos: 10 },
             { kind: TokenSyntaxKind.Tag, text: "@abc234", pos: 11 },
+            { kind: TokenSyntaxKind.Text, text: " ", pos: 18 },
+            { kind: TokenSyntaxKind.Tag, text: "@abc-234", pos: 19 },
         ]);
     });
 
@@ -993,12 +997,12 @@ describe("Raw Lexer", () => {
     });
 
     it("Should not recognize tags", () => {
-        const tokens = lex("@123 @@ @ @tag @a @abc234");
+        const tokens = lex("@123 @@ @ @tag @a @abc234 @abc-234");
 
         equal(tokens, [
             {
                 kind: TokenSyntaxKind.Text,
-                text: "@123 @@ @ @tag @a @abc234",
+                text: "@123 @@ @ @tag @a @abc234 @abc-234",
                 pos: 0,
             },
         ]);

--- a/src/test/utils/options/default-options.test.ts
+++ b/src/test/utils/options/default-options.test.ts
@@ -161,11 +161,15 @@ describe("Default Options", () => {
 
     describe("blockTags", () => {
         it("Should disallow non-tags", () => {
-            throws(() => opts.setValue("blockTags", ["@bad-non-tag"]));
+            throws(() => opts.setValue("blockTags", ["@bad_tag"]));
+            throws(() => opts.setValue("blockTags", ["@2bad"]));
         });
 
         it("Should allow tags", () => {
             doesNotThrow(() => opts.setValue("blockTags", ["@good"]));
+            doesNotThrow(() => opts.setValue("blockTags", ["@good2"]));
+            doesNotThrow(() => opts.setValue("blockTags", ["@Good"]));
+            doesNotThrow(() => opts.setValue("blockTags", ["@good-tag"]));
         });
     });
 


### PR DESCRIPTION
JSDoc tags may contain hyphens.  For example, `@TJS-type`, which is used by [`typescript-json-schema`](https://www.npmjs.com/package/typescript-json-schema).

---

~There are no existing tests for this function, but I can add a test for this change, if desired.  ([This test](https://github.com/TypeStrong/typedoc/blob/e8b6df3d83cbbe4010d5919ed72c6003c90036d1/src/test/utils-common/validation.test.ts#L35-L38) is close, but it is testing other functionality, not `isTagString` itself.)~

I stand corrected.  [This test](https://github.com/TypeStrong/typedoc/blob/master/src/test/utils/options/default-options.test.ts#L164) was [recently added](https://github.com/TypeStrong/typedoc/commit/1bf3217dbcf2e4a9ba3eb496296dd6d62db36d5f), explicitly disallowing hyphenated tags.  I'm unclear as to why though.  Is there a reason to reject hyphenated tags?
