### PR TITLE
Validate file registry paths during `validate()` for `--emit none`

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -41,6 +41,7 @@ import { fileURLToPath } from "url";
 import { createRequire } from "module";
 import { Outputs } from "./output/output.js";
 import { validateMergeModuleWith } from "./validation/unusedMergeModuleWith.js";
+import { validateFilePaths } from "./validation/filePaths.js";
 import { diagnostic, diagnostics } from "./utils/loggers.js";
 import { ValidatingFileRegistry } from "./utils/ValidatingFileRegistry.js";
 import { Internationalization } from "./internationalization/internationalization.js";
@@ -701,6 +702,10 @@ export class Application extends AbstractComponent<
 
         if (checks.unusedMergeModuleWith) {
             validateMergeModuleWith(project, this.logger);
+        }
+
+        if (checks.invalidPath) {
+            validateFilePaths(project, this.logger);
         }
 
         this.trigger(Application.EVENT_VALIDATE_PROJECT, project);

--- a/src/lib/models/FileRegistry.ts
+++ b/src/lib/models/FileRegistry.ts
@@ -121,6 +121,20 @@ export class FileRegistry {
         return this.names.get(id);
     }
 
+    /**
+     * Iterate over all registered media file paths, yielding entries
+     * that do NOT have an associated reflection.
+     */
+    getMediaPaths(): Iterable<NormalizedPath> {
+        const result: NormalizedPath[] = [];
+        for (const [id, path] of this.mediaToPath.entries()) {
+            if (!this.mediaToReflection.has(id)) {
+                result.push(path);
+            }
+        }
+        return result;
+    }
+
     getNameToAbsoluteMap(): ReadonlyMap<string, string> {
         const result = new Map<string, string>();
         for (const [id, name] of this.names.entries()) {

--- a/src/lib/output/plugins/AssetsPlugin.ts
+++ b/src/lib/output/plugins/AssetsPlugin.ts
@@ -125,10 +125,6 @@ export class AssetsPlugin extends RendererComponent {
             for (const [fileName, absolute] of toCopy.entries()) {
                 if (isFile(absolute)) {
                     copySync(absolute, join(media, fileName));
-                } else {
-                    this.application.logger.warn(
-                        i18n.relative_path_0_is_not_a_file_and_will_not_be_copied_to_output(absolute),
-                    );
                 }
             }
         }

--- a/src/lib/validation/filePaths.ts
+++ b/src/lib/validation/filePaths.ts
@@ -1,0 +1,16 @@
+import type { ProjectReflection } from "../models/index.js";
+import { i18n, type Logger } from "#utils";
+import { isFile } from "../utils/fs.js";
+
+export function validateFilePaths(
+    project: ProjectReflection,
+    logger: Logger,
+): void {
+    for (const absolute of project.files.getMediaPaths()) {
+        if (!isFile(absolute)) {
+            logger.validationWarning(
+                i18n.relative_path_0_is_not_a_file_and_will_not_be_copied_to_output(absolute),
+            );
+        }
+    }
+}


### PR DESCRIPTION
**:warning: Disclaimer:** This is vibe-coded.  I did my best to steer Claude to follow the conventions of this project, and the result looks reasonable to me, but I am very open to feedback.  I would like to get this issue fixed, but I don't have a strong opinion on how it should be fixed.  If you would prefer me to file an issue instead, let me know.  For additional context, see https://github.com/modelcontextprotocol/typescript-sdk/pull/1546.

---

When `--emit none` is used with `treatWarningsAsErrors`, warnings about relative links pointing to directories were silently suppressed because the only `isFile()` check lived in `AssetsPlugin.onRenderEnd()`, which is skipped entirely when rendering is disabled.

This adds a `validateFilePaths()` validation pass that runs during `Application.validate()`, gated on the existing `validation.invalidPath` option. It iterates all registered file paths that lack a reflection association (preserving packages-mode directory links which map to reflections) and emits `validationWarning()` for non-file entries.

Because `validate()` runs before the `--emit none` gate in `cli.ts`, directory-pointing relative links now produce warnings regardless of emit mode.
