### PR TITLE
perf(converter): memoize normalizePath fast-path and createSymbolIdImpl

### DIFF
--- a/src/lib/converter/factories/symbol-id.ts
+++ b/src/lib/converter/factories/symbol-id.ts
@@ -7,8 +7,21 @@ import ts from "typescript";
 let transientCount = 0;
 const transientIds = new WeakMap<ts.Symbol, number>();
 
+// Memoizes results for the common case where callers don't pin a specific
+// declaration. When a caller passes an explicit `declaration`, the cache is
+// bypassed both on read and on write so behavior for that path is unchanged.
+const symbolIdCache = new WeakMap<ts.Symbol, ReflectionSymbolId>();
+
 // Don't use this directly, use Context.createSymbolId instead.
 export function createSymbolIdImpl(symbol: ts.Symbol, declaration?: ts.Declaration) {
+    const shouldCache = declaration === undefined;
+    if (shouldCache) {
+        const cached = symbolIdCache.get(symbol);
+        if (cached) {
+            return cached;
+        }
+    }
+
     declaration ??= symbol.declarations?.[0];
     const tsSource = declaration?.getSourceFile().fileName ?? "";
     const sourceFileName = resolveDeclarationMaps(tsSource);
@@ -49,6 +62,10 @@ export function createSymbolIdImpl(symbol: ts.Symbol, declaration?: ts.Declarati
     id.pos = pos;
     id.transientId = transientId;
     id.fileName = normalizePath(sourceFileName);
+
+    if (shouldCache) {
+        symbolIdCache.set(symbol, id);
+    }
 
     return id;
 }

--- a/src/lib/utils/paths.ts
+++ b/src/lib/utils/paths.ts
@@ -135,6 +135,15 @@ export function nicePath(absPath: string) {
     return `./${normalizePath(relativePath)}`;
 }
 
+// Fast-path matchers used by `normalizePath` to skip the regex pipeline when
+// the input is already in the canonical TypeDoc form. The Windows variant
+// requires an upper-case drive letter followed by `/` and contains no
+// backslashes; the POSIX variant requires a leading `/` and contains no
+// backslashes. Both reject backslashes outright so any path containing
+// Windows-style separators falls through to the slow path.
+const ALREADY_NORMALIZED_WIN = /^[A-Z]:\/[^\\]*$/;
+const ALREADY_NORMALIZED_POSIX = /^\/[^\\]*$/;
+
 /**
  * Normalize the given path.
  *
@@ -143,6 +152,10 @@ export function nicePath(absPath: string) {
  */
 export function normalizePath(path: string): NormalizedPath {
     if (process.platform === "win32") {
+        if (ALREADY_NORMALIZED_WIN.test(path)) {
+            return path as NormalizedPath;
+        }
+
         // Ensure forward slashes
         path = path.replace(/\\/g, "/");
 
@@ -156,6 +169,8 @@ export function normalizePath(path: string): NormalizedPath {
             /^([^:]+):\//,
             (_m, m1: string) => m1.toUpperCase() + ":/",
         );
+    } else if (ALREADY_NORMALIZED_POSIX.test(path)) {
+        return path as NormalizedPath;
     }
 
     return path as NormalizedPath;

--- a/src/test/utils/paths.test.ts
+++ b/src/test/utils/paths.test.ts
@@ -132,5 +132,23 @@ describe("paths.ts", () => {
         nixTest("Returns the original path", () => {
             equal(normalizePath("/c/users\\foo"), "/c/users\\foo");
         });
+
+        describe("fast-path", () => {
+            it("returns input unchanged when already normalized (POSIX-style)", () => {
+                equal(normalizePath("/Users/foo/bar.ts"), "/Users/foo/bar.ts");
+            });
+
+            it("returns input unchanged when already normalized (Windows-style upper-cased)", () => {
+                equal(normalizePath("C:/Users/foo/bar.ts"), "C:/Users/foo/bar.ts");
+            });
+
+            it("still normalizes when input has backslashes", () => {
+                // On non-Windows this is a no-op (backslashes are legal POSIX filename chars
+                // and pass through unchanged); on Windows the slow path converts them to `/`.
+                // We just check no error and the result is a string.
+                const result = normalizePath("C:\\Users\\foo\\bar.ts");
+                equal(typeof result, "string");
+            });
+        });
     });
 });


### PR DESCRIPTION
## What

Two small caches that together avoid ~80-150 ms of repeated work on a typedoc-on-typedoc run:

1. **`normalizePath` fast-path** in `src/lib/utils/paths.ts` — when input already matches the normalized shape (`/^[A-Z]:\/[^\\]*$/` on Windows, `/^\/[^\\]*$/` elsewhere), early-return without running the three `String.prototype.replace(regex, …)` calls. The function is called from many hot paths (notably `createSymbolIdImpl` invokes it 3 times per symbol).
2. **`createSymbolIdImpl` WeakMap memo** in `src/lib/converter/factories/symbol-id.ts` — caches the constructed `ReflectionSymbolId` by `ts.Symbol` identity, but **only** when the caller passes no explicit `declaration`. Callers that pass a specific declaration bypass the cache to preserve correctness.

## Deferred (not in this PR)

A third cache was planned for `MarkedPlugin.onParseMarkdown` (~100-250 ms estimated win on the same workload) but turns out **not safe** to land naively. \`parser.render\` has per-page side effects:

- pushes onto `this.page.pageHeadings` (used to build the "On This Page" sidebar)
- calls `this.getSlugger().slug(content)`, which is per-page and stateful (anchor disambiguation)
- reads `this.renderContext.icons` (set per-page, nulled between pages)
- mutates `this.lastHeaderSlug`

A content-keyed cache would silently lose all of those side effects. A correct cache would have to capture and replay the `(heading, slug, level)` tuples and slugger registrations on every hit — that's a meaningful redesign, not a one-line memo. Deferred to a separate PR.

## Perf impact

Estimated 80-150 ms median on the typedoc-on-typedoc workload (down from 180-400 ms originally projected, because of the deferred markdown cache).

## Test plan

- [x] ESLint clean on changed files.
- [x] dprint check clean.
- [x] New \`normalizePath\` fast-path tests pass (3 new \`it(...)\` cases).
- [x] No new IDE diagnostics.
- [ ] CI: full mocha suite green.

## Rollback

Revert this PR. Both caches are transparent optimizations — the public behavior of both functions is unchanged.

## Stack context

Part of the typedoc speedup stack tracked by #3103. This PR is in **Group B** — independent of the async-git stack (#3104) and the other Group B PRs (#3105 page writes, plus PR-6 JSX and PR-8 esbuild bundle opening separately).

Blocks #3103