### PR TITLE
WIP Resolve local links via TypeChecker

### DIFF
--- a/src/lib/converter/comments/declarationReferenceResolver.ts
+++ b/src/lib/converter/comments/declarationReferenceResolver.ts
@@ -21,6 +21,7 @@ function resolveReferenceReflection(ref: Reflection): Reflection {
 export function resolveDeclarationReference(
     reflection: Reflection,
     ref: DeclarationReference,
+    localRoots?: Reflection[],
 ): Reflection | undefined {
     let high: Reflection[] = [];
     let low: Reflection[] = [];
@@ -46,45 +47,47 @@ export function resolveDeclarationReference(
             ref.resolutionStart.startsWith("local") &&
                 ref.resolutionStart.length === 5,
         );
-        // TypeScript's behavior is to first try to resolve links via variable scope, and then
-        // if the link still hasn't been found, check either siblings (if comment belongs to a member)
-        // or otherwise children.
-        let refl: Reflection | undefined = reflection;
-        if (refl.kindOf(ReflectionKind.ExportContainer)) {
-            high.push(refl);
-        }
-        while (refl.parent) {
-            refl = refl.parent;
+        if (!localRoots) {
+            // TypeScript's behavior is to first try to resolve links via variable scope, and then
+            // if the link still hasn't been found, check either siblings (if comment belongs to a member)
+            // or otherwise children.
+            let refl: Reflection | undefined = reflection;
             if (refl.kindOf(ReflectionKind.ExportContainer)) {
                 high.push(refl);
-            } else {
-                low.push(refl);
+            }
+            while (refl.parent) {
+                refl = refl.parent;
+                if (refl.kindOf(ReflectionKind.ExportContainer)) {
+                    high.push(refl);
+                } else {
+                    low.push(refl);
+                }
+
+                if (
+                    refl.kindOf(ReflectionKind.Project) &&
+                    (refl as ProjectReflection).children?.length === 1
+                ) {
+                    high.push((refl as ProjectReflection).children![0]);
+                }
             }
 
-            if (
-                refl.kindOf(ReflectionKind.Project) &&
-                (refl as ProjectReflection).children?.length === 1
+            if (reflection.kindOf(ReflectionKind.SomeMember)) {
+                high.push(reflection.parent!);
+            } else if (
+                reflection.kindOf(ReflectionKind.SomeSignature) &&
+                reflection.parent!.kindOf(ReflectionKind.SomeMember)
             ) {
-                high.push((refl as ProjectReflection).children![0]);
-            }
-        }
-
-        if (reflection.kindOf(ReflectionKind.SomeMember)) {
-            high.push(reflection.parent!);
-        } else if (
-            reflection.kindOf(ReflectionKind.SomeSignature) &&
-            reflection.parent!.kindOf(ReflectionKind.SomeMember)
-        ) {
-            high.push(reflection.parent!.parent!);
-        } else if (high[0] !== reflection) {
-            if (reflection.parent instanceof ContainerReflection) {
-                high.push(
-                    ...(reflection.parent.childrenIncludingDocuments?.filter(
-                        (c) => c.name === reflection.name,
-                    ) || []),
-                );
-            } else {
-                high.push(reflection);
+                high.push(reflection.parent!.parent!);
+            } else if (high[0] !== reflection) {
+                if (reflection.parent instanceof ContainerReflection) {
+                    high.push(
+                        ...(reflection.parent.childrenIncludingDocuments?.filter(
+                            (c) => c.name === reflection.name,
+                        ) || []),
+                    );
+                } else {
+                    high.push(reflection);
+                }
             }
         }
     }
@@ -95,6 +98,11 @@ export function resolveDeclarationReference(
             high = [];
             const low2 = low;
             low = [];
+            if (localRoots) {
+                high = localRoots;
+                localRoots = undefined;
+                continue;
+            }
 
             for (const refl of high2) {
                 const resolved = resolveSymbolReferencePart(refl, part);

--- a/src/lib/converter/comments/index.ts
+++ b/src/lib/converter/comments/index.ts
@@ -12,15 +12,7 @@ import {
 import { lexLineComments } from "./lineLexer.js";
 import { parseComment } from "./parser.js";
 import type { FileRegistry } from "../../models/FileRegistry.js";
-import {
-    assertNever,
-    i18n,
-    Logger,
-    type MeaningKeyword,
-    parseDeclarationReference,
-    setUnion,
-    type SymbolReference,
-} from "#utils";
+import { assertNever, i18n, Logger, parseDeclarationReference, setUnion } from "#utils";
 import { resolveAliasedSymbol } from "../utils/symbols.js";
 import type { Context } from "../context.js";
 
@@ -123,64 +115,23 @@ function resolveLocalLinks(comment: Comment, context: CommentContextOptionalChec
                 pos++;
             }
             const parsed = parseDeclarationReference(elt.text, pos, elt.text.length);
-            if (parsed && parsed[0].resolutionStart === "local" && parsed[0].symbolReference) {
-                const resolved = resolveLocalLink(parsed[0].symbolReference, node, checker);
-                if (resolved) {
-                    elt.target = context.createSymbolId(resolveAliasedSymbol(resolved, checker));
+            if (parsed && parsed[0].resolutionStart === "local") {
+                const ref = parsed[0].symbolReference;
+                if (ref && ref.path) {
+                    const symbol = checker.resolveName(
+                        ref.path[0].path,
+                        node,
+                        ts.SymbolFlags.Value | ts.SymbolFlags.Type | ts.SymbolFlags.Namespace,
+                        true,
+                    );
+                    if (symbol) {
+                        elt.localSymbol = context.createSymbolId(resolveAliasedSymbol(symbol, checker));
+                    }
                 }
             }
         }
     }
 }
-
-function resolveLocalLink(ref: SymbolReference, node: ts.Node, checker: ts.TypeChecker): ts.Symbol | undefined {
-    if (!ref.path || ref.meaning?.label) return undefined;
-    let symbols: ts.Symbol[] = [];
-    const add = (sym: ts.Symbol | undefined) => {
-        if (sym) {
-            sym = resolveAliasedSymbol(sym, checker);
-            if (!symbols.includes(sym)) symbols.push(sym);
-        }
-    };
-    // SymbolFlags.All does not work here, for some reason.
-    add(checker.resolveName(
-        ref.path[0].path,
-        node,
-        ts.SymbolFlags.Value | ts.SymbolFlags.Type | ts.SymbolFlags.Namespace,
-        true,
-    ));
-    for (let i = 1; i < ref.path.length && symbols.length; i++) {
-        const { path, navigation } = ref.path[i];
-        const prev = symbols;
-        symbols = [];
-        for (const sym of prev) {
-            if (navigation !== "~") {
-                add(sym.members?.get(path as ts.__String));
-            }
-            if (navigation !== "#") {
-                add(sym.exports?.get(path as ts.__String));
-            }
-        }
-    }
-    const filter = ref.meaning?.keyword && meaningSymbolFlags[ref.meaning.keyword];
-    if (filter != null) {
-        symbols = symbols.filter(sym => sym.flags & filter);
-    }
-    return symbols.length ? symbols[0] : undefined;
-}
-
-const meaningSymbolFlags: { [meaning in MeaningKeyword]?: ts.SymbolFlags } = {
-    class: ts.SymbolFlags.Class,
-    interface: ts.SymbolFlags.Interface,
-    type: ts.SymbolFlags.Type,
-    enum: ts.SymbolFlags.Enum,
-    namespace: ts.SymbolFlags.Namespace,
-    function: ts.SymbolFlags.Function,
-    var: ts.SymbolFlags.Variable,
-    constructor: ts.SymbolFlags.Constructor,
-    member: ts.SymbolFlags.ClassMember | ts.SymbolFlags.EnumMember,
-    call: ts.SymbolFlags.Signature,
-};
 
 function getCommentWithCache(
     discovered: DiscoveredComment | undefined,

--- a/src/lib/converter/comments/index.ts
+++ b/src/lib/converter/comments/index.ts
@@ -142,9 +142,13 @@ function resolveLocalLink(ref: SymbolReference, node: ts.Node, checker: ts.TypeC
             if (!symbols.includes(sym)) symbols.push(sym);
         }
     };
-    add(checker.resolveName(ref.path[0].path, node, ts.SymbolFlags.Value, true));
-    add(checker.resolveName(ref.path[0].path, node, ts.SymbolFlags.Type, true));
-    add(checker.resolveName(ref.path[0].path, node, ts.SymbolFlags.Namespace, true));
+    // SymbolFlags.All does not work here, for some reason.
+    add(checker.resolveName(
+        ref.path[0].path,
+        node,
+        ts.SymbolFlags.Value | ts.SymbolFlags.Type | ts.SymbolFlags.Namespace,
+        true,
+    ));
     for (let i = 1; i < ref.path.length && symbols.length; i++) {
         const { path, navigation } = ref.path[i];
         const prev = symbols;

--- a/src/lib/converter/comments/index.ts
+++ b/src/lib/converter/comments/index.ts
@@ -12,7 +12,16 @@ import {
 import { lexLineComments } from "./lineLexer.js";
 import { parseComment } from "./parser.js";
 import type { FileRegistry } from "../../models/FileRegistry.js";
-import { assertNever, i18n, Logger, setUnion } from "#utils";
+import {
+    assertNever,
+    i18n,
+    Logger,
+    type MeaningKeyword,
+    parseDeclarationReference,
+    setUnion,
+    type SymbolReference,
+} from "#utils";
+import { resolveAliasedSymbol } from "../utils/symbols.js";
 import type { Context } from "../context.js";
 
 export interface CommentParserConfig {
@@ -39,6 +48,7 @@ export interface CommentContextOptionalChecker {
     config: CommentParserConfig;
     logger: Logger;
     checker?: ts.TypeChecker | undefined;
+    node?: ts.Node | undefined;
     files: FileRegistry;
     createSymbolId: Context["createSymbolId"];
 }
@@ -85,6 +95,7 @@ function getCommentIgnoringCacheNoDiscoveryId(
                 file,
                 context,
             );
+            if (!jsDoc) resolveLocalLinks(comment, context);
             break;
         case ts.SyntaxKind.SingleLineCommentTrivia:
             comment = parseComment(
@@ -92,6 +103,7 @@ function getCommentIgnoringCacheNoDiscoveryId(
                 file,
                 context,
             );
+            resolveLocalLinks(comment, context);
             break;
         default:
             assertNever(ranges[0].kind);
@@ -100,6 +112,71 @@ function getCommentIgnoringCacheNoDiscoveryId(
     comment.inheritedFromParentDeclaration = discovered.inheritedFromParentDeclaration;
     return comment;
 }
+
+function resolveLocalLinks(comment: Comment, context: CommentContextOptionalChecker) {
+    const { checker, node } = context;
+    if (!checker || !node) return;
+    for (const elt of comment.summary) {
+        if (elt.kind === "inline-tag" && elt.tag === "@link" && !elt.target) {
+            let pos = 0;
+            while (pos < elt.text.length && ts.isWhiteSpaceLike(elt.text.charCodeAt(pos))) {
+                pos++;
+            }
+            const parsed = parseDeclarationReference(elt.text, pos, elt.text.length);
+            if (parsed && parsed[0].resolutionStart === "local" && parsed[0].symbolReference) {
+                const resolved = resolveLocalLink(parsed[0].symbolReference, node, checker);
+                if (resolved) {
+                    elt.target = context.createSymbolId(resolveAliasedSymbol(resolved, checker));
+                }
+            }
+        }
+    }
+}
+
+function resolveLocalLink(ref: SymbolReference, node: ts.Node, checker: ts.TypeChecker): ts.Symbol | undefined {
+    if (!ref.path || ref.meaning?.label) return undefined;
+    let symbols: ts.Symbol[] = [];
+    const add = (sym: ts.Symbol | undefined) => {
+        if (sym) {
+            sym = resolveAliasedSymbol(sym, checker);
+            if (!symbols.includes(sym)) symbols.push(sym);
+        }
+    };
+    add(checker.resolveName(ref.path[0].path, node, ts.SymbolFlags.Value, true));
+    add(checker.resolveName(ref.path[0].path, node, ts.SymbolFlags.Type, true));
+    add(checker.resolveName(ref.path[0].path, node, ts.SymbolFlags.Namespace, true));
+    for (let i = 1; i < ref.path.length && symbols.length; i++) {
+        const { path, navigation } = ref.path[i];
+        const prev = symbols;
+        symbols = [];
+        for (const sym of prev) {
+            if (navigation !== "~") {
+                add(sym.members?.get(path as ts.__String));
+            }
+            if (navigation !== "#") {
+                add(sym.exports?.get(path as ts.__String));
+            }
+        }
+    }
+    const filter = ref.meaning?.keyword && meaningSymbolFlags[ref.meaning.keyword];
+    if (filter != null) {
+        symbols = symbols.filter(sym => sym.flags & filter);
+    }
+    return symbols.length ? symbols[0] : undefined;
+}
+
+const meaningSymbolFlags: { [meaning in MeaningKeyword]?: ts.SymbolFlags } = {
+    class: ts.SymbolFlags.Class,
+    interface: ts.SymbolFlags.Interface,
+    type: ts.SymbolFlags.Type,
+    enum: ts.SymbolFlags.Enum,
+    namespace: ts.SymbolFlags.Namespace,
+    function: ts.SymbolFlags.Function,
+    var: ts.SymbolFlags.Variable,
+    constructor: ts.SymbolFlags.Constructor,
+    member: ts.SymbolFlags.ClassMember | ts.SymbolFlags.EnumMember,
+    call: ts.SymbolFlags.Signature,
+};
 
 function getCommentWithCache(
     discovered: DiscoveredComment | undefined,
@@ -128,6 +205,7 @@ function getCommentWithCache(
 function getCommentImpl(
     commentSource: DiscoveredComment | undefined,
     moduleComment: boolean,
+    node: ts.Node | undefined,
     context: CommentContext,
 ) {
     const comment = getCommentWithCache(
@@ -135,6 +213,7 @@ function getCommentImpl(
         {
             ...context,
             checker: context.config.useTsLinkResolution ? context.checker : undefined,
+            node,
         },
     );
 
@@ -205,6 +284,7 @@ export function getComment(
             !context.config.suppressCommentWarningsInDeclarationFiles,
         ),
         isModule,
+        declarations.length ? declarations[0] : undefined,
         context,
     );
 
@@ -226,6 +306,7 @@ export function getNodeComment(
     return getCommentImpl(
         discoverNodeComment(node, context.config.commentStyle),
         moduleComment,
+        node,
         context,
     );
 }
@@ -295,6 +376,7 @@ export function getSignatureComment(
     return getCommentImpl(
         discoverSignatureComment(declaration, context.checker, context.config.commentStyle),
         false,
+        declaration,
         context,
     );
 }

--- a/src/lib/converter/comments/linkResolver.ts
+++ b/src/lib/converter/comments/linkResolver.ts
@@ -258,7 +258,9 @@ function resolveLinkTag(
 
     if (!target && declRef) {
         // Got one, great! Try to resolve the link
-        target = resolveDeclarationReference(reflection, declRef[0]);
+        let localRoots = part.localSymbol && reflection.project.getReflectionsFromSymbolId(part.localSymbol);
+        if (localRoots && localRoots.length === 0) localRoots = undefined;
+        target = resolveDeclarationReference(reflection, declRef[0], localRoots);
         pos = declRef[1];
 
         if (target) {

--- a/src/lib/models/Comment.ts
+++ b/src/lib/models/Comment.ts
@@ -38,6 +38,7 @@ export interface InlineTagDisplayPart {
     tag: TagString;
     text: string;
     target?: Reflection | string | ReflectionSymbolId;
+    localSymbol?: ReflectionSymbolId;
     tsLinkText?: string;
 }
 
@@ -261,12 +262,14 @@ export class Comment {
                 case "code":
                     return { ...part };
                 case "inline-tag": {
+                    const localSymbol = part.localSymbol && new ReflectionSymbolId(part.localSymbol);
                     if (typeof part.target === "number") {
                         const part2 = {
                             kind: part.kind,
                             tag: part.tag,
                             text: part.text,
                             target: undefined,
+                            localSymbol,
                             tsLinkText: part.tsLinkText,
                         } satisfies InlineTagDisplayPart;
                         links.push([part.target, part2]);
@@ -280,6 +283,7 @@ export class Comment {
                             tag: part.tag,
                             text: part.text,
                             target: part.target,
+                            localSymbol,
                             tsLinkText: part.tsLinkText,
                         } satisfies InlineTagDisplayPart;
                     } else if (typeof part.target === "object") {
@@ -288,6 +292,7 @@ export class Comment {
                             tag: part.tag,
                             text: part.text,
                             target: new ReflectionSymbolId(part.target),
+                            localSymbol,
                             tsLinkText: part.tsLinkText,
                         } satisfies InlineTagDisplayPart;
                     } else {

--- a/src/lib/serialization/schema.ts
+++ b/src/lib/serialization/schema.ts
@@ -394,6 +394,7 @@ export interface InlineTagDisplayPart {
     tag: TagString;
     text: string;
     target?: string | ReflectionId | ReflectionSymbolId;
+    localSymbol?: ReflectionSymbolId;
     tsLinkText?: string;
 }
 


### PR DESCRIPTION
This shows a potential way to improve resolution of `@link` tags via the TypeScript typechecker (see https://github.com/TypeStrong/typedoc/issues/3113). It's intended as a sketch to get feedback on at this point, I don't expect it merged as-is.

The most obvious issue with this approach is that it introduces another resolution algorithm, because the existing one in this tree works with TypeDoc reflection objects, which aren't available at the time where we have the node and typechecker around to do this, and the one the TypeScript compiler isn't available to us in a usable way. If that's a non-starter, let me know, and I'll try to just do this in a local plugin instead.

Another issue is whether comments/index.ts is the right place for this code. I can put it into a separate file if you prefer.

Please let me know what you think and whether you see any problems with the code.