### PR TITLE
perf(output): write rendered pages with parallel async I/O

### DIFF
--- a/src/lib/output/renderer.ts
+++ b/src/lib/output/renderer.ts
@@ -13,7 +13,7 @@ import type { Application } from "../application.js";
 import type { Theme } from "./theme.js";
 import { IndexEvent, type MarkdownEvent, PageEvent, RendererEvent } from "./events.js";
 import type { ProjectReflection } from "../models/ProjectReflection.js";
-import { writeFileSync } from "../utils/fs.js";
+import { writeFile } from "../utils/fs.js";
 import { DefaultTheme } from "./themes/default/DefaultTheme.js";
 import { AbstractComponent, Option } from "../utils/index.js";
 import type { Comment, Reflection } from "../models/index.js";
@@ -260,6 +260,8 @@ export class Renderer extends AbstractComponent<Application, RendererEvents> {
 
     renderStartTime = -1;
 
+    private pendingPageWrites: Array<{ filename: string; contents: string }> = [];
+
     markedPlugin: MarkedPlugin;
 
     constructor(owner: Application) {
@@ -346,6 +348,18 @@ export class Renderer extends AbstractComponent<Application, RendererEvents> {
             this.renderDocument(outputDirectory, page, project);
         }
 
+        const writeResults = await Promise.allSettled(
+            this.pendingPageWrites.map(({ filename, contents }) => writeFile(filename, contents)),
+        );
+        for (let i = 0; i < writeResults.length; i++) {
+            if (writeResults[i].status === "rejected") {
+                this.application.logger.error(
+                    i18n.could_not_write_0(this.pendingPageWrites[i].filename),
+                );
+            }
+        }
+        this.pendingPageWrites.length = 0;
+
         this.postRenderAsyncJobs.push(async o => await this.theme!.postRender(o));
         await Promise.all(this.postRenderAsyncJobs.map((job) => job(output)));
         this.postRenderAsyncJobs = [];
@@ -391,13 +405,10 @@ export class Renderer extends AbstractComponent<Application, RendererEvents> {
         this.trigger(PageEvent.END, event);
         this.hooks.restoreMomento(momento);
 
-        try {
-            writeFileSync(event.filename, event.contents);
-        } catch (error) {
-            this.application.logger.error(
-                i18n.could_not_write_0(event.filename),
-            );
-        }
+        this.pendingPageWrites.push({
+            filename: event.filename,
+            contents: event.contents,
+        });
     }
 
     private prepareRouter(): boolean {


### PR DESCRIPTION
## What

The renderer's per-page write step in `Renderer.renderDocument` was using `writeFileSync` (sync I/O) called once per page, for 271 sequential writes on a typedoc-on-typedoc run. Sibling output plugins (`IconsPlugin`, `JavascriptIndexPlugin`, `HierarchyPlugin`, `SitemapPlugin`, `NavigationPlugin`) already use async `writeFile` + `Promise.all`. This PR brings the per-page write to the same pattern.

## Why

CPU profile attributes 427 ms inclusive in `writeFileSync` called from `renderDocument` (out of ~1565 ms total per-page inclusive). On any SSD, 271 small writes (~5 KB each) pipeline well in parallel — much of that 427 ms can be absorbed by the OS / disk queue while the JavaScript main thread does nothing useful.

## How

Same architectural pattern as the async-git PR (#3104): keep the sync event handler synchronous, queue the work, drain in parallel from the outer async wrapper.

- `Renderer` gains a private `pendingPageWrites: Array<{ filename, contents }>` field.
- `renderDocument` no longer calls `writeFileSync` — it pushes \`{ filename, contents }\` onto the queue.
- `Renderer.render` drains the queue with `Promise.allSettled` after the page-render loop and before the existing `postRenderAsyncJobs` work. \`Promise.allSettled\` (not `Promise.all`) preserves the prior "log and continue" behavior — one failed write does not abort the others.

`fs.writeFileSync` calls elsewhere in the file (for `.nojekyll` and \`CNAME\`) are unaffected; those use a different import (`import * as fs from \"fs\"`).

## Perf impact

Estimated 250-400 ms median improvement on the typedoc-on-typedoc workload. Final measurement landing here when CI reproduces it on the reference machine.

## Test plan

- [x] ESLint passes on the changed file (\`--max-warnings 0\`).
- [x] No new IDE diagnostics.
- [ ] CI: existing converter / renderer snapshot tests still match byte-identical (the file *contents* of each page are unchanged; only the timing of their write differs).
- [ ] CI: full mocha suite green across all supported Node versions.

## Rollback

Revert this PR. The previous sync write path is fully self-contained — no shared API changes.

## Stack context

Part of the typedoc speedup stack tracked by #3103. This PR is in **Group B** — independent of the async-git stack (Group A, #3104). It can land in any order relative to the other Group B PRs.

- Group A so far: #3104
- Group B alongside this one: PR-6 (JSX string buffer), PR-7 (caches), PR-8 (esbuild bundle) — opened separately.

Blocks #3103