### PR TITLE
Fix anchor links not scrolling in mobile hamburger menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ title: Changelog
 
 ## Unreleased
 
+### Bug Fixes
+
+- Anchor links in the mobile hamburger menu now correctly scroll to their target, #3049.
+
 ## v0.28.20 (2026-07-05)
 
 ### Features

--- a/src/frontend/typedoc/components/Toggle.ts
+++ b/src/frontend/typedoc/components/Toggle.ts
@@ -65,7 +65,15 @@ export class Toggle extends Component {
                         href = href.substring(0, href.indexOf("#"));
                     }
                     if (link.href.substring(0, href.length) == href) {
-                        setTimeout(() => this.setActive(false), 250);
+                        const hash = link.hash;
+                        setTimeout(() => {
+                            this.setActive(false);
+                            if (hash) {
+                                document
+                                    .getElementById(decodeURIComponent(hash.slice(1)))
+                                    ?.scrollIntoView();
+                            }
+                        }, 250);
                     }
                 }
             }

--- a/src/frontend/typedoc/components/Toggle.ts
+++ b/src/frontend/typedoc/components/Toggle.ts
@@ -65,14 +65,9 @@ export class Toggle extends Component {
                         href = href.substring(0, href.indexOf("#"));
                     }
                     if (link.href.substring(0, href.length) == href) {
-                        const hash = link.hash;
                         setTimeout(() => {
                             this.setActive(false);
-                            if (hash) {
-                                document
-                                    .getElementById(decodeURIComponent(hash.slice(1)))
-                                    ?.scrollIntoView();
-                            }
+                            this.app.scrollToHash();
                         }, 250);
                     }
                 }


### PR DESCRIPTION
## What was broken
Tapping an anchor link in the mobile sidebar menu updated the URL hash but didn't scroll to the target.

## Root cause
`.has-menu body { overflow: hidden }` is still active when the browser tries to do its native scroll-to-hash, since Toggle.ts doesn't close the menu (and lift the scroll lock) until a 250ms setTimeout later. By then the native scroll opportunity has passed.

## Fix
Toggle.ts now manually calls `scrollIntoView()` on the target after closing the menu, instead of relying on the browser's one-shot native scroll.

## Testing
Verified on [device/browser] that tapping sidebar anchors now scrolls correctly. 

Fixes #3049