### PR TITLE
fix: sort group and category titles with localeCompare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 - Introduced `generateOutputsBegin` and `generateOutputsEnd` events on `Application` for plugin use.
 - Group/category section headings (`<h2>`) in the default theme now include an `id` attribute so they can be linked to via fragment identifiers (e.g. `modules.html#runtime-guards`), #3029.
 
+### Bug Fixes
+
+- Custom `@group` and `@category` titles with the same sort weight are now ordered with `localeCompare`, consistent with the `alphabetical` reflection sort, instead of by UTF-16 code point. Previously a group named `components` sorted after `Helpers` and `Utilities` because lowercase letters have higher code points than uppercase ones.
+
 ## v0.28.19 (2026-04-12)
 
 ### Features

--- a/src/lib/converter/plugins/CategoryPlugin.ts
+++ b/src/lib/converter/plugins/CategoryPlugin.ts
@@ -249,7 +249,7 @@ export class CategoryPlugin extends ConverterComponent {
             }
         }
         if (aWeight === bWeight) {
-            return a.title > b.title ? 1 : -1;
+            return a.title.localeCompare(b.title);
         }
         return aWeight - bWeight;
     }

--- a/src/lib/converter/plugins/GroupPlugin.ts
+++ b/src/lib/converter/plugins/GroupPlugin.ts
@@ -296,7 +296,7 @@ export class GroupPlugin extends ConverterComponent {
             }
         }
         if (aWeight === bWeight) {
-            return a.title > b.title ? 1 : -1;
+            return a.title.localeCompare(b.title);
         }
         return aWeight - bWeight;
     }

--- a/src/test/behavior.c2.test.ts
+++ b/src/test/behavior.c2.test.ts
@@ -1510,6 +1510,24 @@ describe("Behavior Tests", () => {
         );
     });
 
+    it("Sorts custom group and category titles with localeCompare", () => {
+        app.options.setValue("categorizeByGroup", false);
+        const project = convert("localeSortGroupCategory");
+
+        // Custom @group/@category titles are user facing strings, so they are
+        // ordered with localeCompare to stay consistent with the alphabetical
+        // reflection sort in sort.ts (see #2684). A raw code point comparison
+        // would place every uppercase letter before every lowercase one.
+        equal(
+            project.groups?.map((g) => g.title),
+            ["components", "Helpers", "Utilities"],
+        );
+        equal(
+            project.categories?.map((c) => c.title),
+            ["Adapters", "sensors", "Tools"],
+        );
+    });
+
     it("Handles different type parameter comments on class/constructor", () => {
         const project = convert("ctorTypeParam");
 

--- a/src/test/converter2/behavior/localeSortGroupCategory.ts
+++ b/src/test/converter2/behavior/localeSortGroupCategory.ts
@@ -1,0 +1,21 @@
+/**
+ * @module
+ */
+
+/**
+ * @group Utilities
+ * @category Tools
+ */
+export const a = 1;
+
+/**
+ * @group components
+ * @category sensors
+ */
+export const b = 2;
+
+/**
+ * @group Helpers
+ * @category Adapters
+ */
+export const c = 3;


### PR DESCRIPTION
`sortGroupCallback` and `sortCatCallback` order groups/categories by a fixed weight first, then fall back to comparing the titles when two entries share the same weight. That fallback used `a.title > b.title ? 1 : -1`, which compares by UTF-16 code point. Code point order places every uppercase letter before every lowercase one and ignores locale collation, so a group named `components` sorted after `Helpers` and `Utilities`, and accented titles sorted after every unaccented one.

The `alphabetical` reflection sort already moved to `localeCompare` in #2684, and `sortGroupCallback` carries a note that it should be kept in sync with the category sort. This change makes both title fallbacks use `localeCompare` so custom `@group` / `@category` titles order the same way reflection names do.

Only equal-weight titles are affected, which in practice means user-defined `@group` / `@category` names that are not listed in `groupOrder` / `categoryOrder`; built-in kind groups keep their existing weighted order. I added a behavior test covering both sorts. Its assertion relies on case differences (`components` before `Helpers` before `Utilities`), which holds regardless of the host locale, and the existing converter specs are unchanged.
