### PR TITLE
Fix typedoc-ts export path for typedoc/browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
             "default": "./dist/models.js"
         },
         "./browser": {
-            "typedoc-ts": "./src/lib/browser-utils/index.ts",
+            "typedoc-ts": "./src/lib/browser-utils.ts",
             "types": "./dist/types/browser-utils.d.ts",
             "default": "./dist/browser-utils.js"
         },


### PR DESCRIPTION
The `typedoc-ts` condition on the `./browser` export points at `./src/lib/browser-utils/index.ts`, which doesn't exist. The actual file is `./src/lib/browser-utils.ts`, so resolving `typedoc/browser` under that condition currently fails. This corrects the path.

Fixes #3123
