### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git://github.com/TypeStrong/TypeDoc.git"
+        "url": "https://github.com/TypeStrong/TypeDoc.git"
     },
     "bugs": {
         "url": "https://github.com/TypeStrong/TypeDoc/issues"


### PR DESCRIPTION
## Summary
- replace the npm repository metadata URL with the public HTTPS GitHub URL
- keep the existing repository target unchanged

## Verification
- `node -e "const p=require('./package.json'); if (p.repository.url !== 'https://github.com/TypeStrong/TypeDoc.git') throw new Error(p.repository.url); console.log(p.repository.url)"`
- `git diff --check`
- `npx -y pnpm@10.25.0 install --frozen-lockfile --ignore-scripts`
- `npm pack --dry-run --ignore-scripts --json .`

I also tried `npx -y pnpm@10.25.0 run build:tsc`, but it fails before this metadata change is involved because `@typestrong/fs-fixture-builder` is unavailable after the install was run with scripts disabled.