### PR TITLE
feat(theme): add id attribute to group/category section headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ title: Changelog
 ### Features
 
 - Introduced `generateOutputsBegin` and `generateOutputsEnd` events on `Application` for plugin use.
+- Group/category section headings (`<h2>`) in the default theme now include an `id` attribute so they can be linked to via fragment identifiers (e.g. `modules.html#runtime-guards`), #3029.
 
 ## v0.28.19 (2026-04-12)
 

--- a/src/lib/output/themes/default/partials/index.tsx
+++ b/src/lib/output/themes/default/partials/index.tsx
@@ -2,14 +2,22 @@ import { classNames, getMemberSections, isNoneSection, type MemberSection, rende
 import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext.js";
 import { i18n, JSX } from "#utils";
 import type { ContainerReflection } from "../../../../models/index.js";
+import { anchorIcon } from "./anchor-icon.js";
 
 function renderSection(
-    { urlTo, reflectionIcon, getReflectionClasses, markdown }: DefaultThemeRenderContext,
+    context: DefaultThemeRenderContext,
     item: MemberSection,
 ) {
+    const { urlTo, reflectionIcon, getReflectionClasses, markdown, slugger } = context;
+    const sectionAnchor = !isNoneSection(item) ? slugger.slug(item.title) : undefined;
     return (
         <section class="tsd-index-section">
-            {!isNoneSection(item) && <h3 class="tsd-index-heading">{item.title}</h3>}
+            {!isNoneSection(item) && (
+                <h3 class="tsd-index-heading tsd-anchor-link" id={sectionAnchor}>
+                    {item.title}
+                    {anchorIcon(context, sectionAnchor)}
+                </h3>
+            )}
             {item.description && (
                 <div class="tsd-comment tsd-typography">
                     <JSX.Raw html={markdown(item.description)} />

--- a/src/lib/output/themes/default/partials/members.tsx
+++ b/src/lib/output/themes/default/partials/members.tsx
@@ -18,12 +18,13 @@ export function members(context: DefaultThemeRenderContext, props: ContainerRefl
                 }
 
                 context.page.startNewSection(section.title);
+                const sectionAnchor = context.slugger.slug(section.title);
 
                 return (
                     <details class="tsd-panel-group tsd-member-group tsd-accordion" open>
                         <summary class="tsd-accordion-summary" data-key={"section-" + section.title}>
                             {context.icons.chevronDown()}
-                            <h2>
+                            <h2 id={sectionAnchor}>
                                 {section.title}
                             </h2>
                         </summary>

--- a/src/lib/output/themes/default/partials/members.tsx
+++ b/src/lib/output/themes/default/partials/members.tsx
@@ -2,6 +2,7 @@ import type { DefaultThemeRenderContext } from "../DefaultThemeRenderContext.js"
 import { JSX } from "#utils";
 import { type ContainerReflection } from "../../../../models/index.js";
 import { getMemberSections, isNoneSection } from "../../lib.js";
+import { anchorIcon } from "./anchor-icon.js";
 
 export function members(context: DefaultThemeRenderContext, props: ContainerReflection) {
     const sections = getMemberSections(props, (child) => !context.router.hasOwnDocument(child));
@@ -24,8 +25,9 @@ export function members(context: DefaultThemeRenderContext, props: ContainerRefl
                     <details class="tsd-panel-group tsd-member-group tsd-accordion" open>
                         <summary class="tsd-accordion-summary" data-key={"section-" + section.title}>
                             {context.icons.chevronDown()}
-                            <h2 id={sectionAnchor}>
+                            <h2 class="tsd-anchor-link" id={sectionAnchor}>
                                 {section.title}
+                                {anchorIcon(context, sectionAnchor)}
                             </h2>
                         </summary>
                         <section>{section.children.map((item) => context.member(item))}</section>

--- a/src/lib/output/themes/default/partials/moduleReflection.tsx
+++ b/src/lib/output/themes/default/partials/moduleReflection.tsx
@@ -55,11 +55,13 @@ export function moduleReflection(context: DefaultThemeRenderContext, mod: Declar
                     );
                 }
 
+                const sectionAnchor = context.slugger.slug(section.title);
+
                 return (
                     <details class="tsd-panel-group tsd-member-group tsd-accordion" open>
                         <summary class="tsd-accordion-summary" data-key={"section-" + section.title}>
                             {context.icons.chevronDown()}
-                            <h2>
+                            <h2 id={sectionAnchor}>
                                 {section.title}
                             </h2>
                         </summary>

--- a/src/lib/output/themes/default/partials/moduleReflection.tsx
+++ b/src/lib/output/themes/default/partials/moduleReflection.tsx
@@ -61,8 +61,9 @@ export function moduleReflection(context: DefaultThemeRenderContext, mod: Declar
                     <details class="tsd-panel-group tsd-member-group tsd-accordion" open>
                         <summary class="tsd-accordion-summary" data-key={"section-" + section.title}>
                             {context.icons.chevronDown()}
-                            <h2 id={sectionAnchor}>
+                            <h2 class="tsd-anchor-link" id={sectionAnchor}>
                                 {section.title}
+                                {anchorIcon(context, sectionAnchor)}
                             </h2>
                         </summary>
                         {content}

--- a/src/test/renderer/specs/classes/BaseClass.json
+++ b/src/test/renderer/specs/classes/BaseClass.json
@@ -105,7 +105,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -126,7 +135,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -172,7 +190,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2#constructors": "Constructors"
+                                "h2.tsd-anchor-link#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -261,7 +288,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2#methods": "Methods"
+                                "h2.tsd-anchor-link#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/BaseClass.json
+++ b/src/test/renderer/specs/classes/BaseClass.json
@@ -172,7 +172,7 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors": "Constructors"
                             }
                         },
                         {
@@ -261,7 +261,7 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods": "Methods"
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3007.DOMBase.json
+++ b/src/test/renderer/specs/classes/GH3007.DOMBase.json
@@ -96,7 +96,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -117,7 +126,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -153,7 +171,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2#constructors": "Constructors"
+                                "h2.tsd-anchor-link#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -317,7 +344,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2#methods": "Methods"
+                                "h2.tsd-anchor-link#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3007.DOMBase.json
+++ b/src/test/renderer/specs/classes/GH3007.DOMBase.json
@@ -153,7 +153,7 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors": "Constructors"
                             }
                         },
                         {
@@ -317,7 +317,7 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods": "Methods"
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3007.DOMClass.json
+++ b/src/test/renderer/specs/classes/GH3007.DOMClass.json
@@ -131,7 +131,7 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods": "Methods"
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3007.DOMClass.json
+++ b/src/test/renderer/specs/classes/GH3007.DOMClass.json
@@ -96,7 +96,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Methods"
+                                                "h3.tsd-index-heading.tsd-anchor-link#methods": [
+                                                    "Methods",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#methods",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -131,7 +140,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2#methods": "Methods"
+                                "h2.tsd-anchor-link#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3014.json
+++ b/src/test/renderer/specs/classes/GH3014.json
@@ -90,7 +90,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Constructors"
+                                                "h3.tsd-index-heading.tsd-anchor-link#constructors": [
+                                                    "Constructors",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#constructors",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -125,7 +134,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2#constructors": "Constructors"
+                                "h2.tsd-anchor-link#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3014.json
+++ b/src/test/renderer/specs/classes/GH3014.json
@@ -125,7 +125,7 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors": "Constructors"
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3052.CustomPromise.json
+++ b/src/test/renderer/specs/classes/GH3052.CustomPromise.json
@@ -223,7 +223,7 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors": "Constructors"
                             }
                         },
                         {
@@ -369,7 +369,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {
@@ -454,7 +454,7 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods": "Methods"
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3052.CustomPromise.json
+++ b/src/test/renderer/specs/classes/GH3052.CustomPromise.json
@@ -115,7 +115,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -136,7 +145,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -167,7 +185,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -223,7 +250,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2#constructors": "Constructors"
+                                "h2.tsd-anchor-link#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -369,7 +405,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -454,7 +499,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2#methods": "Methods"
+                                "h2.tsd-anchor-link#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3052.PromiseReference.json
+++ b/src/test/renderer/specs/classes/GH3052.PromiseReference.json
@@ -137,7 +137,7 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors": "Constructors"
                             }
                         },
                         {
@@ -226,7 +226,7 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods": "Methods"
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GH3052.PromiseReference.json
+++ b/src/test/renderer/specs/classes/GH3052.PromiseReference.json
@@ -70,7 +70,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -91,7 +100,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -137,7 +155,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2#constructors": "Constructors"
+                                "h2.tsd-anchor-link#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -226,7 +253,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2#methods": "Methods"
+                                "h2.tsd-anchor-link#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GenericClass.json
+++ b/src/test/renderer/specs/classes/GenericClass.json
@@ -100,7 +100,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -121,7 +130,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -163,7 +181,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2#constructors": "Constructors"
+                                "h2.tsd-anchor-link#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -347,7 +374,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2#methods": "Methods"
+                                "h2.tsd-anchor-link#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/GenericClass.json
+++ b/src/test/renderer/specs/classes/GenericClass.json
@@ -163,7 +163,7 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors": "Constructors"
                             }
                         },
                         {
@@ -347,7 +347,7 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods": "Methods"
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/ModifiersClass.json
+++ b/src/test/renderer/specs/classes/ModifiersClass.json
@@ -146,7 +146,7 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors": "Constructors"
                             }
                         },
                         {
@@ -269,7 +269,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/ModifiersClass.json
+++ b/src/test/renderer/specs/classes/ModifiersClass.json
@@ -59,7 +59,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -80,7 +89,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -146,7 +164,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2#constructors": "Constructors"
+                                "h2.tsd-anchor-link#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -269,7 +296,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/RenderClass.json
+++ b/src/test/renderer/specs/classes/RenderClass.json
@@ -281,7 +281,7 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2": "Constructors"
+                                "h2#constructors": "Constructors"
                             }
                         },
                         {
@@ -450,7 +450,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {
@@ -525,7 +525,7 @@
                                 "data-key": "section-Accessors"
                             },
                             "children": {
-                                "h2": "Accessors"
+                                "h2#accessors": "Accessors"
                             }
                         },
                         {
@@ -788,7 +788,7 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods": "Methods"
                             }
                         },
                         {

--- a/src/test/renderer/specs/classes/RenderClass.json
+++ b/src/test/renderer/specs/classes/RenderClass.json
@@ -146,7 +146,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Constructors"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#constructors": [
+                                                        "Constructors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#constructors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -167,7 +176,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -188,7 +206,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Accessors"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#accessors": [
+                                                        "Accessors",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#accessors",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -225,7 +252,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Methods"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#methods": [
+                                                        "Methods",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#methods",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -281,7 +317,16 @@
                                 "data-key": "section-Constructors"
                             },
                             "children": {
-                                "h2#constructors": "Constructors"
+                                "h2.tsd-anchor-link#constructors-1": [
+                                    "Constructors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#constructors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -450,7 +495,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -525,7 +579,16 @@
                                 "data-key": "section-Accessors"
                             },
                             "children": {
-                                "h2#accessors": "Accessors"
+                                "h2.tsd-anchor-link#accessors-1": [
+                                    "Accessors",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#accessors-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -788,7 +851,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2#methods": "Methods"
+                                "h2.tsd-anchor-link#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/enums/Enumeration.json
+++ b/src/test/renderer/specs/enums/Enumeration.json
@@ -97,7 +97,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Enumeration Members"
+                                                "h3.tsd-index-heading.tsd-anchor-link#enumeration-members": [
+                                                    "Enumeration Members",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#enumeration-members",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -142,7 +151,16 @@
                                 "data-key": "section-Enumeration Members"
                             },
                             "children": {
-                                "h2#enumeration-members": "Enumeration Members"
+                                "h2.tsd-anchor-link#enumeration-members-1": [
+                                    "Enumeration Members",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#enumeration-members-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/enums/Enumeration.json
+++ b/src/test/renderer/specs/enums/Enumeration.json
@@ -142,7 +142,7 @@
                                 "data-key": "section-Enumeration Members"
                             },
                             "children": {
-                                "h2": "Enumeration Members"
+                                "h2#enumeration-members": "Enumeration Members"
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/BaseInterface.json
+++ b/src/test/renderer/specs/interfaces/BaseInterface.json
@@ -140,7 +140,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Methods"
+                                                "h3.tsd-index-heading.tsd-anchor-link#methods": [
+                                                    "Methods",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#methods",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -185,7 +194,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2#methods": "Methods"
+                                "h2.tsd-anchor-link#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/BaseInterface.json
+++ b/src/test/renderer/specs/interfaces/BaseInterface.json
@@ -185,7 +185,7 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods": "Methods"
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/ExpandType.ExpandedByDefault.json
+++ b/src/test/renderer/specs/interfaces/ExpandType.ExpandedByDefault.json
@@ -146,7 +146,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/ExpandType.ExpandedByDefault.json
+++ b/src/test/renderer/specs/interfaces/ExpandType.ExpandedByDefault.json
@@ -111,7 +111,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -146,7 +155,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/GH2982.TMXDataNode.json
+++ b/src/test/renderer/specs/interfaces/GH2982.TMXDataNode.json
@@ -226,7 +226,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/GH2982.TMXDataNode.json
+++ b/src/test/renderer/specs/interfaces/GH2982.TMXDataNode.json
@@ -191,7 +191,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -226,7 +235,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/GH3007.DOMIterable.json
+++ b/src/test/renderer/specs/interfaces/GH3007.DOMIterable.json
@@ -212,7 +212,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/GH3007.DOMIterable.json
+++ b/src/test/renderer/specs/interfaces/GH3007.DOMIterable.json
@@ -177,7 +177,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -212,7 +221,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/NoneCategory.json
+++ b/src/test/renderer/specs/interfaces/NoneCategory.json
@@ -266,7 +266,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {
@@ -333,7 +333,7 @@
                                 "data-key": "section-Properties - Other"
                             },
                             "children": {
-                                "h2": "Properties - Other"
+                                "h2#properties-other": "Properties - Other"
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/NoneCategory.json
+++ b/src/test/renderer/specs/interfaces/NoneCategory.json
@@ -159,7 +159,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -180,7 +189,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties - Other"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#properties-other": [
+                                                        "Properties - Other",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties-other",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -266,7 +284,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -333,7 +360,16 @@
                                 "data-key": "section-Properties - Other"
                             },
                             "children": {
-                                "h2#properties-other": "Properties - Other"
+                                "h2.tsd-anchor-link#properties-other-1": [
+                                    "Properties - Other",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-other-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/NoneGroup.json
+++ b/src/test/renderer/specs/interfaces/NoneGroup.json
@@ -224,7 +224,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/NoneGroup.json
+++ b/src/test/renderer/specs/interfaces/NoneGroup.json
@@ -138,7 +138,16 @@
                                         {
                                             "section.tsd-index-section": [
                                                 {
-                                                    "h3.tsd-index-heading": "Properties"
+                                                    "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                        "Properties",
+                                                        {
+                                                            "tag": "a.tsd-anchor-icon",
+                                                            "props": {
+                                                                "href": "#properties",
+                                                                "aria-label": "Permalink"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
                                                     "div.tsd-index-list": [
@@ -224,7 +233,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/gh2995.json
+++ b/src/test/renderer/specs/interfaces/gh2995.json
@@ -136,7 +136,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Methods"
+                                                "h3.tsd-index-heading.tsd-anchor-link#methods": [
+                                                    "Methods",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#methods",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -177,7 +186,16 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2#methods": "Methods"
+                                "h2.tsd-anchor-link#methods-1": [
+                                    "Methods",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#methods-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/interfaces/gh2995.json
+++ b/src/test/renderer/specs/interfaces/gh2995.json
@@ -177,7 +177,7 @@
                                 "data-key": "section-Methods"
                             },
                             "children": {
-                                "h2": "Methods"
+                                "h2#methods": "Methods"
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules.json
+++ b/src/test/renderer/specs/modules.json
@@ -34,7 +34,16 @@
                                 "data-key": "section-Documents"
                             },
                             "children": {
-                                "h2#documents": "Documents"
+                                "h2.tsd-anchor-link#documents": [
+                                    "Documents",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#documents",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -78,7 +87,16 @@
                                 "data-key": "section-Namespaces"
                             },
                             "children": {
-                                "h2#namespaces": "Namespaces"
+                                "h2.tsd-anchor-link#namespaces": [
+                                    "Namespaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#namespaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -191,7 +209,16 @@
                                 "data-key": "section-Enumerations"
                             },
                             "children": {
-                                "h2#enumerations": "Enumerations"
+                                "h2.tsd-anchor-link#enumerations": [
+                                    "Enumerations",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#enumerations",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -235,7 +262,16 @@
                                 "data-key": "section-Classes"
                             },
                             "children": {
-                                "h2#classes": "Classes"
+                                "h2.tsd-anchor-link#classes": [
+                                    "Classes",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#classes",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -371,7 +407,16 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2#interfaces": "Interfaces"
+                                "h2.tsd-anchor-link#interfaces": [
+                                    "Interfaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#interfaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -507,7 +552,16 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2#type-aliases": "Type Aliases"
+                                "h2.tsd-anchor-link#type-aliases": [
+                                    "Type Aliases",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#type-aliases",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -574,7 +628,16 @@
                                 "data-key": "section-Functions"
                             },
                             "children": {
-                                "h2#functions": "Functions"
+                                "h2.tsd-anchor-link#functions": [
+                                    "Functions",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#functions",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -618,7 +681,16 @@
                                 "data-key": "section-References"
                             },
                             "children": {
-                                "h2#references": "References"
+                                "h2.tsd-anchor-link#references": [
+                                    "References",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#references",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules.json
+++ b/src/test/renderer/specs/modules.json
@@ -34,7 +34,7 @@
                                 "data-key": "section-Documents"
                             },
                             "children": {
-                                "h2": "Documents"
+                                "h2#documents": "Documents"
                             }
                         },
                         {
@@ -78,7 +78,7 @@
                                 "data-key": "section-Namespaces"
                             },
                             "children": {
-                                "h2": "Namespaces"
+                                "h2#namespaces": "Namespaces"
                             }
                         },
                         {
@@ -191,7 +191,7 @@
                                 "data-key": "section-Enumerations"
                             },
                             "children": {
-                                "h2": "Enumerations"
+                                "h2#enumerations": "Enumerations"
                             }
                         },
                         {
@@ -235,7 +235,7 @@
                                 "data-key": "section-Classes"
                             },
                             "children": {
-                                "h2": "Classes"
+                                "h2#classes": "Classes"
                             }
                         },
                         {
@@ -371,7 +371,7 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2": "Interfaces"
+                                "h2#interfaces": "Interfaces"
                             }
                         },
                         {
@@ -507,7 +507,7 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2": "Type Aliases"
+                                "h2#type-aliases": "Type Aliases"
                             }
                         },
                         {
@@ -574,7 +574,7 @@
                                 "data-key": "section-Functions"
                             },
                             "children": {
-                                "h2": "Functions"
+                                "h2#functions": "Functions"
                             }
                         },
                         {
@@ -618,7 +618,7 @@
                                 "data-key": "section-References"
                             },
                             "children": {
-                                "h2": "References"
+                                "h2#references": "References"
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/ExpandType.NestedBehavior1.json
+++ b/src/test/renderer/specs/modules/ExpandType.NestedBehavior1.json
@@ -48,7 +48,7 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2": "Type Aliases"
+                                "h2#type-aliases": "Type Aliases"
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/ExpandType.NestedBehavior1.json
+++ b/src/test/renderer/specs/modules/ExpandType.NestedBehavior1.json
@@ -48,7 +48,16 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2#type-aliases": "Type Aliases"
+                                "h2.tsd-anchor-link#type-aliases": [
+                                    "Type Aliases",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#type-aliases",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/ExpandType.json
+++ b/src/test/renderer/specs/modules/ExpandType.json
@@ -37,7 +37,16 @@
                                 "data-key": "section-Namespaces"
                             },
                             "children": {
-                                "h2#namespaces": "Namespaces"
+                                "h2.tsd-anchor-link#namespaces": [
+                                    "Namespaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#namespaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -81,7 +90,16 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2#interfaces": "Interfaces"
+                                "h2.tsd-anchor-link#interfaces": [
+                                    "Interfaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#interfaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -125,7 +143,16 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2#type-aliases": "Type Aliases"
+                                "h2.tsd-anchor-link#type-aliases": [
+                                    "Type Aliases",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#type-aliases",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/ExpandType.json
+++ b/src/test/renderer/specs/modules/ExpandType.json
@@ -37,7 +37,7 @@
                                 "data-key": "section-Namespaces"
                             },
                             "children": {
-                                "h2": "Namespaces"
+                                "h2#namespaces": "Namespaces"
                             }
                         },
                         {
@@ -81,7 +81,7 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2": "Interfaces"
+                                "h2#interfaces": "Interfaces"
                             }
                         },
                         {
@@ -125,7 +125,7 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2": "Type Aliases"
+                                "h2#type-aliases": "Type Aliases"
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/GH2982.json
+++ b/src/test/renderer/specs/modules/GH2982.json
@@ -37,7 +37,7 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2": "Interfaces"
+                                "h2#interfaces": "Interfaces"
                             }
                         },
                         {
@@ -81,7 +81,7 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2": "Type Aliases"
+                                "h2#type-aliases": "Type Aliases"
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/GH2982.json
+++ b/src/test/renderer/specs/modules/GH2982.json
@@ -37,7 +37,16 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2#interfaces": "Interfaces"
+                                "h2.tsd-anchor-link#interfaces": [
+                                    "Interfaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#interfaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -81,7 +90,16 @@
                                 "data-key": "section-Type Aliases"
                             },
                             "children": {
-                                "h2#type-aliases": "Type Aliases"
+                                "h2.tsd-anchor-link#type-aliases": [
+                                    "Type Aliases",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#type-aliases",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/GH3007.json
+++ b/src/test/renderer/specs/modules/GH3007.json
@@ -37,7 +37,7 @@
                                 "data-key": "section-Classes"
                             },
                             "children": {
-                                "h2": "Classes"
+                                "h2#classes": "Classes"
                             }
                         },
                         {
@@ -104,7 +104,7 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2": "Interfaces"
+                                "h2#interfaces": "Interfaces"
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/GH3007.json
+++ b/src/test/renderer/specs/modules/GH3007.json
@@ -37,7 +37,16 @@
                                 "data-key": "section-Classes"
                             },
                             "children": {
-                                "h2#classes": "Classes"
+                                "h2.tsd-anchor-link#classes": [
+                                    "Classes",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#classes",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {
@@ -104,7 +113,16 @@
                                 "data-key": "section-Interfaces"
                             },
                             "children": {
-                                "h2#interfaces": "Interfaces"
+                                "h2.tsd-anchor-link#interfaces": [
+                                    "Interfaces",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#interfaces",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/GH3052.json
+++ b/src/test/renderer/specs/modules/GH3052.json
@@ -37,7 +37,16 @@
                                 "data-key": "section-Classes"
                             },
                             "children": {
-                                "h2#classes": "Classes"
+                                "h2.tsd-anchor-link#classes": [
+                                    "Classes",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#classes",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/modules/GH3052.json
+++ b/src/test/renderer/specs/modules/GH3052.json
@@ -37,7 +37,7 @@
                                 "data-key": "section-Classes"
                             },
                             "children": {
-                                "h2": "Classes"
+                                "h2#classes": "Classes"
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.AExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.AExpanded.json
@@ -169,7 +169,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -224,7 +233,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.AExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.AExpanded.json
@@ -224,7 +224,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.BExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.BExpanded.json
@@ -169,7 +169,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -224,7 +233,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.BExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.BExpanded.json
@@ -224,7 +224,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.Expandable.json
+++ b/src/test/renderer/specs/types/ExpandType.Expandable.json
@@ -115,7 +115,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -150,7 +159,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.Expandable.json
+++ b/src/test/renderer/specs/types/ExpandType.Expandable.json
@@ -150,7 +150,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.Expandable2.json
+++ b/src/test/renderer/specs/types/ExpandType.Expandable2.json
@@ -115,7 +115,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -150,7 +159,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.Expandable2.json
+++ b/src/test/renderer/specs/types/ExpandType.Expandable2.json
@@ -150,7 +150,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AExpanded.json
@@ -178,7 +178,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -233,7 +242,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AExpanded.json
@@ -233,7 +233,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AllExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AllExpanded.json
@@ -178,7 +178,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -233,7 +242,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AllExpanded.json
+++ b/src/test/renderer/specs/types/ExpandType.NestedBehavior1.AllExpanded.json
@@ -233,7 +233,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/Nested.json
+++ b/src/test/renderer/specs/types/Nested.json
@@ -201,7 +201,16 @@
                                     "div.tsd-accordion-details": {
                                         "section.tsd-index-section": [
                                             {
-                                                "h3.tsd-index-heading": "Properties"
+                                                "h3.tsd-index-heading.tsd-anchor-link#properties": [
+                                                    "Properties",
+                                                    {
+                                                        "tag": "a.tsd-anchor-icon",
+                                                        "props": {
+                                                            "href": "#properties",
+                                                            "aria-label": "Permalink"
+                                                        }
+                                                    }
+                                                ]
                                             },
                                             {
                                                 "div.tsd-index-list": [
@@ -236,7 +245,16 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2#properties": "Properties"
+                                "h2.tsd-anchor-link#properties-1": [
+                                    "Properties",
+                                    {
+                                        "tag": "a.tsd-anchor-icon",
+                                        "props": {
+                                            "href": "#properties-1",
+                                            "aria-label": "Permalink"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         {

--- a/src/test/renderer/specs/types/Nested.json
+++ b/src/test/renderer/specs/types/Nested.json
@@ -236,7 +236,7 @@
                                 "data-key": "section-Properties"
                             },
                             "children": {
-                                "h2": "Properties"
+                                "h2#properties": "Properties"
                             }
                         },
                         {

--- a/static/style.css
+++ b/static/style.css
@@ -1047,7 +1047,7 @@
 
         cursor: pointer;
     }
-    .tsd-accordion-summary a {
+    .tsd-accordion-summary > a {
         width: calc(100% - 1.5rem);
     }
     .tsd-accordion-summary > * {


### PR DESCRIPTION
Closes #3029.

### Summary

Adds an `id` attribute to the `<h2>` group/category section headings rendered by the default theme's `members` and `moduleReflection` partials so that section headers can be linked to directly via fragment URLs (e.g. `…/MyClass.html#methods`).

### Changes

- `src/lib/output/themes/default/partials/members.tsx` — slug `section.title` via `context.slugger.slug(...)` and pass it to the heading `<h2>` as `id`.
- `src/lib/output/themes/default/partials/moduleReflection.tsx` — same treatment for the module-reflection sections (skipped for the unnamed/none section, which has no title to slug).
- `CHANGELOG.md` — Unreleased note under Features.
- Snapshot specs regenerated with `pnpm rebuild_specs` (only the new `id` attribute is added to the `h2` tag — no other changes).

The slugger is the existing per-page `Slugger` instance, which already tracks heading collisions for member anchors, so section anchors will be deduplicated against everything else on the page automatically.

### Testing

- `pnpm lint` — clean.
- `pnpm build` — clean.
- `pnpm test` — 1046 passing.
- `pnpm rebuild_specs` — snapshot diff is exclusively the new `id` attributes.
