### PR TITLE
Add styles for inline & block <math> elements

### DIFF
--- a/example/src/documents/markdown.md
+++ b/example/src/documents/markdown.md
@@ -88,3 +88,18 @@ To use an alert, include a blockquote in any markdown content which starts with 
 
 > [!CAUTION]
 > Advises about risks or negative outcomes of certain actions.
+
+## MathML
+
+Markdown supports inline HTML, including `<math>` elements.
+MathML can be used inline, for example
+<math><msup><mrow><mi>a</mi><mo>&InvisibleTimes;</mo><mi>x</mi></mrow><mn>2</mn></msup> <mo>+</mo> <mi>b</mi><mo>&InvisibleTimes;</mo><mi>x</mi><mo>+</mo> <mi>c</mi><mo> = </mo><mn>0</mn></math>.
+Block elements can also be used:
+
+<math display="block"><mtable columnalign="right left">
+<mtr><mtd><mtext>Area of a circle:</mtext></mtd><mtd><mi>a</mi><mo> = </mo><msup><mrow><mi>π</mi><mo>&InvisibleTimes;</mo><mi>r</mi></mrow><mn>2</mn></mtd></mtr>
+<mtr><mtd><mtext>Area of a triangle:</mtext></mtd><mtd><mi>a</mi><mo> = </mo><mfrac><mn>1</mn><mn>2</mn></mfrac><mo>&InvisibleTimes;</mo><mi>w</mi><mo>&InvisibleTimes;</mo><mi>h</mi></mtd></mtr>
+</mtable></math>
+
+If you'd prefer to write equations using LaTeX expressions, you can load a markdown-it plugin using
+the [`markdownItLoader` configuration option.](https://typedoc.org/documents/Options.Output.html#markdownitloader)

--- a/src/lib/utils/highlighter.tsx
+++ b/src/lib/utils/highlighter.tsx
@@ -103,7 +103,7 @@ class ShikiHighlighter {
         for (i = 0; i < this.schemes.size; i++) {
             style.push(`.hl-${i} { color: var(--hl-${i}); }`);
         }
-        style.push("pre, code { background: var(--code-background); }", "");
+        style.push("pre, code, math { background: var(--code-background); }", "");
 
         return style.join("\n");
     }

--- a/src/lib/utils/highlighter.tsx
+++ b/src/lib/utils/highlighter.tsx
@@ -103,7 +103,7 @@ class ShikiHighlighter {
         for (i = 0; i < this.schemes.size; i++) {
             style.push(`.hl-${i} { color: var(--hl-${i}); }`);
         }
-        style.push("pre, code, math { background: var(--code-background); }", "");
+        style.push("pre, code, math[display='block'] { background: var(--code-background); }", "");
 
         return style.join("\n");
     }

--- a/static/style.css
+++ b/static/style.css
@@ -531,6 +531,21 @@
         scroll-margin-block: calc(var(--dim-header-height) + 0.5rem);
     }
 
+    math {
+        padding: 0.2em;
+        margin: 0;
+        font-size: 0.875rem;
+        border-radius: 0.8em;
+    }
+
+    math[display="block"] {
+        position: relative;
+        padding: 10px;
+        border: 1px solid var(--color-accent);
+        margin-bottom: 8px;
+        font-size: 100%;
+    }
+
     code,
     pre {
         font-family: Menlo, Monaco, Consolas, "Courier New", monospace;

--- a/static/style.css
+++ b/static/style.css
@@ -531,19 +531,12 @@
         scroll-margin-block: calc(var(--dim-header-height) + 0.5rem);
     }
 
-    math {
-        padding: 0.2em;
-        margin: 0;
-        font-size: 0.875rem;
-        border-radius: 0.8em;
-    }
-
     math[display="block"] {
         position: relative;
         padding: 10px;
         border: 1px solid var(--color-accent);
+        border-radius: 0.8em;
         margin-bottom: 8px;
-        font-size: 100%;
     }
 
     code,


### PR DESCRIPTION
This commit adds styles for `<math>` elements. Inline element styles match inline `<code>` elements, except for font, while block element styles match `<pre><code>` elements, except for font, line wrap, and word break styles.