### PR TITLE
Handle relative links in `<source srcset>`

### DIFF
--- a/src/lib/converter/comments/textParser.ts
+++ b/src/lib/converter/comments/textParser.ts
@@ -297,7 +297,7 @@ function checkReference(data: TextParserData): RelativeLink | undefined {
 }
 
 /**
- * Looks for `<a href="./relative">` and `<img src="./relative">`
+ * Looks for `<a href="./relative">`, `<img src="./relative">`, and `<source srcset="./relative">`
  */
 function checkTagLink(data: TextParserData): RelativeLink | undefined {
     const { pos, token } = data;
@@ -310,6 +310,11 @@ function checkTagLink(data: TextParserData): RelativeLink | undefined {
     if (token.text.startsWith("<a ", pos)) {
         data.pos += 3;
         return checkAttribute(data, "href");
+    }
+
+    if (token.text.startsWith("<source ", pos)) {
+        data.pos += 8;
+        return checkAttribute(data, "srcset");
     }
 }
 

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -1636,6 +1636,38 @@ describe("Comment Parser", () => {
         );
     });
 
+    it("Recognizes HTML picture source srcset links", () => {
+        const comment = getComment(`/**
+        * <source media="(prefers-color-scheme: light)"  srcset="./test.png" >
+        * <source media="(prefers-color-scheme: dark)"  srcset="./test space.png"/>
+        * <source srcset="https://example.com/favicon.ico">
+        */`);
+
+        equal(
+            comment.summary,
+            [
+                { kind: "text", text: '<source media="(prefers-color-scheme: light)"  srcset="' },
+                {
+                    kind: "relative-link",
+                    text: "./test.png",
+                    target: 1 as FileId,
+                    targetAnchor: undefined,
+                },
+                { kind: "text", text: '" >\n<source media="(prefers-color-scheme: dark)"  srcset="' },
+                {
+                    kind: "relative-link",
+                    text: "./test space.png",
+                    target: 2 as FileId,
+                    targetAnchor: undefined,
+                },
+                {
+                    kind: "text",
+                    text: '"/>\n<source srcset="https://example.com/favicon.ico">',
+                },
+            ] satisfies CommentDisplayPart[],
+        );
+    });
+
     it("Recognizes HTML anchor links", () => {
         const comment = getComment(`/**
         * <a data-foo="./path.txt" href="./test.png" >


### PR DESCRIPTION
I tried this locally and it seems to work. Fixes #2975.

## Before

<img width="1185" height="729" alt="image" src="https://github.com/user-attachments/assets/8f8a62a1-2334-4526-b4b4-304fb0ddfeca" />


## After

<img width="1185" height="729" alt="image" src="https://github.com/user-attachments/assets/b1455ba4-340f-4d2b-8778-c00b1e99d0ed" />
