### PR TITLE
Support --commentStyle triple-slash

### DIFF
--- a/src/lib/converter/comments/discovery.ts
+++ b/src/lib/converter/comments/discovery.ts
@@ -737,6 +737,12 @@ function permittedRange(
             return ranges[0].kind === ts.SyntaxKind.MultiLineCommentTrivia;
         case CommentStyle.Line:
             return ranges[0].kind === ts.SyntaxKind.SingleLineCommentTrivia;
+        case CommentStyle.TripleSlash:
+            return (
+                ranges[0].kind === ts.SyntaxKind.SingleLineCommentTrivia &&
+                text[ranges[0].pos + 2] === "/" &&
+                text[ranges[0].pos + 3] !== "/"
+            );
         case CommentStyle.JSDoc:
             return (
                 ranges[0].kind === ts.SyntaxKind.MultiLineCommentTrivia &&

--- a/src/lib/utils/options/declaration.ts
+++ b/src/lib/utils/options/declaration.ts
@@ -35,6 +35,7 @@ export const CommentStyle = {
     JSDoc: "jsdoc",
     Block: "block",
     Line: "line",
+    TripleSlash: "triple-slash",
     All: "all",
 } as const;
 export type CommentStyle = (typeof CommentStyle)[keyof typeof CommentStyle];


### PR DESCRIPTION
Which acts like 'line', but ignores comment lines that don't start with (precisely) three slashes.
