### PR TITLE
Fix: Custom theme icons are not used in the "On This Page" side nav

### DIFF
--- a/src/lib/output/events.ts
+++ b/src/lib/output/events.ts
@@ -6,6 +6,7 @@ import {
     type ReflectionKind,
 } from "../models/index.js";
 import type { PageDefinition, PageKind, RouterTarget } from "./router.js";
+import { type Icons } from "./themes/default/partials/icon.js";
 
 /**
  * An event emitted by the {@link Renderer} class at the very beginning and
@@ -59,6 +60,7 @@ export interface PageHeading {
     level?: number;
     kind?: ReflectionKind;
     classes?: string;
+    icon?: keyof Icons & (string | number);
 }
 
 /**

--- a/src/lib/output/themes/default/partials/member.tsx
+++ b/src/lib/output/themes/default/partials/member.tsx
@@ -12,6 +12,7 @@ export function member(context: DefaultThemeRenderContext, props: DeclarationRef
         text: getDisplayName(props),
         kind: props.kind,
         classes: context.getReflectionClasses(props),
+        icon: context.theme.getReflectionIcon(props),
     });
 
     // With the default url derivation, we'll never hit this case as documents are always placed into their

--- a/src/lib/output/themes/default/partials/moduleReflection.tsx
+++ b/src/lib/output/themes/default/partials/moduleReflection.tsx
@@ -81,6 +81,7 @@ export function moduleMemberSummary(
         text: getDisplayName(member),
         kind: member instanceof ReferenceReflection ? member.getTargetReflectionDeep().kind : member.kind,
         classes: context.getReflectionClasses(member),
+        icon: context.theme.getReflectionIcon(member),
     });
 
     let name: JSX.Element;

--- a/src/lib/output/themes/default/partials/navigation.tsx
+++ b/src/lib/output/themes/default/partials/navigation.tsx
@@ -190,7 +190,7 @@ function buildSectionNavigation(context: DefaultThemeRenderContext, headings: Pa
 
         levels[levels.length - 1].push(
             <a href={heading.link} class={classNames({}, heading.classes)}>
-                {heading.kind && context.icons[heading.kind]()}
+                {heading.icon && context.icons[heading.icon]()}
                 <span>{wbr(heading.text)}</span>
             </a>,
         );


### PR DESCRIPTION
Fixes https://github.com/TypeStrong/typedoc/issues/3034.

Uses `getReflectionIcon` instead of just looking up based on `ReflectionKind`.