### PR TITLE
feat(theme): add id attributes to group headings for linking

### DIFF
--- a/src/lib/output/themes/default/partials/index.tsx
+++ b/src/lib/output/themes/default/partials/index.tsx
@@ -2,14 +2,22 @@ import { classNames, getMemberSections, isNoneSection, type MemberSection, rende
 import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext.js";
 import { i18n, JSX } from "#utils";
 import type { ContainerReflection } from "../../../../models/index.js";
+import { anchorIcon } from "./anchor-icon.js";
 
 function renderSection(
-    { urlTo, reflectionIcon, getReflectionClasses, markdown }: DefaultThemeRenderContext,
+    context: DefaultThemeRenderContext,
     item: MemberSection,
 ) {
+    const { urlTo, reflectionIcon, getReflectionClasses, markdown, slugger } = context;
+    const sectionId = !isNoneSection(item) ? slugger.slug(item.title) : undefined;
     return (
         <section class="tsd-index-section">
-            {!isNoneSection(item) && <h3 class="tsd-index-heading">{item.title}</h3>}
+            {!isNoneSection(item) && (
+                <h3 class="tsd-index-heading" id={sectionId}>
+                    {item.title}
+                    {anchorIcon(context, sectionId)}
+                </h3>
+            )}
             {item.description && (
                 <div class="tsd-comment tsd-typography">
                     <JSX.Raw html={markdown(item.description)} />

--- a/src/lib/output/themes/default/partials/index.tsx
+++ b/src/lib/output/themes/default/partials/index.tsx
@@ -13,7 +13,7 @@ function renderSection(
     return (
         <section class="tsd-index-section">
             {!isNoneSection(item) && (
-                <h3 class="tsd-index-heading" id={sectionId}>
+                <h3 class="tsd-index-heading tsd-anchor-link" id={sectionId}>
                     {item.title}
                     {anchorIcon(context, sectionId)}
                 </h3>

--- a/src/lib/output/themes/default/partials/members.tsx
+++ b/src/lib/output/themes/default/partials/members.tsx
@@ -2,6 +2,7 @@ import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext.js"
 import { JSX } from "#utils";
 import { type ContainerReflection } from "../../../../models/index.js";
 import { getMemberSections, isNoneSection } from "../../lib.js";
+import { anchorIcon } from "./anchor-icon.js";
 
 export function members(context: DefaultThemeRenderContext, props: ContainerReflection) {
     const sections = getMemberSections(props, (child) => !context.router.hasOwnDocument(child));
@@ -19,12 +20,14 @@ export function members(context: DefaultThemeRenderContext, props: ContainerRefl
 
                 context.page.startNewSection(section.title);
 
+                const sectionId = context.slugger.slug(section.title);
                 return (
                     <details class="tsd-panel-group tsd-member-group tsd-accordion" open>
                         <summary class="tsd-accordion-summary" data-key={"section-" + section.title}>
                             {context.icons.chevronDown()}
-                            <h2>
+                            <h2 id={sectionId}>
                                 {section.title}
+                                {anchorIcon(context, sectionId)}
                             </h2>
                         </summary>
                         <section>{section.children.map((item) => context.member(item))}</section>

--- a/src/lib/output/themes/default/partials/members.tsx
+++ b/src/lib/output/themes/default/partials/members.tsx
@@ -25,7 +25,7 @@ export function members(context: DefaultThemeRenderContext, props: ContainerRefl
                     <details class="tsd-panel-group tsd-member-group tsd-accordion" open>
                         <summary class="tsd-accordion-summary" data-key={"section-" + section.title}>
                             {context.icons.chevronDown()}
-                            <h2 id={sectionId}>
+                            <h2 class="tsd-anchor-link" id={sectionId}>
                                 {section.title}
                                 {anchorIcon(context, sectionId)}
                             </h2>

--- a/src/lib/output/themes/default/partials/moduleReflection.tsx
+++ b/src/lib/output/themes/default/partials/moduleReflection.tsx
@@ -60,7 +60,7 @@ export function moduleReflection(context: DefaultThemeRenderContext, mod: Declar
                     <details class="tsd-panel-group tsd-member-group tsd-accordion" open>
                         <summary class="tsd-accordion-summary" data-key={"section-" + section.title}>
                             {context.icons.chevronDown()}
-                            <h2 id={sectionId}>
+                            <h2 class="tsd-anchor-link" id={sectionId}>
                                 {section.title}
                                 {anchorIcon(context, sectionId)}
                             </h2>

--- a/src/lib/output/themes/default/partials/moduleReflection.tsx
+++ b/src/lib/output/themes/default/partials/moduleReflection.tsx
@@ -55,12 +55,14 @@ export function moduleReflection(context: DefaultThemeRenderContext, mod: Declar
                     );
                 }
 
+                const sectionId = context.slugger.slug(section.title);
                 return (
                     <details class="tsd-panel-group tsd-member-group tsd-accordion" open>
                         <summary class="tsd-accordion-summary" data-key={"section-" + section.title}>
                             {context.icons.chevronDown()}
-                            <h2>
+                            <h2 id={sectionId}>
                                 {section.title}
+                                {anchorIcon(context, sectionId)}
                             </h2>
                         </summary>
                         {content}

--- a/src/test/renderer/specs/classes/BaseClass.json
+++ b/src/test/renderer/specs/classes/BaseClass.json
@@ -105,7 +105,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -126,7 +135,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -172,7 +190,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -261,7 +288,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3007.DOMBase.json
+++ b/src/test/renderer/specs/classes/GH3007.DOMBase.json
@@ -96,7 +96,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -117,7 +126,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -153,7 +171,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -317,7 +344,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3007.DOMClass.json
+++ b/src/test/renderer/specs/classes/GH3007.DOMClass.json
@@ -96,7 +96,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Methods"
+                                                "h3.tsd-index-heading#methods": [
+                                                    "Methods",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#methods",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -131,7 +140,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3014.json
+++ b/src/test/renderer/specs/classes/GH3014.json
@@ -90,7 +90,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Constructors"
+                                                "h3.tsd-index-heading#constructors": [
+                                                    "Constructors",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#constructors",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -125,7 +134,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3052.CustomPromise.json
+++ b/src/test/renderer/specs/classes/GH3052.CustomPromise.json
@@ -115,7 +115,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -136,7 +145,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -167,7 +185,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -223,7 +250,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -369,7 +405,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -454,7 +499,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3052.PromiseReference.json
+++ b/src/test/renderer/specs/classes/GH3052.PromiseReference.json
@@ -70,7 +70,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -91,7 +100,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -137,7 +155,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -226,7 +253,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GenericClass.json
+++ b/src/test/renderer/specs/classes/GenericClass.json
@@ -100,7 +100,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -121,7 +130,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -163,7 +181,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -347,7 +374,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/ModifiersClass.json
+++ b/src/test/renderer/specs/classes/ModifiersClass.json
@@ -59,7 +59,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -80,7 +89,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -146,7 +164,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -269,7 +296,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/RenderClass.json
+++ b/src/test/renderer/specs/classes/RenderClass.json
@@ -146,7 +146,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -167,7 +176,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -188,7 +206,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Accessors"
+                                                    "h3.tsd-index-heading#accessors": [
+                                                        "Accessors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#accessors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -225,7 +252,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -281,7 +317,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -450,7 +495,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -525,7 +579,16 @@
                                 "data-key": "section-Accessors"
                             },
                             "children": {
-                                "h2": "Accessors"
+                                "h2#accessors-1": [
+                                    "Accessors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#accessors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -788,7 +851,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/enums/Enumeration.json
+++ b/src/test/renderer/specs/enums/Enumeration.json
@@ -97,7 +97,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Enumeration Members"
+                                                "h3.tsd-index-heading#enumeration-members": [
+                                                    "Enumeration Members",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#enumeration-members",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -142,7 +151,16 @@
                                 "data-key": "section-Enumeration Members"
                             },
                             "children": {
-                                "h2": "Enumeration Members"
+                                "h2#enumeration-members-1": [
+                                    "Enumeration Members",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#enumeration-members-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/BaseInterface.json
+++ b/src/test/renderer/specs/interfaces/BaseInterface.json
@@ -140,7 +140,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Methods"
+                                                "h3.tsd-index-heading#methods": [
+                                                    "Methods",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#methods",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -185,7 +194,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/ExpandType.ExpandedByDefault.json
+++ b/src/test/renderer/specs/interfaces/ExpandType.ExpandedByDefault.json
@@ -111,7 +111,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -146,7 +155,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/GH2982.TMXDataNode.json
+++ b/src/test/renderer/specs/interfaces/GH2982.TMXDataNode.json
@@ -191,7 +191,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -226,7 +235,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/GH3007.DOMIterable.json
+++ b/src/test/renderer/specs/interfaces/GH3007.DOMIterable.json
@@ -177,7 +177,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -212,7 +221,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/NoneCategory.json
+++ b/src/test/renderer/specs/interfaces/NoneCategory.json
@@ -159,7 +159,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -180,7 +189,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties - Other"
+                                                    "h3.tsd-index-heading#properties-other": [
+                                                        "Properties - Other",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties-other",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -266,7 +284,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -333,7 +360,16 @@
                                 "data-key": "section-Properties - Other"
                             },
                             "children": {
-                                "h2": "Properties - Other"
+                                "h2#properties-other-1": [
+                                    "Properties - Other",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-other-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/NoneGroup.json
+++ b/src/test/renderer/specs/interfaces/NoneGroup.json
@@ -138,7 +138,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -224,7 +233,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/gh2995.json
+++ b/src/test/renderer/specs/interfaces/gh2995.json
@@ -136,7 +136,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Methods"
+                                                "h3.tsd-index-heading#methods": [
+                                                    "Methods",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#methods",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -177,7 +186,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules.json
+++ b/src/test/renderer/specs/modules.json
@@ -34,7 +34,16 @@
                                 "data-key": "section-Documents"
                             },
                             "children": {
-                                "h2": "Documents"
+                                "h2#documents": [
+                                    "Documents",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#documents",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -78,7 +87,16 @@
                                 "data-key": "section-Namespaces"
                             },
                             "children": {
-                                "h2": "Namespaces"
+                                "h2#namespaces": [
+                                    "Namespaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#namespaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -191,7 +209,16 @@
                                 "data-key": "section-Enumerations"
                             },
                             "children": {
-                                "h2": "Enumerations"
+                                "h2#enumerations": [
+                                    "Enumerations",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#enumerations",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -235,7 +262,16 @@
                                 "data-key": "section-Classes"
                             },
                             "children": {
-                                "h2": "Classes"
+                                "h2#classes": [
+                                    "Classes",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#classes",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -371,7 +407,16 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2": "Interfaces"
+                                "h2#interfaces": [
+                                    "Interfaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#interfaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -507,7 +552,16 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2": "Type Aliases"
+                                "h2#type-aliases": [
+                                    "Type Aliases",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#type-aliases",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -574,7 +628,16 @@
                                 "data-key": "section-Functions"
                             },
                             "children": {
-                                "h2": "Functions"
+                                "h2#functions": [
+                                    "Functions",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#functions",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -618,7 +681,16 @@
                                 "data-key": "section-References"
                             },
                             "children": {
-                                "h2": "References"
+                                "h2#references": [
+                                    "References",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#references",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/ExpandType.NestedBehavior1.json
+++ b/src/test/renderer/specs/modules/ExpandType.NestedBehavior1.json
@@ -48,7 +48,16 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2": "Type Aliases"
+                                "h2#type-aliases": [
+                                    "Type Aliases",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#type-aliases",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/ExpandType.json
+++ b/src/test/renderer/specs/modules/ExpandType.json
@@ -37,7 +37,16 @@
                                 "data-key": "section-Namespaces"
                             },
                             "children": {
-                                "h2": "Namespaces"
+                                "h2#namespaces": [
+                                    "Namespaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#namespaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -81,7 +90,16 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2": "Interfaces"
+                                "h2#interfaces": [
+                                    "Interfaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#interfaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -125,7 +143,16 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2": "Type Aliases"
+                                "h2#type-aliases": [
+                                    "Type Aliases",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#type-aliases",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/GH2982.json
+++ b/src/test/renderer/specs/modules/GH2982.json
@@ -37,7 +37,16 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2": "Interfaces"
+                                "h2#interfaces": [
+                                    "Interfaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#interfaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -81,7 +90,16 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2": "Type Aliases"
+                                "h2#type-aliases": [
+                                    "Type Aliases",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#type-aliases",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/GH3007.json
+++ b/src/test/renderer/specs/modules/GH3007.json
@@ -37,7 +37,16 @@
                                 "data-key": "section-Classes"
                             },
                             "children": {
-                                "h2": "Classes"
+                                "h2#classes": [
+                                    "Classes",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#classes",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -104,7 +113,16 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2": "Interfaces"
+                                "h2#interfaces": [
+                                    "Interfaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#interfaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/GH3052.json
+++ b/src/test/renderer/specs/modules/GH3052.json
@@ -37,7 +37,16 @@
                                 "data-key": "section-Classes"
                             },
                             "children": {
-                                "h2": "Classes"
+                                "h2#classes": [
+                                    "Classes",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#classes",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.AExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.AExpanded.json
@@ -169,7 +169,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -224,7 +233,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.BExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.BExpanded.json
@@ -169,7 +169,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -224,7 +233,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.Expandable.json
+++ b/src/test/renderer/specs/types/ExpandType.Expandable.json
@@ -115,7 +115,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -150,7 +159,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.Expandable2.json
+++ b/src/test/renderer/specs/types/ExpandType.Expandable2.json
@@ -115,7 +115,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -150,7 +159,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AExpanded.json
@@ -178,7 +178,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -233,7 +242,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AllExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AllExpanded.json
@@ -178,7 +178,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -233,7 +242,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/Nested.json
+++ b/src/test/renderer/specs/types/Nested.json
@@ -201,7 +201,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -236,7 +245,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {


### PR DESCRIPTION
Add id attributes and anchor icons to group headings in the default theme, allowing users to link directly to specific groups in the documentation.

This includes:
- h2 group headings in members.tsx (member groups)
- h2 group headings in moduleReflection.tsx (module groups)
- h3 group headings in index.tsx (index sections)

Example: modules.html#Runtime_Guards now links directly to that group.

Closes TypeStrong#3029