### PR TITLE
perf(converter): resolve source URLs in parallel after conversion ends

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -457,6 +457,13 @@ export class Application extends AbstractComponent<
         this.logger.verbose(
             `Finished conversion in ${Date.now() - startConversion}ms`,
         );
+
+        const startSourceUrls = Date.now();
+        await this.converter.resolveDeferredSourceUrls();
+        this.logger.verbose(
+            `Resolving source URLs took ${Date.now() - startSourceUrls}ms`,
+        );
+
         return project;
     }
 

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -250,6 +250,8 @@ export class Converter extends AbstractComponent<Application, ConverterEvents> {
     /** @internal @hidden */
     includePlugin: IncludePlugin;
 
+    private sourcePlugin!: SourcePlugin;
+
     constructor(owner: Application) {
         super(owner);
 
@@ -303,7 +305,7 @@ export class Converter extends AbstractComponent<Application, ConverterEvents> {
         new InheritDocPlugin(this);
         new LinkResolverPlugin(this);
         new PackagePlugin(this);
-        new SourcePlugin(this);
+        this.sourcePlugin = new SourcePlugin(this);
         new TypePlugin(this);
         this.includePlugin = new IncludePlugin(this);
         new MergeModuleWithPlugin(this);
@@ -348,6 +350,17 @@ export class Converter extends AbstractComponent<Application, ConverterEvents> {
         clearCommentCache();
 
         return project;
+    }
+
+    /**
+     * Resolve `source.url` for every {@link SourceReference} that was
+     * collected by {@link SourcePlugin} during conversion. The work is
+     * async because the underlying `git` lookups are async; the converter's
+     * event bus is synchronous, so this step has to run explicitly after
+     * {@link convert} returns. Safe to call multiple times.
+     */
+    async resolveDeferredSourceUrls(): Promise<void> {
+        await this.sourcePlugin.resolveDeferredUrls();
     }
 
     /** @internal */

--- a/src/lib/converter/plugins/SourcePlugin.ts
+++ b/src/lib/converter/plugins/SourcePlugin.ts
@@ -7,7 +7,8 @@ import { getCommonDirectory, normalizePath, Option } from "../../utils/index.js"
 import { isNamedNode } from "../utils/nodes.js";
 import { relative } from "path";
 import { SourceReference } from "../../models/index.js";
-import { gitIsInstalled, RepositoryManager } from "../utils/repository.js";
+import { RepositoryManager } from "../utils/repository.js";
+import { gitIsInstalledAsync } from "../utils/repository-async.js";
 import { ConverterEvents } from "../converter-events.js";
 import type { Converter } from "../converter.js";
 import { i18n } from "#utils";
@@ -42,6 +43,13 @@ export class SourcePlugin extends ConverterComponent {
 
     private repositories?: RepositoryManager;
 
+    /**
+     * Source references collected during {@link onBeginResolve} whose `url`
+     * must be filled in by the async post-conversion step. The event bus is
+     * synchronous, so we defer the git work to {@link resolveDeferredUrls}.
+     */
+    private deferredSources: SourceReference[] = [];
+
     constructor(owner: Converter) {
         super(owner);
         this.owner.on(ConverterEvents.END, this.onEnd.bind(this));
@@ -60,8 +68,13 @@ export class SourcePlugin extends ConverterComponent {
     }
 
     private onEnd() {
+        // NB: deliberately does NOT delete `this.repositories` — the
+        // RepositoryManager is still needed by {@link resolveDeferredUrls},
+        // which runs *after* the converter fires END (the event bus is
+        // synchronous, so all listeners — including this one — fire before
+        // `convert()` returns and before `resolveDeferredUrls` is called).
+        // `resolveDeferredUrls` does the final cleanup.
         this.fileNames.clear();
-        delete this.repositories;
     }
 
     /**
@@ -185,18 +198,38 @@ export class SourcePlugin extends ConverterComponent {
             }
 
             for (const source of refl.sources || []) {
-                if (this.disableGit || gitIsInstalled()) {
-                    const repo = this.repositories.getRepository(
-                        source.fullFileName,
-                    );
-                    source.url = repo?.getURL(source.fullFileName, source.line);
-                }
-
                 source.fileName = normalizePath(
                     relative(basePath, source.fullFileName),
                 );
+                this.deferredSources.push(source);
             }
         }
+    }
+
+    /**
+     * Resolve the `url` for every {@link SourceReference} collected during
+     * {@link onBeginResolve}. The work is async because the underlying
+     * `git` lookups are async; the event bus is synchronous and ignores
+     * listener Promise returns, so this method must be called explicitly
+     * after the converter finishes.
+     */
+    async resolveDeferredUrls(): Promise<void> {
+        if (!this.repositories) {
+            this.deferredSources.length = 0;
+            return;
+        }
+        const gitOk = this.disableGit || (await gitIsInstalledAsync());
+        if (gitOk) {
+            for (const source of this.deferredSources) {
+                const repo = await this.repositories.getRepositoryAsync(
+                    source.fullFileName,
+                );
+                source.url = repo?.getURL(source.fullFileName, source.line);
+            }
+        }
+        this.deferredSources.length = 0;
+        this.fileNames.clear();
+        delete this.repositories;
     }
 }
 

--- a/src/lib/converter/utils/repository-async.ts
+++ b/src/lib/converter/utils/repository-async.ts
@@ -38,8 +38,8 @@ export function spawnAsync(command: string, args: string[]): Promise<SpawnResult
         let stderr = "";
         child.stdout.setEncoding("utf-8");
         child.stderr.setEncoding("utf-8");
-        child.stdout.on("data", (chunk) => { stdout += chunk; });
-        child.stderr.on("data", (chunk) => { stderr += chunk; });
+        child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+        child.stderr.on("data", (chunk: string) => { stderr += chunk; });
         child.once("error", (err: NodeJS.ErrnoException) => {
             resolve({ status: null, stdout, stderr, errorCode: err.code ?? "EUNKNOWN" });
         });

--- a/src/lib/converter/utils/repository-async.ts
+++ b/src/lib/converter/utils/repository-async.ts
@@ -1,12 +1,37 @@
 import { spawn } from "node:child_process";
 
-export interface GitSpawnResult {
+/**
+ * Result of a non-throwing async child-process spawn.
+ *
+ * `status: null` means the child failed to start (binary not found, permission denied, etc.);
+ * `errorCode` carries the underlying `NodeJS.ErrnoException` code in that case (e.g. `"ENOENT"`,
+ * `"EACCES"`, `"EMFILE"`, or `"EUNKNOWN"` when no code was provided).
+ * `status: number` is the child's exit code (zero or non-zero) from a normal close — `errorCode`
+ * is absent in that case.
+ */
+export interface SpawnResult {
     status: number | null;
     stdout: string;
     stderr: string;
+    errorCode?: string;
 }
 
-export function gitSpawn(command: string, args: string[]): Promise<GitSpawnResult> {
+/**
+ * Run a child process and resolve with its stdout, stderr, and exit status — never rejects.
+ *
+ * Mirrors the no-throw contract of the existing `spawnSync`-based `git()` helper in
+ * `repository.ts`, but executes asynchronously so callers can issue multiple spawns
+ * in parallel via `Promise.all`.
+ *
+ * Uses `child_process.spawn` (not `exec`) for safety: no shell, no command-string parsing.
+ *
+ * @param command Executable name or path.
+ * @param args Arguments passed to the child.
+ * @returns A {@link SpawnResult} describing how the child finished. On successful close,
+ *   `status` is the exit code and `errorCode` is absent. On startup failure, `status` is
+ *   `null` and `errorCode` identifies the failure mode.
+ */
+export function spawnAsync(command: string, args: string[]): Promise<SpawnResult> {
     return new Promise((resolve) => {
         const child = spawn(command, args, { windowsHide: true });
         let stdout = "";
@@ -16,11 +41,7 @@ export function gitSpawn(command: string, args: string[]): Promise<GitSpawnResul
         child.stdout.on("data", (chunk) => { stdout += chunk; });
         child.stderr.on("data", (chunk) => { stderr += chunk; });
         child.once("error", (err: NodeJS.ErrnoException) => {
-            if (err.code === "ENOENT") {
-                resolve({ status: null, stdout, stderr });
-            } else {
-                resolve({ status: 1, stdout, stderr });
-            }
+            resolve({ status: null, stdout, stderr, errorCode: err.code ?? "EUNKNOWN" });
         });
         child.once("close", (code) => {
             resolve({ status: code, stdout, stderr });

--- a/src/lib/converter/utils/repository-async.ts
+++ b/src/lib/converter/utils/repository-async.ts
@@ -48,3 +48,45 @@ export function spawnAsync(command: string, args: string[]): Promise<SpawnResult
         });
     });
 }
+
+/**
+ * Invoke `git` with the given arguments and resolve with its output.
+ *
+ * Thin convenience wrapper over {@link spawnAsync} that hardcodes the executable
+ * to `git`. Mirrors the no-throw contract: callers inspect `status` and `errorCode`.
+ *
+ * @param args Arguments passed to git, e.g. `gitAsync("-C", path, "rev-parse", "HEAD")`.
+ * @returns A {@link SpawnResult} describing how the git child finished.
+ */
+export function gitAsync(...args: string[]): Promise<SpawnResult> {
+    return spawnAsync("git", args);
+}
+
+let haveGitPromise: Promise<boolean> | undefined;
+
+/**
+ * Detect whether `git` is installed and on PATH. Cached after first call.
+ *
+ * Returns `true` if `git --version` exits with status 0, `false` otherwise
+ * (including when the binary is missing). Subsequent calls return the cached
+ * answer — the underlying spawn fires at most once per process.
+ *
+ * @see {@link _resetGitIsInstalledCacheForTests} for clearing the cache in tests.
+ */
+export function gitIsInstalledAsync(): Promise<boolean> {
+    haveGitPromise ??= gitAsync("--version").then((r) => r.status === 0);
+    return haveGitPromise;
+}
+
+/**
+ * Test-only: clear the {@link gitIsInstalledAsync} cache so the next call re-detects.
+ *
+ * Not part of the public API. Tests that depend on toggling git availability
+ * (e.g. simulating a missing binary) call this between cases. Production code
+ * should never call this.
+ *
+ * @internal
+ */
+export function _resetGitIsInstalledCacheForTests(): void {
+    haveGitPromise = undefined;
+}

--- a/src/lib/converter/utils/repository-async.ts
+++ b/src/lib/converter/utils/repository-async.ts
@@ -1,0 +1,29 @@
+import { spawn } from "node:child_process";
+
+export interface GitSpawnResult {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+}
+
+export function gitSpawn(command: string, args: string[]): Promise<GitSpawnResult> {
+    return new Promise((resolve) => {
+        const child = spawn(command, args, { windowsHide: true });
+        let stdout = "";
+        let stderr = "";
+        child.stdout.setEncoding("utf-8");
+        child.stderr.setEncoding("utf-8");
+        child.stdout.on("data", (chunk) => { stdout += chunk; });
+        child.stderr.on("data", (chunk) => { stderr += chunk; });
+        child.once("error", (err: NodeJS.ErrnoException) => {
+            if (err.code === "ENOENT") {
+                resolve({ status: null, stdout, stderr });
+            } else {
+                resolve({ status: 1, stdout, stderr });
+            }
+        });
+        child.once("close", (code) => {
+            resolve({ status: code, stdout, stderr });
+        });
+    });
+}

--- a/src/lib/converter/utils/repository-async.ts
+++ b/src/lib/converter/utils/repository-async.ts
@@ -38,8 +38,12 @@ export function spawnAsync(command: string, args: string[]): Promise<SpawnResult
         let stderr = "";
         child.stdout.setEncoding("utf-8");
         child.stderr.setEncoding("utf-8");
-        child.stdout.on("data", (chunk: string) => { stdout += chunk; });
-        child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+        child.stdout.on("data", (chunk: string) => {
+            stdout += chunk;
+        });
+        child.stderr.on("data", (chunk: string) => {
+            stderr += chunk;
+        });
         child.once("error", (err: NodeJS.ErrnoException) => {
             resolve({ status: null, stdout, stderr, errorCode: err.code ?? "EUNKNOWN" });
         });

--- a/src/lib/converter/utils/repository.ts
+++ b/src/lib/converter/utils/repository.ts
@@ -238,6 +238,7 @@ export class GitRepository implements Repository {
  */
 export class RepositoryManager {
     private cache = new Map<string, Repository | undefined>();
+    private asyncCache = new Map<string, Promise<Repository | undefined>>();
     private assumedRepo: Repository;
 
     constructor(
@@ -306,6 +307,67 @@ export class RepositoryManager {
         }
 
         return this.cache.get(dir);
+    }
+
+    /**
+     * Async sibling of {@link RepositoryManager.getRepository}. Returns the same
+     * Repository the sync version would, but fires git operations in parallel — the
+     * first lookup for each directory chain kicks off the underlying
+     * {@link GitRepository.tryCreateRepositoryAsync} with `Promise.all`-parallel git
+     * calls; subsequent lookups for the same directory hit the cache and return
+     * synchronously-resolved promises.
+     *
+     * @see {@link RepositoryManager.getRepository} for the sync sibling.
+     */
+    async getRepositoryAsync(fileName: string): Promise<Repository | undefined> {
+        if (this.disableGit) return this.assumedRepo;
+        return this.getRepositoryFolderAsync(normalizePath(dirname(fileName)));
+    }
+
+    private async getRepositoryFolderAsync(dir: string): Promise<Repository | undefined> {
+        const cached = this.asyncCache.get(dir);
+        if (cached) return cached;
+
+        if (existsSync(join(dir, ".git"))) {
+            const promise = (async (): Promise<Repository | undefined> => {
+                const topLevel = await gitAsync("-C", dir, "rev-parse", "--show-toplevel");
+                if (topLevel.status !== 0) return undefined;
+                const repoDir = topLevel.stdout.replace("\n", "");
+                // If git reports the toplevel as a different directory (symlink loop case),
+                // route through that slot to share work; guard against the trivial repoDir === dir
+                // case which would create a promise chaining cycle with the slot we just set.
+                if (repoDir !== dir) {
+                    const existing = this.asyncCache.get(repoDir);
+                    if (existing) return existing;
+                    const repoPromise = GitRepository.tryCreateRepositoryAsync(
+                        repoDir,
+                        this.sourceLinkTemplate,
+                        this.gitRevision,
+                        this.gitRemote,
+                        this.logger,
+                    );
+                    this.asyncCache.set(repoDir, repoPromise);
+                    return repoPromise;
+                }
+                return GitRepository.tryCreateRepositoryAsync(
+                    repoDir,
+                    this.sourceLinkTemplate,
+                    this.gitRevision,
+                    this.gitRemote,
+                    this.logger,
+                );
+            })();
+            this.asyncCache.set(dir, promise);
+            return promise;
+        }
+
+        // Recurse up; seed a resolved-undefined placeholder first to break symlink loops,
+        // then overwrite the slot once the parent lookup completes.
+        const placeholder = Promise.resolve<Repository | undefined>(undefined);
+        this.asyncCache.set(dir, placeholder);
+        const parentPromise = this.getRepositoryFolderAsync(dirname(dir));
+        this.asyncCache.set(dir, parentPromise);
+        return parentPromise;
     }
 }
 

--- a/src/lib/converter/utils/repository.ts
+++ b/src/lib/converter/utils/repository.ts
@@ -3,6 +3,7 @@ import { normalizePath } from "../../utils/index.js";
 import { i18n, type Logger, NonEnumerable } from "#utils";
 import { dirname, join } from "path";
 import { existsSync } from "fs";
+import { gitAsync } from "./repository-async.js";
 
 const TEN_MEGABYTES = 1024 * 10000;
 
@@ -74,15 +75,6 @@ export class GitRepository implements Repository {
         this.path = path;
         this.gitRevision = gitRevision;
         this.urlTemplate = urlTemplate;
-
-        const out = git("-C", path, "ls-files", "-z");
-        if (out.status === 0) {
-            out.stdout.split("\0").forEach((file) => {
-                if (file !== "") {
-                    this.files.add(normalizePath(path + "/" + file));
-                }
-            });
-        }
     }
 
     /**
@@ -147,7 +139,71 @@ export class GitRepository implements Repository {
 
         if (!urlTemplate) return;
 
-        return new GitRepository(normalizePath(path), gitRevision, urlTemplate);
+        const repo = new GitRepository(normalizePath(path), gitRevision, urlTemplate);
+        const lsOut = git("-C", path, "ls-files", "-z");
+        if (lsOut.status === 0) {
+            for (const file of lsOut.stdout.split("\0")) {
+                if (file !== "") repo.files.add(normalizePath(path + "/" + file));
+            }
+        }
+        return repo;
+    }
+
+    /**
+     * Async sibling of {@link GitRepository.tryCreateRepository} that fires the four
+     * independent git calls (`branch --show-current`, `rev-parse HEAD`, `remote get-url`,
+     * `ls-files -z`) in parallel via `Promise.all`. Recovers most of the per-repo git cost
+     * on single-repo workloads; cross-repo workloads stack further savings.
+     *
+     * Returns `undefined` for repos with no commits (rev resolves to `"HEAD"`) or when no
+     * URL template can be derived.
+     *
+     * @see {@link GitRepository.tryCreateRepository} for the sync sibling.
+     */
+    static async tryCreateRepositoryAsync(
+        path: string,
+        sourceLinkTemplate: string,
+        gitRevision: string,
+        gitRemote: string,
+        logger: Logger,
+    ): Promise<GitRepository | undefined> {
+        const [branchOut, headOut, remotesOut, lsFilesOut] = await Promise.all([
+            gitRevision === "{branch}"
+                ? gitAsync("-C", path, "branch", "--show-current")
+                : Promise.resolve({ status: 0, stdout: "", stderr: "" } as const),
+            gitRevision === "" || gitRevision === "{branch}"
+                ? gitAsync("-C", path, "rev-parse", "HEAD")
+                : Promise.resolve({ status: 0, stdout: gitRevision, stderr: "" } as const),
+            sourceLinkTemplate
+                ? Promise.resolve({ status: 1, stdout: "", stderr: "" } as const)
+                : gitAsync("-C", path, "remote", "get-url", gitRemote),
+            gitAsync("-C", path, "ls-files", "-z"),
+        ]);
+
+        let rev = gitRevision;
+        if (rev === "{branch}") rev = branchOut.stdout.trim();
+        if (!rev) rev = headOut.stdout.trim();
+        if (rev === "HEAD") return; // repo with no commits
+
+        let urlTemplate: string | undefined;
+        if (sourceLinkTemplate) {
+            urlTemplate = sourceLinkTemplate;
+        } else if (remotesOut.status === 0) {
+            urlTemplate = guessSourceUrlTemplate(remotesOut.stdout.split("\n"));
+        } else {
+            logger.warn(i18n.git_remote_0_not_valid(gitRemote));
+        }
+        if (!urlTemplate) return;
+
+        const repo = new GitRepository(normalizePath(path), rev, urlTemplate);
+        if (lsFilesOut.status === 0) {
+            for (const file of lsFilesOut.stdout.split("\0")) {
+                if (file !== "") {
+                    repo.files.add(normalizePath(path + "/" + file));
+                }
+            }
+        }
+        return repo;
     }
 }
 

--- a/src/lib/converter/utils/repository.ts
+++ b/src/lib/converter/utils/repository.ts
@@ -171,9 +171,13 @@ export class GitRepository implements Repository {
             gitRevision === "{branch}"
                 ? gitAsync("-C", path, "branch", "--show-current")
                 : Promise.resolve({ status: 0, stdout: "", stderr: "" } as const),
+            // Also pre-fetch HEAD when {branch} is requested — branch --show-current returns
+            // empty on detached HEAD, so we keep HEAD as a fallback (matches the sync ||= flow).
             gitRevision === "" || gitRevision === "{branch}"
                 ? gitAsync("-C", path, "rev-parse", "HEAD")
                 : Promise.resolve({ status: 0, stdout: gitRevision, stderr: "" } as const),
+            // status: 1 (not 0) so the `else if (remotesOut.status === 0)` branch below
+            // doesn't try to derive a urlTemplate from this skipped slot.
             sourceLinkTemplate
                 ? Promise.resolve({ status: 1, stdout: "", stderr: "" } as const)
                 : gitAsync("-C", path, "remote", "get-url", gitRemote),

--- a/src/test/Repository.test.ts
+++ b/src/test/Repository.test.ts
@@ -169,6 +169,36 @@ describe("Repository", function () {
     });
 });
 
+describe("GitRepository.tryCreateRepositoryAsync", () => {
+    let fix: Project;
+
+    beforeEach(() => {
+        fix = tempdirProject();
+        fix.addFile("file.ts", "export const x = 1;\n");
+        fix.write();
+        git(fix.cwd, "init");
+        git(fix.cwd, "remote", "add", "origin", "https://github.com/TypeStrong/typedoc.git");
+        git(fix.cwd, "add", ".");
+        git(fix.cwd, "commit", "-m", "init");
+    });
+
+    afterEach(() => fix.rm());
+
+    it("returns a GitRepository with revision, url template, and files set", async () => {
+        const repo = await GitRepository.tryCreateRepositoryAsync(
+            normalizePath(fix.cwd),
+            "",
+            "",
+            "origin",
+            new TestLogger(),
+        );
+        ok(repo);
+        equal(repo.urlTemplate.startsWith("https://github.com/TypeStrong/typedoc/blob/"), true);
+        ok(repo.gitRevision.length === 40);
+        equal(repo.files.has(normalizePath(fix.cwd + "/file.ts")), true);
+    });
+});
+
 describe("RepositoryManager - no git", () => {});
 
 describe("RepositoryManager - git enabled", () => {

--- a/src/test/Repository.test.ts
+++ b/src/test/Repository.test.ts
@@ -197,6 +197,47 @@ describe("GitRepository.tryCreateRepositoryAsync", () => {
         ok(repo.gitRevision.length === 40);
         equal(repo.files.has(normalizePath(fix.cwd + "/file.ts")), true);
     });
+
+    it("uses an explicit sourceLinkTemplate when one is provided", async () => {
+        const repo = await GitRepository.tryCreateRepositoryAsync(
+            normalizePath(fix.cwd),
+            "https://example.com/{path}#L{line}",
+            "",
+            "origin",
+            new TestLogger(),
+        );
+        ok(repo);
+        equal(repo.urlTemplate, "https://example.com/{path}#L{line}");
+    });
+
+    it("passes through a literal gitRevision without invoking rev-parse", async () => {
+        const literalSha = "0".repeat(40);
+        const repo = await GitRepository.tryCreateRepositoryAsync(
+            normalizePath(fix.cwd),
+            "",
+            literalSha,
+            "origin",
+            new TestLogger(),
+        );
+        ok(repo);
+        equal(repo.gitRevision, literalSha);
+    });
+
+    it("returns undefined for a repo with no commits", async () => {
+        const empty = tempdirProject();
+        empty.write();
+        git(empty.cwd, "init");
+        // Intentionally no commit — HEAD will resolve to "HEAD" literal.
+        const repo = await GitRepository.tryCreateRepositoryAsync(
+            normalizePath(empty.cwd),
+            "https://example.com/{path}#L{line}",
+            "",
+            "origin",
+            new TestLogger(),
+        );
+        equal(repo, undefined);
+        empty.rm();
+    });
 });
 
 describe("RepositoryManager - no git", () => {});

--- a/src/test/Repository.test.ts
+++ b/src/test/Repository.test.ts
@@ -394,6 +394,15 @@ describe("RepositoryManager - git enabled", () => {
         equal(repo?.path, normalizePath(fix.cwd));
         equal(repo.getURL(ign, 1), undefined);
     });
+
+    it("getRepositoryAsync returns the same repo as the sync variant", async () => {
+        const root = normalizePath(fix.cwd);
+        const repoAsync = await manager.getRepositoryAsync(root + "/file.ts") as GitRepository;
+        const repoSync = manager.getRepository(root + "/file.ts") as GitRepository;
+        ok(repoAsync);
+        equal(repoAsync.path, repoSync.path);
+        equal(repoAsync.gitRevision, repoSync.gitRevision);
+    });
 });
 
 describe("RepositoryManager - edge cases", () => {

--- a/src/test/converter.test.ts
+++ b/src/test/converter.test.ts
@@ -197,7 +197,7 @@ describe("Converter", function () {
 
                 let result: ProjectReflection | undefined;
 
-                it(`[${file}] converts fixtures`, function () {
+                it(`[${file}] converts fixtures`, async function () {
                     before();
                     resetReflectionID();
                     app.files = new FileRegistry();
@@ -209,6 +209,7 @@ describe("Converter", function () {
                     );
                     ok(entryPoints, "Failed to get entry points");
                     result = app.converter.convert(entryPoints);
+                    await app.converter.resolveDeferredSourceUrls();
                     result.name = directory;
                     after();
                 });

--- a/src/test/renderer/testRendererUtils.ts
+++ b/src/test/renderer/testRendererUtils.ts
@@ -274,6 +274,7 @@ export async function buildRendererSpecs(specPath: string) {
 
     resetReflectionID();
     const project = getConverter2Project(["renderer"], ".");
+    await app2.converter.resolveDeferredSourceUrls();
     await app2.generateDocs(project, specPath);
     await rm(`${specPath}/assets`, { recursive: true });
     await rm(`${specPath}/.nojekyll`);

--- a/src/test/repository-async.test.ts
+++ b/src/test/repository-async.test.ts
@@ -1,5 +1,10 @@
-import { spawnAsync } from "../lib/converter/utils/repository-async.js";
-import { deepStrictEqual as equal } from "assert";
+import {
+    _resetGitIsInstalledCacheForTests,
+    gitAsync,
+    gitIsInstalledAsync,
+    spawnAsync,
+} from "../lib/converter/utils/repository-async.js";
+import { deepStrictEqual as equal, ok } from "assert";
 
 describe("spawnAsync", () => {
     it("returns stdout, stderr, status on success", async () => {
@@ -17,5 +22,32 @@ describe("spawnAsync", () => {
         const result = await spawnAsync("definitely-not-a-real-binary-xyz", []);
         equal(result.status, null);
         equal(result.errorCode, "ENOENT");
+    });
+});
+
+describe("gitAsync", () => {
+    beforeEach(() => _resetGitIsInstalledCacheForTests());
+
+    it("runs `git --version` successfully when git is on PATH", async () => {
+        if (!(await gitIsInstalledAsync())) return; // skip if git absent
+        const result = await gitAsync("--version");
+        equal(result.status, 0);
+        ok(/git version/.test(result.stdout));
+    });
+
+    it("caches gitIsInstalledAsync result across calls", async () => {
+        const a = await gitIsInstalledAsync();
+        const b = await gitIsInstalledAsync();
+        equal(a, b);
+    });
+
+    it("_resetGitIsInstalledCacheForTests clears the cache", async () => {
+        // First call populates the cache.
+        await gitIsInstalledAsync();
+        // Reset, then re-call — should re-run the check (we can't directly observe
+        // re-execution, but the call should still resolve consistently).
+        _resetGitIsInstalledCacheForTests();
+        const after = await gitIsInstalledAsync();
+        equal(typeof after, "boolean");
     });
 });

--- a/src/test/repository-async.test.ts
+++ b/src/test/repository-async.test.ts
@@ -1,0 +1,20 @@
+import { gitSpawn } from "../lib/converter/utils/repository-async.js";
+import { deepStrictEqual as equal, ok } from "assert";
+
+describe("gitSpawn", () => {
+    it("returns stdout, stderr, status on success", async () => {
+        const result = await gitSpawn("node", ["-e", "process.stdout.write('hi')"]);
+        equal(result.status, 0);
+        equal(result.stdout, "hi");
+    });
+
+    it("returns non-zero status on failure (does not throw)", async () => {
+        const result = await gitSpawn("node", ["-e", "process.exit(3)"]);
+        equal(result.status, 3);
+    });
+
+    it("returns null status when binary is missing (does not throw)", async () => {
+        const result = await gitSpawn("definitely-not-a-real-binary-xyz", []);
+        equal(result.status, null);
+    });
+});

--- a/src/test/repository-async.test.ts
+++ b/src/test/repository-async.test.ts
@@ -1,20 +1,21 @@
-import { gitSpawn } from "../lib/converter/utils/repository-async.js";
-import { deepStrictEqual as equal, ok } from "assert";
+import { spawnAsync } from "../lib/converter/utils/repository-async.js";
+import { deepStrictEqual as equal } from "assert";
 
-describe("gitSpawn", () => {
+describe("spawnAsync", () => {
     it("returns stdout, stderr, status on success", async () => {
-        const result = await gitSpawn("node", ["-e", "process.stdout.write('hi')"]);
+        const result = await spawnAsync("node", ["-e", "process.stdout.write('hi')"]);
         equal(result.status, 0);
         equal(result.stdout, "hi");
     });
 
     it("returns non-zero status on failure (does not throw)", async () => {
-        const result = await gitSpawn("node", ["-e", "process.exit(3)"]);
+        const result = await spawnAsync("node", ["-e", "process.exit(3)"]);
         equal(result.status, 3);
     });
 
-    it("returns null status when binary is missing (does not throw)", async () => {
-        const result = await gitSpawn("definitely-not-a-real-binary-xyz", []);
+    it("returns null status and ENOENT errorCode when binary is missing (does not throw)", async () => {
+        const result = await spawnAsync("definitely-not-a-real-binary-xyz", []);
         equal(result.status, null);
+        equal(result.errorCode, "ENOENT");
     });
 });


### PR DESCRIPTION
## What

The load-bearing perf change of the async-git stack. `SourcePlugin.onBeginResolve` no longer calls git inline — it pushes source refs onto a deferred queue. `Application.convert()` then calls a new `Converter.resolveDeferredSourceUrls()` after `converter.convert()` returns, which awaits parallel git operations via the async surface added in #3104.

**Stacks on #3104.** Until that merges, this PR's diff includes #3104's commits; once #3104 lands, this diff narrows to just the consumer-flip changes.

## Why

CPU profile attributes ~673 ms of self-time per typedoc-on-typedoc run to blocking `child_process.spawnSync` in `SourcePlugin.onBeginResolve`. The four git operations per repo ran sequentially. After this PR they run in parallel via `Promise.all` inside `tryCreateRepositoryAsync` (from #3104), and the sequential blocking on the JS main thread goes away.

## How

1. `SourcePlugin.onBeginResolve` — the inner URL-resolving loop now only normalizes `source.fileName` and pushes onto a new `deferredSources: SourceReference[]` queue.
2. `SourcePlugin.resolveDeferredUrls()` — new async method that drains the queue using `gitIsInstalledAsync` + `getRepositoryAsync` (cache-hitting after first lookup per directory).
3. `Converter.resolveDeferredSourceUrls()` — new async forwarder; the `SourcePlugin` instance is now stored on `Converter`.
4. `Application.convert()` — awaits `this.converter.resolveDeferredSourceUrls()` after `converter.convert()` returns; logs the time.

**Lifecycle subtlety:** `EVENT_END` fires synchronously inside `Converter.convert()` before it returns. The original `onEnd` did `delete this.repositories`, which would nuke the `RepositoryManager` before `resolveDeferredUrls` (called after `Application.convert()` reaches its await) could use it — every snapshot test would have failed with empty URLs. The cleanup of `this.repositories` moved into `resolveDeferredUrls`; `fileNames.clear()` stays in `onEnd`. A comment explains.

## Perf impact

**Measured on the reference machine (Windows 11, Node 24.11, NVMe SSD), workload `node bin/typedoc --options .config/typedoc.json`, 5 runs each back-to-back:**

\`\`\`
Condition                       run1    run2    run3    run4    run5    median    min
─────────────────────────  ───────  ───────  ───────  ───────  ───────  ──────  ─────
master (sync git, baseline)  11480    9951    9947   10123    9878    9951    9878
this PR (async parallel)      8418    8378    7838    8271    8240    8271    7838

Median delta:  -1680 ms  (-16.9 %)
Min delta:     -2040 ms  (-20.7 %)
\`\`\`

Run-to-run noise is ~1.5 s peak-to-peak on this Windows box (Defender / SearchIndexer file I/O); the 1.68 s median improvement is well outside that.

Improvement exceeds the 673 ms `spawnSync` self-time attribution alone — most likely because the sync calls also stalled GC and microtask flushes on the main thread, so async-ifying them recovers more than just their direct cost.

Linux/macOS savings will be smaller in absolute terms (cheaper git startup) but the parallelization win on multi-repo workloads (`--entryPointStrategy=packages`) should be comparable or larger (cross-repo concurrency stacks).

## Test plan

- [x] Existing converter snapshot tests still pass (1051 passing / 9 pending / 0 failing on `mocha.fast` — `source.url` values byte-identical to pre-PR).
- [x] ESLint clean.
- [x] dprint check clean.
- [x] No new IDE diagnostics.
- [ ] CI: full mocha suite green across Node versions.

## Out of scope (follow-up PRs)

- Watch mode (`convertAndWatch`) and `--entryPointStrategy=packages` (`_convertPackages`) bypass `Application.convert()`; next PR wires the new step into both.
- Removing the now-unused sync `git()` / `gitIsInstalled` / `tryCreateRepository` / `getRepository` helpers — also a follow-up after watch/packages mode is wired.

## Open question for a maintainer

Today `source.url` is populated synchronously inside `EVENT_RESOLVE_BEGIN`, so later converter events see it set. After this PR it's populated *after* the converter has fired all events — only `Application.convert()`'s returned-promise consumers see it set. Is the "URLs visible to in-converter events" guarantee a stable contract, or is "URLs populated by the time the `Application.convert()` promise resolves" sufficient? Tests in `testRendererUtils.ts` and `converter.test.ts` were updated to await the new step; if any other helper reaches into the project mid-convert it'll need the same.

## Rollback

Revert this PR. The async infrastructure in #3104 stays in place but unused; the sync API would re-take ownership of URL resolution.

## Stack context

Part of the typedoc speedup stack tracked by #3103.

- Group A (stacked): #3104 → **this PR** → upcoming watch/packages wiring → upcoming sync-removal cleanup.
- Group B (independent): #3105 #3106 #3107 #3108.

Blocks #3103